### PR TITLE
Include py-scripts/examples/ Scripts in Automated Linting

### DIFF
--- a/py-scripts/examples/port_probe.py
+++ b/py-scripts/examples/port_probe.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# flake8: noqa
 """
 NAME: port_probe.py
 

--- a/py-scripts/examples/radio_info.py
+++ b/py-scripts/examples/radio_info.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# flake8: noqa
 '''
 NAME: radio_info.py
 

--- a/py-scripts/examples/show_ports.py
+++ b/py-scripts/examples/show_ports.py
@@ -33,6 +33,7 @@ logging.basicConfig(level=logging.INFO,
 DEFAULT_FIELDS = ["_links", "port", "alias", "down", "phantom"]
 DEFAULT_FIELDS_CSV = ",".join(DEFAULT_FIELDS)
 
+
 def show_ports(mgr: str = "localhost", mgr_port: int = 8080, resource: str = "all", addtl_fields: str = "") -> pandas.DataFrame:
     """
     Using the LANforge REST API, gather and print specified information on all ports.
@@ -71,7 +72,7 @@ def show_ports(mgr: str = "localhost", mgr_port: int = 8080, resource: str = "al
 
     ports_data = json_data.get("interfaces")
     if not ports_data:
-        logger.error(f"Key \'interfaces\' not in JSON data")
+        logger.error("Key \'interfaces\' not in JSON data")
         exit(1)
 
     # Unpack ports data into temporary data structure

--- a/py-scripts/examples/show_ports.py
+++ b/py-scripts/examples/show_ports.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# flake8: noqa
 """
 NAME: show_ports.py
 


### PR DESCRIPTION
Include `py-scripts/examples/` scripts in automated linting, first fixing linting failures in `show_ports.py` script.