### PR TITLE
lf_gui_cmd.pl: Fix auto save not selected regression

### DIFF
--- a/lf_gui_cmd.pl
+++ b/lf_gui_cmd.pl
@@ -147,7 +147,7 @@ if ($ttype ne "") {
     if ($verbosity >= 1) {
         print doCmd("cv set '$tname' 'VERBOSITY' '$verbosity'");
     }
-  print doCmd("cv click '$tname' 'Auto Save Report'");
+  print doCmd("cv set '$tname' auto_save 1");
 
   for ($i = 0; $i<@modifiers_key; $i++) {
      my $k = $modifiers_key[$i];


### PR DESCRIPTION
In recent LANforge versions, the 'Auto Save Report' checkbox ('auto_save' key in config) has been added to the default saved config values. Thus, using the 'cv click' GUI cmd will toggle this, when really a user just wants it always enabled.

This change ensures the 'Auto Save Report' option is always enabled.

Verified:
    ./lf_gui_cmd.pl \
        --mgr       192.168.91.50 \
        --port      3990 \
        --ttype     "WiFi Capacity" \
        --rpt_dest  "/var/www/html/lf_reports"