### PR TITLE
ci: Set runner version to Ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ on: [push, pull_request]
 # Lint code using flake8 and run unit tests using pytest
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    # Tie runner to Ubuntu 22.04 LTS, as it still supports Python 3.7
+    # Minimum Python version on Ubuntu 24.04 LTS is Python 3.9.
+    runs-on: ubuntu-22.04
     name: Run Linter
     steps:
       - name: Check out source repository


### PR DESCRIPTION
Addresses recent change of 'ubuntu-latest' runner
bumped to Ubuntu 24.04 LTS. More details here:
https://github.com/actions/runner-images/issues/10636

This fixes Python 3.7 issue in linting action.