### PR TITLE
py-scripts/lf_atten_mod_test.py : to use create_bare_argparse elimnates unnessary args like CX and Radio

### DIFF
--- a/py-scripts/lf_atten_mod_test.py
+++ b/py-scripts/lf_atten_mod_test.py
@@ -62,7 +62,7 @@ class CreateAttenuator(Realm):
 
 def main():
     # create_basic_argparse defined in lanforge-scripts/py-json/LANforge/lfcli_base.py
-    parser = Realm.create_basic_argparse(
+    parser = Realm.create_bare_argparse(
         prog='lf_atten_mod_test.py',
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=None,


### PR DESCRIPTION
py-scripts/lf_atten_mod_test.py only needed the arguments in the
Realm.create_bare_argparse to remove the CX and radio related arguments that are not needed.

Verified:
./lf_atten_mod_test.py --help


