### PR TITLE
py-scripts/test_l3.py updated two examples to be executible when copied

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -42,7 +42,7 @@ Example running traffic with two radios
 
         # Interopt example Creating stations
             Interopt testing creating stations
-            ./test_l3.py --lfmgr 192.168.0.104\
+            ./test_l3.py --lfmgr 192.168.50.104\
              --test_duration 60s\
             --polling_interval 5s\
             --upstream_port 1.1.eth2\
@@ -137,22 +137,25 @@ Example running traffic with two radios
             --test_tag 'test_l3'
 
          # Example : LAN-1927  WPA2-TLS-Configuration
-            ./test_l3.py
-             --lfmgr 192.168.0.103
-             --test_duration 20s
-             --polling_interval 5s
-             --upstream_port 1.1.eth2
-             --radio 'radio==wiphy1,stations==1,ssid==ax88u_5g,ssid_pw==[BLANK],security==wpa2,wifi_settings==wifi_settings,wifi_mode==0,enable_flags==8021x_radius&&80211r_pmska_cache,wifi_extra==key_mgmt&&WPA-EAP!!eap&&TLS!!identity&&testuser!!passwd&&testpasswd!!private_key&&/home/lanforge/client.p12!!ca_cert&&/home/lanforge/ca.pem!!pk_password&&lanforge!!ieee80211w&&Disabled'
-             --endp_type lf_udp
-             --rates_are_totals
-             --side_a_min_bps=256000
-             --side_b_min_bps=300000000
-             --test_rig ID_003
-             --test_tag 'test_l3'
-             --dut_model_num GT-AXE11000
-             --dut_sw_version 3.0.0.4.386_44266
-             --dut_hw_version 1.0
-             --dut_serial_num 12345678
+            ./test_l3.py\
+             --lfmgr 192.168.50.104\
+             --test_duration 20s\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==wiphy1,stations==1,ssid==ax88u_5g,ssid_pw==lf_ax88u_5g,security==wpa2\
+,wifi_settings==wifi_settings,wifi_mode==0,enable_flags==8021x_radius&&80211r_pmska_cache,\
+wifi_extra==key_mgmt&&WPA-EAP!!eap&&TLS!!identity&&testuser!!passwd&&testpasswd!!private_key&&/home/lanforge/client.p12!!\
+ca_cert&&/home/lanforge/ca.pem!!pk_password&&lanforge!!ieee80211w&&Disabled'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=256000\
+             --side_b_min_bps=300000000\
+             --test_rig ID_003\
+             --test_tag 'test_l3'\
+             --dut_model_num GT-AXE11000\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
              --log_level debug
 
         # Example : LAN-1927  WPA2-TTLS-Configuration


### PR DESCRIPTION
This commit is to make some of the examples executable when copied without editing

Verified:
            ./test_l3.py --lfmgr 192.168.50.104\
             --test_duration 60s\
            --polling_interval 5s\
            --upstream_port 1.1.eth2\
            --radio radio==wiphy1,stations==2,ssid==axe11000_5g,ssid_pw==lf_axe11000_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==ht160_enable&&wpa2_enable\
            --endp_type lf_udp,lf_tcp,mc_udp\
            --rates_are_totals\
            --side_a_min_bps=2000000\
            --side_b_min_bps=3000000\
            --test_rig CT-ID-004\
            --test_tag test_l3\
            --dut_model_num AXE11000\
            --dut_sw_version 3.0.0.4.386_44266\
            --dut_hw_version 1.0\
            --dut_serial_num 123456\
            --tos BX,BE,VI,VO\
            --log_level info\
            --no_cleanup\
            --cleanup_cx