### PR TITLE
py-scripts/test_l3.py LAN-3596 flake8: commented out unused variables

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -6774,35 +6774,34 @@ INCLUDE_IN_README: False
 
                 logger.debug("wifi_extra: {extra}".format(
                     extra=radio_info_dict['wifi_extra']))
-
-                key_mgmt = '[BLANK]'
-                pairwise = '[BLANK]'
-                group = '[BLANK]'
-                psk = '[BLANK]'
-                eap = '[BLANK]'
-                identity = '[BLANK]'
-                anonymous_identity = "[BLANK]"
-                phase1 = "[BLANK]"
-                phase2 = "[BLANK]"
-                passwd = '[BLANK]'
-                pin = '[BLANK]'
-                pac_file = '[BLANK]'
-                private_key = '[BLANK]'
-                pk_password = '[BLANK]'
-                hessid = "00:00:00:00:00:00"
-                realm = "[BLANK]"
-                client_cert = "[BLANK]"
-                imsi = "[BLANK]"
-                milenage = "[BLANK]"
-                domain = "[BLANK]"
-                roaming_consortium = "[BLANK]"
-                venue_group = "[BLANK]"
-                network_type = "[BLANK]"
-                ipaddr_type_avail = "[BLANK]"
-                network_auth_type = "[BLANK]"
-                anqp_3gpp_cell_net = "[BLANK]"
-
-                ieee80211w = 'Optional'
+                # These values are actually assigned as lists below
+                # key_mgmt = '[BLANK]'
+                # pairwise = '[BLANK]'
+                # group = '[BLANK]'
+                # psk = '[BLANK]'
+                # eap = '[BLANK]'
+                # identity = '[BLANK]'
+                # anonymous_identity = "[BLANK]"
+                # phase1 = "[BLANK]"
+                # phase2 = "[BLANK]"
+                # passwd = '[BLANK]'
+                # pin = '[BLANK]'
+                # pac_file = '[BLANK]'
+                # private_key = '[BLANK]'
+                # pk_password = '[BLANK]'
+                # hessid = "00:00:00:00:00:00"
+                # realm = "[BLANK]"
+                # client_cert = "[BLANK]"
+                # imsi = "[BLANK]"
+                # milenage = "[BLANK]"
+                # domain = "[BLANK]"
+                # roaming_consortium = "[BLANK]"
+                # venue_group = "[BLANK]"
+                # network_type = "[BLANK]"
+                # ipaddr_type_avail = "[BLANK]"
+                # network_auth_type = "[BLANK]"
+                # anqp_3gpp_cell_net = "[BLANK]"
+                # ieee80211w = 'Optional'
 
                 wifi_extra_dict = dict(
                     map(


### PR DESCRIPTION
Commented out unused variables left in as reference

Verified:
            ./test_l3.py --lfmgr 192.168.50.104\
             --test_duration 60s\
            --polling_interval 5s\
            --upstream_port 1.1.eth2\
            --radio radio==wiphy1,stations==2,ssid==axe11000_5g,ssid_pw==lf_axe11000_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==ht160_enable&&wpa2_enable\
            --endp_type lf_udp,lf_tcp,mc_udp\
            --rates_are_totals\
            --side_a_min_bps=2000000\
            --side_b_min_bps=3000000\
            --test_rig CT-ID-004\
            --test_tag test_l3\
            --dut_model_num AXE11000\
            --dut_sw_version 3.0.0.4.386_44266\
            --dut_hw_version 1.0\
            --dut_serial_num 123456\
            --tos BX,BE,VI,VO\
            --log_level info\
            --no_cleanup\
            --cleanup_cx