### PR TITLE
Test l3 flake8 compliance:  long line returns shortened one commit , other commit  commented out import of traceback

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -536,7 +536,7 @@ import logging
 import platform
 import itertools
 import pandas as pd
-import traceback
+# import traceback # TODO incorporate traceback if using try except
 import json
 
 if sys.version_info[0] != 3:

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -2105,7 +2105,9 @@ class L3VariableTime(Realm):
                                             mac=mac, ap_row_tx_dl=ap_row_tx_dl))
                                     # Find latency, jitter for connections
                                     # using this port.
-                                    latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll, dl_rx_drop_percent, total_ul_rate, total_ul_rate_ll, total_ul_pkts_ll, ul_rx_drop_percent = self.get_endp_stats_for_port(
+                                    (latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll,
+                                     dl_rx_drop_percent, total_ul_rate, total_ul_rate_ll,
+                                     total_ul_pkts_ll, ul_rx_drop_percent) = self.get_endp_stats_for_port(
                                         port_data["port"], endps)
 
                                     ap_row_tx_dl.append(ap_row_chanim)
@@ -2184,7 +2186,9 @@ class L3VariableTime(Realm):
                                     logger.debug(pformat(response))
                                 else:
                                     port_data = response['interface']
-                                    latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll, dl_rx_drop_percent, total_ul_rate, total_ul_rate_ll, total_ul_pkts_ll, ul_rx_drop_percent = self.get_endp_stats_for_port(
+                                    (latency, jitter, total_dl_rate, total_dl_rate_ll,
+                                     total_dl_pkts_ll, dl_rx_drop_percent, total_ul_rate,
+                                     total_ul_rate_ll, total_ul_pkts_ll, ul_rx_drop_percent) = self.get_endp_stats_for_port(
                                         port_data["port"], endps)
                                     self.write_dl_port_csv(
                                         len(temp_stations_list),
@@ -2253,7 +2257,8 @@ class L3VariableTime(Realm):
                     # FutureWarning: Indexing with multiple keys need to make single [] to double [[]]
                     # https://stackoverflow.com/questions/60999753/pandas-future-warning-indexing-with-multiple-keys
                     all_dl_ports_stations_sum_df = all_dl_ports_stations_df.groupby(['Time epoch'])[['Rx-Bps', 'Tx-Bps', 'Rx-Latency', 'Rx-Jitter',
-                                                                                                    'Ul-Rx-Goodput-bps', 'Ul-Rx-Rate-ll', 'Ul-Rx-Pkts-ll', 'Dl-Rx-Goodput-bps', 'Dl-Rx-Rate-ll', 'Dl-Rx-Pkts-ll']].sum()
+                                                                                                     'Ul-Rx-Goodput-bps', 'Ul-Rx-Rate-ll', 'Ul-Rx-Pkts-ll',
+                                                                                                     'Dl-Rx-Goodput-bps', 'Dl-Rx-Rate-ll', 'Dl-Rx-Pkts-ll']].sum()
                     all_dl_ports_stations_sum_file_name = self.outfile[:-4]
                     all_dl_port_stations_sum_file_name = all_dl_ports_stations_sum_file_name + \
                         "-dl-all-eids-sum-per-interval.csv"


### PR DESCRIPTION
flake8 compliance: long line returns shortened , commented out import of traceback , put in TODO
    for if there exceptions put in will have traceback in place
    
    Verified:
                ./test_l3.py --lfmgr 192.168.50.104\
                 --test_duration 60s\
                --polling_interval 5s\
                --upstream_port 1.1.eth2\
                --radio radio==wiphy1,stations==2,ssid==axe11000_5g,ssid_pw==lf_axe11000_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==ht160_enable&&wpa2_enable\
                --endp_type lf_udp,lf_tcp,mc_udp\
                --rates_are_totals\
                --side_a_min_bps=2000000\
                --side_b_min_bps=3000000\
                --test_rig CT-ID-004\
                --test_tag test_l3\
                --dut_model_num AXE11000\
                --dut_sw_version 3.0.0.4.386_44266\
                --dut_hw_version 1.0\
                --dut_serial_num 123456\
                --tos BX,BE,VI,VO\
                --log_level info\
                --no_cleanup\
                --cleanup_cx
    
    Signed-off-by: Chuck SmileyRekiere <chuck.smileyrekiere@candelatech.com>