### PR TITLE
test_l3.py LAN-3133 flake8 compliance: dl_rx_drop_percent updated

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1474,9 +1474,9 @@ class L3VariableTime(Realm):
                             and not endp['rx drop %'].isnumeric()) or endp['rx drop %'] is None:
                         logging.debug(
                             'Expected integer response for rx drop %, received non-numeric string instead. Replacing with 0')
-                        dl_tx_drop_percent = 0
+                        dl_rx_drop_percent = 0
                     else:
-                        dl_tx_drop_percent = round(endp["rx drop %"], 2)
+                        dl_rx_drop_percent = round(endp["rx drop %"], 2)
 
                 # -B upload side
                 else:
@@ -2159,7 +2159,7 @@ class L3VariableTime(Realm):
                                         total_dl_rate,
                                         total_dl_rate_ll,
                                         total_dl_pkts_ll,
-                                        dl_tx_drop_percent,
+                                        dl_rx_drop_percent,
                                         ap_row_rx_ul)  # ap_ul_row added
                                 if not self.dowebgui:
                                     logger.info("ap_row_rx_ul {ap_row_rx_ul}".format(


### PR DESCRIPTION
flake8 compliance ,  dl_rx_drop_percent possibly mis-labeled ast it was reading rx drop this was caught by flake8

Verified:
            ./test_l3.py --lfmgr 192.168.50.104\
             --test_duration 60s\
            --polling_interval 5s\
            --upstream_port 1.1.eth2\
            --radio radio==wiphy1,stations==2,ssid==axe11000_5g,ssid_pw==lf_axe11000_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==ht160_enable&&wpa2_enable\
            --endp_type lf_udp,lf_tcp,mc_udp\
            --rates_are_totals\
            --side_a_min_bps=2000000\
            --side_b_min_bps=3000000\
            --test_rig CT-ID-004\
            --test_tag test_l3\
            --dut_model_num AXE11000\
            --dut_sw_version 3.0.0.4.386_44266\
            --dut_hw_version 1.0\
            --dut_serial_num 123456\
            --tos BX,BE,VI,VO\
            --log_level info\
            --no_cleanup\
            --cleanup_cx