### PR TITLE
test_l3_longevity.py LAN-3597 flake8 compliant fixed logger.debug

### DIFF
--- a/py-scripts/test_l3_longevity.py
+++ b/py-scripts/test_l3_longevity.py
@@ -504,7 +504,7 @@ class L3VariableTime(Realm):
         output = stdout.read()
         logger.debug("command:  {command} output: {output}".format(command=command, output=output))
         output = output.decode('utf-8', 'ignore')
-        logger.debug("after utf-8 ignoer output: {output}".format(command=command, output=output))
+        logger.debug("after utf-8 ignoer command: {command} output: {output}".format(command=command, output=output))
 
         ssh.close()
         return output


### PR DESCRIPTION
test_l3_longevity.py LAN-3597 flake8 compliant

            ./test_l3.py --lfmgr 192.168.50.104\
             --test_duration 60s\
            --polling_interval 5s\
            --upstream_port 1.1.eth2\
            --radio radio==wiphy1,stations==2,ssid==axe11000_5g,ssid_pw==lf_axe11000_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==ht160_enable&&wpa2_enable\
            --endp_type lf_udp,lf_tcp,mc_udp\
            --rates_are_totals\
            --side_a_min_bps=2000000\
            --side_b_min_bps=3000000\
            --test_rig CT-ID-004\
            --test_tag test_l3\
            --dut_model_num AXE11000\
            --dut_sw_version 3.0.0.4.386_44266\
            --dut_hw_version 1.0\
            --dut_serial_num 123456\
            --tos BX,BE,VI,VO\
            --log_level info\
            --no_cleanup\
            --cleanup_cx