### PR TITLE
Updates to lf_base_interop_profile.py in preperation for flake8

### DIFF
--- a/py-scripts/lf_base_interop_profile.py
+++ b/py-scripts/lf_base_interop_profile.py
@@ -1251,8 +1251,8 @@ class RealDevice(Realm):
             hw_ver = resource_data_dict['hw version']
             phantom = resource_data_dict['phantom']
             # It appends only non-phantom  androids into resources list
-            if only_androids :
-                if not hw_ver.startswith(('Win', 'Linux', 'Apple')) and phantom == False:
+            if only_androids:
+                if not hw_ver.startswith(('Win', 'Linux', 'Apple')) and not phantom:
                     os_type = 'android'
                     resources.append(resource_id)
                     resources_os_types[resource_id] = os_type

--- a/py-scripts/lf_base_interop_profile.py
+++ b/py-scripts/lf_base_interop_profile.py
@@ -707,13 +707,13 @@ class RealDevice(Realm):
                         '6G band is selected for connectivity for required ssid, encryption and password are not properly provided. Aborting the test')
                     exit(1)
 
-    def query_all_devices_to_configure_wifi(self,device_list=None):
+    def query_all_devices_to_configure_wifi(self, device_list=None):
         self.all_devices = {}
         self.selected_2g_serials = []
         self.selected_5g_serials = []
         self.selected_6g_serials = []
 
-        index = 1 # serial number for selection of devices
+        index = 1  # serial number for selection of devices
 
         # fetch all androids
         self.androids_obj = interop_connectivity.Android(
@@ -793,17 +793,17 @@ class RealDevice(Realm):
                 if ('all' in band):
                     self.selected_2g_serials = list(range(1, index))
                 else:
-                    self.selected_2g_serials = list(map(int, band.replace('2g=','').strip().split(',')))
+                    self.selected_2g_serials = list(map(int, band.replace('2g=', '').strip().split(',')))
             elif ('5g' in band) and ('5g' in self.selected_bands or '5G' in self.selected_bands):
                 if ('all' in band):
                     self.selected_5g_serials = list(range(1, index))
                 else:
-                    self.selected_5g_serials = list(map(int, band.replace('5g=','').strip().split(',')))
+                    self.selected_5g_serials = list(map(int, band.replace('5g=', '').strip().split(',')))
             elif ('6g' in band):
                 if ('all' in band and '6g' in self.selected_bands or '6G' in self.selected_bands):
                     self.selected_6g_serials = list(range(1, index))
                 else:
-                    self.selected_6g_serials = list(map(int, band.replace('6g=','').strip().split(',')))
+                    self.selected_6g_serials = list(map(int, band.replace('6g=', '').strip().split(',')))
 
         print(self.selected_2g_serials, self.selected_5g_serials, self.selected_6g_serials)
         return [self.selected_2g_serials, self.selected_5g_serials, self.selected_6g_serials]
@@ -897,7 +897,7 @@ class RealDevice(Realm):
 
             # fetching resource data for android device
             current_android_resource_data = \
-            self.json_get('/resource/{}/{}/'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['resource']
+                self.json_get('/resource/{}/{}/'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['resource']
 
             if(current_android_resource_data['phantom']):
                 logging.warning(
@@ -907,8 +907,7 @@ class RealDevice(Realm):
 
             # fetching port data for the android device
             current_android_port_data = \
-            self.json_get('/port/{}/{}/wlan0'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['interface']
-
+                self.json_get('/port/{}/{}/wlan0'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['interface']
 
             current_android_port_data.update(current_android_resource_data)
 
@@ -927,8 +926,8 @@ class RealDevice(Realm):
                 continue
 
             username = \
-            self.json_get('resource/{}/{}?fields=user'.format(resource_id.split('.')[0], resource_id.split('.')[1]))[
-                'resource']['user']
+                self.json_get('resource/{}/{}?fields=user'.format(resource_id.split('.')[0], resource_id.split('.')[1]))[
+                    'resource']['user']
 
             self.selected_devices.append(resource_id)
             self.selected_macs.append(current_android_port_data['mac'])
@@ -946,7 +945,6 @@ class RealDevice(Realm):
                 'hw version': 'Android',
                 'MAC': current_android_port_data['mac']
             }
-
 
         for android in exclude_androids:
             selected_androids.remove(android)
@@ -1035,13 +1033,13 @@ class RealDevice(Realm):
         print(df)
         return [self.selected_devices, self.report_labels, self.selected_macs]
 
-    async def configure_wifi_groups(self,select_serials,serials_input,ssid_input,passwd_input,enc_input,eap_method_input,eap_identity_input):
+    async def configure_wifi_groups(self, select_serials, serials_input, ssid_input, passwd_input, enc_input, eap_method_input, eap_identity_input):
         self.station_list = []
         selected_androids = []
         selected_androids_temp = []
         selected_laptops = []
-        selected_t_devices = {}
-        print(serials_input,passwd_input)
+        # selected_t_devices = {} # unused
+        print(serials_input, passwd_input)
         for selected_serial in select_serials:
             selected_username = self.all_devices[selected_serial]['username']
             selected_os = self.all_devices[selected_serial]['os']
@@ -1086,12 +1084,12 @@ class RealDevice(Realm):
 
         return [selected_androids, selected_laptops]
 
-    def monitor_connection(self,selected_androids,selected_laptops):
+    def monitor_connection(self, selected_androids, selected_laptops):
         station_list = []
         selected_t_devices = {}
         selected_devices = []
         selected_macs = []
-        report_labels= []
+        report_labels = []
         androids = 0
         android_list = []
         linuxs = 0
@@ -1106,7 +1104,6 @@ class RealDevice(Realm):
 
             curr_ssid = android[3]
 
-
             # get resource id for the android device from interop tab
             resource_id = self.json_get('/adb/1/1/{}'.format(android[2]))['devices']['resource-id']
 
@@ -1117,11 +1114,11 @@ class RealDevice(Realm):
 
             # fetching port data for the android device
             current_android_port_data = \
-            self.json_get('/port/{}/{}/wlan0'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['interface']
+                self.json_get('/port/{}/{}/wlan0'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['interface']
 
             # fetching resource data for android device
             current_android_resource_data = \
-            self.json_get('/resource/{}/{}/'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['resource']
+                self.json_get('/resource/{}/{}/'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['resource']
 
             current_android_port_data.update(current_android_resource_data)
 
@@ -1136,8 +1133,8 @@ class RealDevice(Realm):
                 continue
 
             username = \
-            self.json_get('resource/{}/{}?fields=user'.format(resource_id.split('.')[0], resource_id.split('.')[1]))[
-                'resource']['user']
+                self.json_get('resource/{}/{}?fields=user'.format(resource_id.split('.')[0], resource_id.split('.')[1]))[
+                    'resource']['user']
 
             selected_devices.append(resource_id)
             selected_macs.append(current_android_port_data['mac'])
@@ -1228,12 +1225,12 @@ class RealDevice(Realm):
         return [selected_devices, report_labels, selected_macs]
 
     # getting data of all real devices already configured to an SSID
-    def get_devices(self, only_androids = False):
-        devices            = []
-        devices_data       = {}
-        resources          = []
+    def get_devices(self, only_androids=False):
+        devices = []
+        devices_data = {}
+        resources = []
         resources_os_types = {}
-        resources_data     = {}
+        resources_data = {}
 
         # Get resources and OS types
         resources_list = self.json_get("/resource/all")["resources"]
@@ -1246,7 +1243,7 @@ class RealDevice(Realm):
                 logging.error('Malformed json response for endpoint /resource/all')
                 raise ValueError('Malformed json response for endpoint /resource/all')
 
-            if resource_data_dict['ct-kernel'] == True:
+            if resource_data_dict['ct-kernel']:
                 # Custom kernel indicates not a real device, so do not track this resource
                 continue
 
@@ -1260,7 +1257,7 @@ class RealDevice(Realm):
                     os_type = 'android'
                     resources.append(resource_id)
                     resources_os_types[resource_id] = os_type
-                    resources_data[resource_id]   = resource_data_dict
+                    resources_data[resource_id] = resource_data_dict
 
             # It appends both androids and laptops into resources list when laptops and android arguments are not passed
             else:
@@ -1275,8 +1272,7 @@ class RealDevice(Realm):
 
                 resources.append(resource_id)
                 resources_os_types[resource_id] = os_type
-                resources_data[resource_id]     = resource_data_dict
-
+                resources_data[resource_id] = resource_data_dict
 
         # Get ports
         # TODO: Add optional argument to function to allow the detection of down ports.
@@ -1288,7 +1284,7 @@ class RealDevice(Realm):
             # Assume three components to port ID, each separated by a period (e.g. '1.1.wlan0')
             # First two components is the resource ID (e.g. '1.1' for '1.1.wlan0')
             port_id_parts = port_id.split('.')
-            resource_id   = port_id_parts[0] + '.' + port_id_parts[1]
+            resource_id = port_id_parts[0] + '.' + port_id_parts[1]
 
             # Skip any non-real devices we have decided to not track
             if resource_id not in resources:
@@ -1315,11 +1311,11 @@ class RealDevice(Realm):
             port_data_dict.update(resources_data[resource_id])
 
             devices.append(port_id)
-            port_data_dict['ostype']  = resources_os_types[resource_id]
-            devices_data[port_id]     = port_data_dict
+            port_data_dict['ostype'] = resources_os_types[resource_id]
+            devices_data[port_id] = port_data_dict
 
-        self.devices          = devices
-        self.devices_data     = devices_data
+        self.devices = devices
+        self.devices_data = devices_data
 
         return self.devices
 
@@ -1343,7 +1339,7 @@ class RealDevice(Realm):
         print(df)
 
         if dowebgui:
-            self.selected_device_eids=device_list.split(",")
+            self.selected_device_eids = device_list.split(",")
         else:
             self.selected_device_eids = input('Select the devices to run the test(e.g. 1.10,1.11 or all to run the test on all devices): ').split(',')
 
@@ -1395,7 +1391,7 @@ class RealDevice(Realm):
 
 
 def main():
-    help_summary='''\
+    help_summary = '''\
 This script is a standard library which support different functionality of interop including wi-fi connectivity on all kinds of real clients.
     '''
     desc = """standard library which supports different functionality of interop
@@ -1508,14 +1504,14 @@ This script is a standard library which support different functionality of inter
         asyncio.run(real_devices.query_all_devices_to_configure_wifi())
     else:
         obj = BaseInteropWifi(manager_ip=args.host,
-                            port=8080,
-                            ssid=args.ssid,
-                            passwd=args.passwd,
-                            encryption=args.crypt,
-                            release="12",
-                            screen_size_prcnt=0.4,
-                            _debug_on=False,
-                            _exit_on_error=False)
+                              port=8080,
+                              ssid=args.ssid,
+                              passwd=args.passwd,
+                              encryption=args.crypt,
+                              release="12",
+                              screen_size_prcnt=0.4,
+                              _debug_on=False,
+                              _exit_on_error=False)
         z = obj.scan_results()
         print(z)
 

--- a/py-scripts/lf_base_interop_profile.py
+++ b/py-scripts/lf_base_interop_profile.py
@@ -107,7 +107,7 @@ class BaseInteropWifi(Realm):
         out = json.loads(output)
         final = out["devices"]
         value, resource_id = [], {}
-        if type(final) == list:
+        if isinstance(final, list):
             keys_lst = []
             for i in range(len(final)):
                 keys_lst.append(list(final[i].keys())[0])
@@ -134,7 +134,7 @@ class BaseInteropWifi(Realm):
         output = (stdout.decode("utf-8"))
         out = json.loads(output)
         final = out["devices"]
-        if type(final) == list:
+        if isinstance(final, list):
             keys_lst = []
             for i in range(len(final)):
                 keys_lst.append(list(final[i].keys())[0])
@@ -152,7 +152,7 @@ class BaseInteropWifi(Realm):
         keys = list(lf_query_resource.keys())
         if "resources" in keys:
             res = lf_query_resource["resources"]
-            if type(res) is list:
+            if isinstance(res, list):
                 sec_key = []
                 for i in res:
                     sec_key.append(list(i.keys()))
@@ -284,7 +284,7 @@ class BaseInteropWifi(Realm):
             devices = self.check_sdk_release()
             logging.info(devices)
         else:
-            if type(device) is list:
+            if isinstance(device, list):
                 devices = device
             else:
                 devices = [device]
@@ -324,7 +324,7 @@ class BaseInteropWifi(Realm):
             logging.info(devices)
             self.set_user_name()
         else:
-            if type(device) is list:
+            if isinstance(device, list):
                 devices = device
             else:
                 devices = [device]
@@ -424,7 +424,7 @@ class BaseInteropWifi(Realm):
         keys = list(lf_query_resource.keys())
         if "resources" in keys:
             res = lf_query_resource["resources"]
-            if type(res) is list:
+            if isinstance(res, list):
                 sec_key = []
                 for i in res:
                     sec_key.append(list(i.keys()))
@@ -447,7 +447,7 @@ class BaseInteropWifi(Realm):
         resources = self.json_get("port/all")
         keys = []
         if "interfaces" in list(resources.keys()):
-            if type(resources['interfaces']) is list:
+            if isinstance(resources['interfaces'], list):
                 for i in resources['interfaces']:
                     keys.append(list(i.keys()))
             new_keys = []
@@ -690,7 +690,7 @@ class RealDevice(Realm):
         self.linux = 0
         self.windows = 0
         self.mac = 0
-        self.groups=groups
+        self.groups = groups
 
         if self.groups is False:
             for band in selected_bands:

--- a/py-scripts/lf_base_interop_profile.py
+++ b/py-scripts/lf_base_interop_profile.py
@@ -53,9 +53,9 @@ sys.path.append(os.path.join(os.path.abspath(__file__ + "../../../")))
 realm = importlib.import_module("py-json.realm")
 Realm = realm.Realm
 interop_connectivity = importlib.import_module("py-json.interop_connectivity")
-from lanforge_client.lanforge_api import LFSession
-from lanforge_client.lanforge_api import LFJsonCommand
-from lanforge_client.lanforge_api import LFJsonQuery
+from lanforge_client.lanforge_api import LFSession  # noqa: 402
+from lanforge_client.lanforge_api import LFJsonCommand  # noqa: 402
+from lanforge_client.lanforge_api import LFJsonQuery  # noqa: 402
 
 
 class BaseInteropWifi(Realm):
@@ -714,7 +714,7 @@ class RealDevice(Realm):
         self.selected_6g_serials = []
 
         index = 1 # serial number for selection of devices
-        
+
         # fetch all androids
         self.androids_obj = interop_connectivity.Android(
             lanforge_ip=self.manager_ip,
@@ -876,7 +876,7 @@ class RealDevice(Realm):
         # selecting devices only those connected to given SSID and contains IP
         # for androids
         exclude_androids = []
-        for android in selected_androids:    
+        for android in selected_androids:
 
             if (android[3] == '2g'):
                 curr_ssid = self.ssid_2g
@@ -911,7 +911,7 @@ class RealDevice(Realm):
 
 
             current_android_port_data.update(current_android_resource_data)
-            
+
             # checking if the android is connected to the desired ssid
             if (current_android_port_data['ssid'] != curr_ssid):
                 logging.warning(
@@ -935,7 +935,7 @@ class RealDevice(Realm):
             self.report_labels.append('{} android {}'.format(resource_id, username)[:25])
             self.android += 1
             self.android_list.append(resource_id)
-            
+
             current_sta_name = resource_id + '.wlan0'
             self.station_list.append(current_sta_name)
 
@@ -946,8 +946,8 @@ class RealDevice(Realm):
                 'hw version': 'Android',
                 'MAC': current_android_port_data['mac']
             }
-            
-            
+
+
         for android in exclude_androids:
             selected_androids.remove(android)
 
@@ -1022,7 +1022,7 @@ class RealDevice(Realm):
                 self.mac_list.append(current_resource_id)
                 selected_t_devices[current_resource_id]['hw version'] = 'Mac'
                 current_laptop_port_data['ostype'] = 'macos'
-            
+
             current_sta_name = current_resource_id
             self.station_list.append(current_sta_name)
 
@@ -1038,7 +1038,7 @@ class RealDevice(Realm):
     async def configure_wifi_groups(self,select_serials,serials_input,ssid_input,passwd_input,enc_input,eap_method_input,eap_identity_input):
         self.station_list = []
         selected_androids = []
-        selected_androids_temp = [] 
+        selected_androids_temp = []
         selected_laptops = []
         selected_t_devices = {}
         print(serials_input,passwd_input)
@@ -1083,9 +1083,9 @@ class RealDevice(Realm):
         logging.info('Applying the new Wi-Fi configuration. Waiting.......')
         # selecting devices only those connected to given SSID and contains IP
         # for androids
-        
+
         return [selected_androids, selected_laptops]
-    
+
     def monitor_connection(self,selected_androids,selected_laptops):
         station_list = []
         selected_t_devices = {}
@@ -1098,11 +1098,11 @@ class RealDevice(Realm):
         linux_list = []
         macs = 0
         mac_list = []
-        
+
         # selecting devices only those connected to given SSID and contains IP
         # for androids
         exclude_androids = []
-        for android in selected_androids:    
+        for android in selected_androids:
 
             curr_ssid = android[3]
 
@@ -1124,7 +1124,7 @@ class RealDevice(Realm):
             self.json_get('/resource/{}/{}/'.format(resource_id.split('.')[0], resource_id.split('.')[1]))['resource']
 
             current_android_port_data.update(current_android_resource_data)
-            
+
             # checking if the android is connected to the desired ssid
             if (current_android_port_data['ssid'] != curr_ssid):
                 exclude_androids.append(android)
@@ -1144,7 +1144,7 @@ class RealDevice(Realm):
             report_labels.append('{} android {}'.format(resource_id, username))
             androids += 1
             android_list.append(resource_id)
-            
+
             current_sta_name = resource_id + '.wlan0'
             station_list.append(current_sta_name)
 
@@ -1155,14 +1155,14 @@ class RealDevice(Realm):
                 'hw version': 'Android',
                 'MAC': current_android_port_data['mac']
             }
-            
+
         for android in exclude_androids:
             selected_androids.remove(android)
-    
+
         # for laptops
         exclude_laptops = []
         for laptop in selected_laptops:
-            
+
             curr_ssid = laptop["ssid"]
 
             # check SSID and IP values from port manager
@@ -1214,7 +1214,7 @@ class RealDevice(Realm):
                 mac_list.append(current_resource_id)
                 selected_t_devices[current_resource_id]['hw version'] = 'Mac'
                 current_laptop_port_data['ostype'] = 'macos'
-            
+
             current_sta_name = current_resource_id
             station_list.append(current_sta_name)
 
@@ -1226,7 +1226,7 @@ class RealDevice(Realm):
         df = pd.DataFrame(data=selected_t_devices).transpose()
         print(df)
         return [selected_devices, report_labels, selected_macs]
-    
+
     # getting data of all real devices already configured to an SSID
     def get_devices(self, only_androids = False):
         devices            = []
@@ -1254,7 +1254,7 @@ class RealDevice(Realm):
             # Get OS version based on 'hw version' field
             hw_ver = resource_data_dict['hw version']
             phantom = resource_data_dict['phantom']
-            # It appends only non-phantom  androids into resources list 
+            # It appends only non-phantom  androids into resources list
             if only_androids :
                 if not hw_ver.startswith(('Win', 'Linux', 'Apple')) and phantom == False:
                     os_type = 'android'
@@ -1322,7 +1322,7 @@ class RealDevice(Realm):
         self.devices_data     = devices_data
 
         return self.devices
-    
+
     # querying the user the required mobiles to test
     def query_user(self, dowebgui=False, device_list=""):
         print('The available real devices are:')
@@ -1401,8 +1401,8 @@ This script is a standard library which support different functionality of inter
     desc = """standard library which supports different functionality of interop
         Operations:
 
-        EXAMPLE-1: 
-        *    Example of scan results: 
+        EXAMPLE-1:
+        *    Example of scan results:
         lf_base_interop_profile.py --host 192.168.1.31 --ssid Airtel_9755718444_5GHz --passwd xyz --crypt psk2
 
         EXAMPLE-2:
@@ -1473,7 +1473,7 @@ This script is a standard library which support different functionality of inter
 
     parser.add_argument('--log_dur', '--ld', type=float, default=0,
                         help='LOG: Gather ADB logs for a duration of this many minutes')
-    
+
     parser.add_argument('--config_wifi', action="store_true",
                         help='Specific this flag to do Wi-Fi connectivity on real devices')
 

--- a/py-scripts/lf_base_interop_profile.py
+++ b/py-scripts/lf_base_interop_profile.py
@@ -120,8 +120,7 @@ class BaseInteropWifi(Realm):
             resource_id[final["resource-id"]] = final["name"]
         self.supported_devices_names = value
         self.supported_devices_resource_id = resource_id
-        logging.info(
-            "List of all Available Devices Serial Numbers in Interop Tab:".format(self.supported_devices_names))
+        logging.info("List of all Available Devices Serial Numbers in Interop Tab:")
         logging.info(self.supported_devices_names)
 
     def get_device_details(self, query="name", device="1.1.RZ8N70TVABP"):


### PR DESCRIPTION
Updates to lf_base_interop_profile.py in preperation for flake8

multiple commits to prepare lf_base_interop_profile.py in preperation for flake8 
The base class was verified with 
./lf_interop_ping.py --mgr 192.168.50.103  --target 192.168.50.203 --virtual --num_sta 1 --radio 1.1.wiphy2 --ssid ax88u_5g --security wpa2 \
  --passwd lf_ax88u_5g --ping_interval 1 --ping_duration .2 --server_ip 192.168.50.1 --debug --local_lf_report_dir /home/lanforge/html-results


