### PR TITLE
Updates to py-json Chamber View test automation core logic

### DIFF
--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -758,11 +758,11 @@ class LFCliBase:
         optional.add_argument('--mgr',
                               '--lfmgr',
                               default='localhost',
-                              help='hostname for where LANforge GUI is running')
+                              help='Hostname or IP address of the LANforge GUI machine (localhost is default)')
         optional.add_argument('--mgr_port',
                               '--port',
                               default=8080,
-                              help='port LANforge GUI HTTP service is running on')
+                              help='IP Port the LANforge GUI is listening on (8080 is default)')
         optional.add_argument('-u',
                               '--upstream_port',
                               default='1.eth1',

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -39,10 +39,12 @@ def cv_base_adjust_parser(args):
 
 def cv_add_base_parser(parser):
     parser.add_argument("-m", "--mgr",
+                        dest="mgr",
                         type=str,
                         default="localhost",
                         help="address of the LANforge GUI machine (localhost is default)")
     parser.add_argument("-o", "--port",
+                        dest="port",
                         type=int,
                         default=8080,
                         help="IP Port the LANforge GUI is listening on (8080 is default)")
@@ -56,15 +58,18 @@ def cv_add_base_parser(parser):
                         help="LANforge Password to pull reports")
 
     parser.add_argument("-i", "--instance_name",
+                        dest="instance_name",
                         type=str,
                         default="cv_dflt_inst",
                         help="create test instance")
     parser.add_argument("-c", "--config_name",
+                        dest="config_name",
                         type=str,
                         default="cv_dflt_cfg",
                         help="Config file name")
 
     parser.add_argument("-r", "--pull_report",
+                        dest="pull_report",
                         action='store_true',
                         help="pull reports from lanforge (by default: False)")
     parser.add_argument("--load_old_cfg",

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -38,40 +38,71 @@ def cv_base_adjust_parser(args):
 
 
 def cv_add_base_parser(parser):
-    parser.add_argument("-m", "--mgr", type=str, default="localhost",
+    parser.add_argument("-m", "--mgr",
+                        type=str,
+                        default="localhost",
                         help="address of the LANforge GUI machine (localhost is default)")
-    parser.add_argument("-o", "--port", type=int, default=8080,
+    parser.add_argument("-o", "--port",
+                        type=int,
+                        default=8080,
                         help="IP Port the LANforge GUI is listening on (8080 is default)")
-    parser.add_argument("--lf_user", type=str, default="lanforge",
+    parser.add_argument("--lf_user",
+                        type=str,
+                        default="lanforge",
                         help="LANforge username to pull reports")
-    parser.add_argument("--lf_password", type=str, default="lanforge",
+    parser.add_argument("--lf_password",
+                        type=str,
+                        default="lanforge",
                         help="LANforge Password to pull reports")
-    parser.add_argument("-i", "--instance_name", type=str, default="cv_dflt_inst",
+
+    parser.add_argument("-i", "--instance_name",
+                        type=str,
+                        default="cv_dflt_inst",
                         help="create test instance")
-    parser.add_argument("-c", "--config_name", type=str, default="cv_dflt_cfg",
+    parser.add_argument("-c", "--config_name",
+                        type=str,
+                        default="cv_dflt_cfg",
                         help="Config file name")
 
-    parser.add_argument("-r", "--pull_report", action='store_true',
+    parser.add_argument("-r", "--pull_report",
+                        action='store_true',
                         help="pull reports from lanforge (by default: False)")
-    parser.add_argument("--load_old_cfg", action='store_true',
+    parser.add_argument("--load_old_cfg",
+                        action='store_true',
                         help="Should we first load defaults from previous run of the capacity test?  Default is False")
 
-    parser.add_argument("--enable", action='append', nargs=1, default=[],
+    parser.add_argument("--enable",
+                        action='append',
+                        nargs=1,
+                        default=[],
                         help="Specify options to enable (set cfg-file value to 1).  See example raw text config for possible options.  May be specified multiple times.  Most tests are enabled by default, except: longterm")
-    parser.add_argument("--disable", action='append', nargs=1, default=[],
+    parser.add_argument("--disable",
+                        action='append',
+                        nargs=1,
+                        default=[],
                         help="Specify options to disable (set value to 0).  See example raw text config for possible options.  May be specified multiple times.")
-    parser.add_argument("--set", action='append', nargs=2, default=[],
+    parser.add_argument("--set",
+                        action='append',
+                        nargs=2,
+                        default=[],
                         help="Specify options to set values based on their label in the GUI. Example: --set 'Basic Client Connectivity' 1  May be specified multiple times.")
-    parser.add_argument("--raw_line", action='append', nargs=1, default=[],
+    parser.add_argument("--raw_line",
+                        action='append',
+                        nargs=1,
+                        default=[],
                         help="Specify lines of the raw config file.  Example: --raw_line 'test_rig: Ferndale-01-Basic'  See example raw text config for possible options.  This is catch-all for any options not available to be specified elsewhere.  May be specified multiple times.")
 
-    parser.add_argument("--raw_lines_file", default="",
+    parser.add_argument("--raw_lines_file",
+                        type=str,
+                        default="",
                         help="Specify a file of raw lines to apply.")
 
     # Reporting info
-    parser.add_argument("--test_rig", default="",
+    parser.add_argument("--test_rig",
+                        default="",
                         help="Specify the test rig info for reporting purposes, for instance:  testbed-01")
-    parser.add_argument("--test_tag", default="",
+    parser.add_argument("--test_tag",
+                        default="",
                         help="Specify the test tag info for reporting purposes, for instance:  testbed-01")
 
 

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -368,7 +368,7 @@ class cv_test(Realm):
                     break
             else:
                 logger.info('Waiting on test completion for kpi')
-                
+
 
             # Of if test stopped for some reason and could not generate report.
             if not self.get_is_running(instance_name):
@@ -394,8 +394,9 @@ class cv_test(Realm):
     def kpi_results_present(self):
         kpi_csv_data_present = False
         kpi_csv = ''
+
         if self.local_lf_report_dir is None or self.local_lf_report_dir == "":
-            logger.info("Report dir empty , No KPI")
+            logger.info("Local report directory not specified. No KPI results present.")
             return False
         else:
             kpi_location = self.local_lf_report_dir + "/" + os.path.basename(self.lf_report_dir)
@@ -410,7 +411,7 @@ class cv_test(Realm):
                 logger.info("kpi_csv file not empty size: {kpi_size} {kpi_csv}".format(kpi_size=kpi_size,kpi_csv=kpi_csv))
                 kpi_csv_data_present = True
 
-        return kpi_csv_data_present 
+        return kpi_csv_data_present
 
     # ************************** chamber view **************************
     def add_text_blob_line(self,

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -42,7 +42,7 @@ def cv_add_base_parser(parser):
                         dest="mgr",
                         type=str,
                         default="localhost",
-                        help="address of the LANforge GUI machine (localhost is default)")
+                        help="Hostname or IP address of the LANforge GUI machine (localhost is default)")
     parser.add_argument("-o", "--port",
                         dest="port",
                         type=int,
@@ -51,17 +51,17 @@ def cv_add_base_parser(parser):
     parser.add_argument("--lf_user",
                         type=str,
                         default="lanforge",
-                        help="LANforge username to pull reports")
+                        help="LANforge system username used to SSH and pull reports")
     parser.add_argument("--lf_password",
                         type=str,
                         default="lanforge",
-                        help="LANforge Password to pull reports")
+                        help="LANforge system password used to SSH in and pull reports")
 
     parser.add_argument("-i", "--instance_name",
                         dest="instance_name",
                         type=str,
                         default="cv_dflt_inst",
-                        help="create test instance")
+                        help="Chamber View test instance name")
     parser.add_argument("-c", "--config_name",
                         dest="config_name",
                         type=str,
@@ -71,41 +71,53 @@ def cv_add_base_parser(parser):
     parser.add_argument("-r", "--pull_report",
                         dest="pull_report",
                         action='store_true',
-                        help="pull reports from lanforge (by default: False)")
+                        help="Pull reports from LANforge system. Off by default")
     parser.add_argument("--load_old_cfg",
                         action='store_true',
-                        help="Should we first load defaults from previous run of the capacity test?  Default is False")
+                        help="Load defaults from previous run of the test")
 
     parser.add_argument("--enable",
                         action='append',
                         nargs=1,
                         default=[],
-                        help="Specify options to enable (set cfg-file value to 1).  See example raw text config for possible options.  May be specified multiple times.  Most tests are enabled by default, except: longterm")
+                        help="Specify options to enable (set config option value to 1). "
+                             "Often used to enable Chamber View test sub-tests, for example "
+                             "the 'Stability' test in the AP-Auto Chamber View test. "
+                             "See test config for possible options. May be specified multiple times")
     parser.add_argument("--disable",
                         action='append',
                         nargs=1,
                         default=[],
-                        help="Specify options to disable (set value to 0).  See example raw text config for possible options.  May be specified multiple times.")
+                        help="Specify options to disable (set config option value to 0). "
+                             "See test config for possible options. May be specified multiple times.")
     parser.add_argument("--set",
                         action='append',
                         nargs=2,
                         default=[],
-                        help="Specify options to set values based on their label in the GUI. Example: --set 'Basic Client Connectivity' 1  May be specified multiple times.")
+                        help="Specify options to set values based on their label in the GUI. "
+                             "For example, '--set \"Basic Client Connectivity\" 1' "
+                             "May be specified multiple times.")
     parser.add_argument("--raw_line",
                         action='append',
                         nargs=1,
                         default=[],
-                        help="Specify lines of the raw config file.  Example: --raw_line 'test_rig: Ferndale-01-Basic'  See example raw text config for possible options.  This is catch-all for any options not available to be specified elsewhere.  May be specified multiple times.")
-
+                        help="Specify lines of the raw config file. "
+                             "For example, '--raw_line \"test_rig: Ferndale-01-Basic\"' "
+                             "See test config for possible options. "
+                             "This is catch-all for any options not available to be specified elsewhere. "
+                             "May be specified multiple times.")
+    # TODO: Clarify which takes precedent, --raw_line or --raw_lines_file
     parser.add_argument("--raw_lines_file",
                         type=str,
                         default="",
-                        help="Specify a file of raw lines to apply.")
+                        help="Specify a file of raw lines to apply. "
+                             "See the '--raw_line' option for more information.")
 
     # Reporting info
     parser.add_argument("--test_rig",
                         default="",
-                        help="Specify the test rig info for reporting purposes, for instance:  testbed-01")
+                        help="Specify the test rig info for reporting purposes. "
+                             "For example, '--test_rig testbed-01'")
     parser.add_argument("--test_tag",
                         default="",
                         help="Specify the test tag info for reporting purposes, for instance:  testbed-01")

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -394,7 +394,7 @@ class cv_test(Realm):
     def kpi_results_present(self):
         kpi_csv_data_present = False
         kpi_csv = ''
-        if self.local_lf_report_dir is None:
+        if self.local_lf_report_dir is None or self.local_lf_report_dir == "":
             logger.info("Report dir empty , No KPI")
             return False
         else:


### PR DESCRIPTION
Mostly readability/quality of life patches, including setting `dest` for multi-option arguments. Also fixed an issue related to KPI file checks when no `--pull_report` or `--lf_local_report_dir` is specified.

See the final commit in the series for the verification CLI (using WCT).