### PR TITLE
lf_create_vap_cv.py  flake 8 linting 

### DIFF
--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# flake8: noqa
+
 """
 NAME: lf_create_vap_cv.py
 

--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -74,12 +74,10 @@ LICENSE:
 INCLUDE_IN_README: False
 
 """
-import subprocess
 import sys
 import os
 import importlib
 import argparse
-import time
 import logging
 import requests
 


### PR DESCRIPTION
lf_create_vap_cv.py  flake 8 linting 

removed unused packages and removed the # flake8: noqa

Verfied:
./lf_create_vap_cv.py\
 --mgr 192.168.50.104\
 --port 8080\
 --lf_user lanforge\
 --lf_password lanforge\
 --delete_old_scenario\
 --scenario_name dfs_2\
 --vap_radio wiphy1\
 --vap_freq 5700\
 --vap_ssid mtk7915_5g_b\
 --vap_passwd lf_mtk7915_5g_b\
 --vap_security wpa2\
 --vap_bw 20\
 --vap_upstream_port 1.1.eth1 
