### PR TITLE
lf_validate_port.py: LAN-1963 - create lf_validate_port.py

### DIFF
--- a/py-scripts/lf_create_wanpath.py
+++ b/py-scripts/lf_create_wanpath.py
@@ -68,6 +68,7 @@ LFUtils = importlib.import_module('py-json.LANforge.LFUtils')
 from lanforge_client.lanforge_api import LFSession          # noqa: E402
 from lanforge_client.lanforge_api import LFJsonCommand      # noqa: E402
 from lanforge_client.lanforge_api import LFJsonQuery        # noqa: E402
+from lf_validate_port import validate_port                  # noqa: E402
 
 if sys.version_info[0] != 3:
     print('This script requires Python3')
@@ -285,6 +286,9 @@ def main():
     parser.add_argument('--lf_logger_config_json', help='--lf_logger_config_json <json file> , json configuration of logger')
 
     args = parser.parse_args()
+
+    # validate port
+    args.mgr_port = validate_port(args.mgr_port)
 
     logger_config = lf_logger_config.lf_logger_config()
     if args.log_level:

--- a/py-scripts/lf_validate_port.py
+++ b/py-scripts/lf_validate_port.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+'''
+NAME:       lf_validate_port.py
+
+PURPOSE:    Validate the port being used for management when trying to talk to the GUI.
+            Prevent 4001 and 4002 and ask for alternative.
+
+NOTES:      # Recommended Usage in py scripts:
+            args.mgr_port = validate_port(args.mgr_port)
+
+EXAMPLE:    # Create a single wanpath on endpoint A - attemped with port 4001:
+            ./lf_create_wanpath.py --mgr 192.168.101.189 --mgr_port 4001\
+                --wp_name test_wp-A --wl_endp test_wl-A\
+                --speed 102400 --latency 25 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
+                --log_level debug --debug
+
+SCRIPT_CLASSIFICATION:
+            Module
+
+SCRIPT_CATEGORIES:
+            Functional
+
+STATUS:     Functional
+
+VERIFIED_ON:
+            16-Jan-2025
+            GUI Version: 5.4.9
+            Kernel Version: 6.11.11+
+
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2023 Candela Technologies Inc
+
+INCLUDE_IN_README:
+            False
+'''
+
+import sys
+import logging
+import importlib
+
+if sys.version_info[0] != 3:
+    print('This script requires Python3')
+    exit()
+
+lf_logger_config = importlib.import_module('py-scripts.lf_logger_config')
+logger = logging.getLogger(__name__)
+
+
+def validate_port(port):
+    ''' Validate management port (not 4001 or 4002)'''
+    portsRestricted = ['4001', '4002']
+    if port in portsRestricted:
+        logger.error('Ports 4001 and 4002 are reserved. Please choose another port. GUI is typically 8080.')
+        response = input("To continue enter non-reserved port: ")
+        if response != '':
+            return response
+        else:
+            logger.error("No new port selected. Exiting...")
+            exit(1)
+    else:
+        return port

--- a/py-scripts/lf_validate_port.py
+++ b/py-scripts/lf_validate_port.py
@@ -9,11 +9,14 @@ PURPOSE:    Validate the port being used for management when trying to talk to t
 NOTES:      # Recommended Usage in py scripts:
             args.mgr_port = validate_port(args.mgr_port)
 
-EXAMPLE:    # Create a single wanpath on endpoint A - attemped with port 4001:
+EXAMPLE:    # Create a single wanlink and a wanpath on one of its endpts - attemped with port 4001:
+            ./lf_create_wanlink.py --mgr 192.168.101.189 --mgr_port 8080 --port_A eth1 --port_B eth2\
+                                   --speed 1024000 --wl_name test_wl --latency 20\
+                                   --log_level debug --debug
+
             ./lf_create_wanpath.py --mgr 192.168.101.189 --mgr_port 4001\
-                --wp_name test_wp-A --wl_endp test_wl-A\
-                --speed 102400 --latency 25 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
-                --log_level debug --debug
+                                   --wp_name test_wp-A --wl_endp test_wl-A\
+                                   --log_level debug --debug
 
 SCRIPT_CLASSIFICATION:
             Module


### PR DESCRIPTION
lf_validate_port.py is used to validate the mgr port when talking to the GUI. It prevents reserved ports (4001 and 4002) from being used and requests an alternative from the user. 

Added validation logic to lf_create_wanpath.py to test functionality. 

Validated with: 
./lf_create_wanpath.py --mgr 192.168.101.189 --mgr_port 4001\
                                        --wp_name test_wp-A --wl_endp test_wl-A\
                                        --log_level debug --debug

Usage in scripts: 
args.mgr_port = validate_port(args.mgr_port)