### PR TITLE
lf_create_wanpath.py: LAN-3630 - added '--help_summary' support

### DIFF
--- a/py-scripts/lf_create_wanpath.py
+++ b/py-scripts/lf_create_wanpath.py
@@ -65,6 +65,8 @@ import logging
 sys.path.append(os.path.join(os.path.abspath(__file__ + '../../../')))
 lanforge_api = importlib.import_module('lanforge_client.lanforge_api')
 LFUtils = importlib.import_module('py-json.LANforge.LFUtils')
+lfcli_base = importlib.import_module('py-json.LANforge.lfcli_base')
+LFCliBase = lfcli_base.LFCliBase
 from lanforge_client.lanforge_api import LFSession          # noqa: E402
 from lanforge_client.lanforge_api import LFJsonCommand      # noqa: E402
 from lanforge_client.lanforge_api import LFJsonQuery        # noqa: E402
@@ -229,72 +231,141 @@ class lf_create_wanpath():
                                       wanlink=wanlink)
 
 
-def main():
+def parse_args():
 
-    parser = argparse.ArgumentParser(
+    parser = LFCliBase.create_basic_argparse(
         prog=__file__,
         formatter_class=argparse.RawTextHelpFormatter,
-        epilog="Note: endp_A is associated with _tx_endp and endp_B is associated with _rx_endp"
+        epilog='''\
+            Create Wanpaths
+            ''',
+        description='''\
+            NAME:       lf_create_wanpath.py
+
+            PURPOSE:    Create a wanpath using the lanforge api given an existing wanlink endpoint
+
+            EXAMPLE:    # Create a single wanpath on endpoint A:
+                        $ ./lf_create_wanpath.py --mgr 192.168.102.158 --mgr_port 8080\
+                            --wp_name test_wp-A --wl_endp test_wl-A\
+                            --speed 102400 --latency 25 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
+                            --log_level debug --debug
+
+                        # Create a single wanpath on endpoint B:
+                        $ ./lf_create_wanpath.py --mgr 192.168.102.158 --mgr_port 8080\
+                            --wp_name test_wp-B --wl_endp test_wl-B\
+                            --speed 102400 --latency 25 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
+                            --log_level debug --debug
+
+                        # Create a single wanpath on endpoint A and test all text fields:
+                        $ ./lf_create_wanpath.py --mgr 192.168.102.158 --mgr_port 8080\
+                            --wp_name test_wp-C --wl_endp test_wl-A\
+                            --source_ip 1.1.1.1 --source_ip_mask 2.2.2.2 --dest_ip 3.3.3.3 --dest_ip_mask 4.4.4.4\
+                            --drop_freq 5 --dup_freq 6 --extra_buffer 7 --jitter_freq 8 --latency 9 --max_drop_amt 10\
+                            --max_jitter 11 --max_lateness 12 --max_reorder_amt 13 --min_drop_amt 14 --min_reorder_amt 15\
+                            --reorder_freq 16 --speed 17 --test_mgr default_tm\
+                            --log_level debug --debug
+
+            NOTES:
+                        # Wanlink must already exist - can be created with lf_create_wanlink.py:
+                            $ ./lf_create_wanlink.py --mgr 192.168.102.158 --mgr_port 8080 --port_A eth1 --port_B eth2\
+                                --speed_A 1024000 --speed_B 2048000 --wl_name test_wl --latency_A 24 --latency_B 32\
+                                --max_jitter_A 50 --max_jitter_B 20 --jitter_freq 6 --drop_freq 12\
+                                --log_level debug --debug
+
+                        # Lanforge api expects 'wanlink' but it is really looking for the endpoint name
+                            ie. wanlink test_wl has endpoints test_wl-A and test_wl-B.
+
+                        # Note: endp_A is associated with _tx_endp and endp_B is associated with _rx_endp
+
+            SCRIPT_CLASSIFICATION:
+                        Creation
+
+            SCRIPT_CATEGORIES:
+                        Functional
+
+            STATUS:     Functional
+
+            VERIFIED_ON:
+                        14-Jan-2024
+                        GUI Version: 5.4.9
+                        Kernel Version: 6.11.11+
+
+            LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+                        Copyright 2024 Candela Technologies Inc.
+
+            INCLUDE_IN_README:
+                        False
+            '''
     )
+
+    required = parser.add_argument_group('required arguments')
+    optional = parser.add_argument_group('optional arguments')
+
+    # required args
+    required.add_argument('--wanlink', '--wl_endp', dest='wanlink', help='(add wanpath) The name of the wanlink endpoint to which we are adding this WanPath.')
+    required.add_argument('--wp_name', '--alias', dest='wp_name', help='(add wanpath) Name of the WanPath')
 
     # http://www.candelatech.com/lfcli_ug.php#add_wanpath
     # connection args
-    parser.add_argument('--host', '--mgr', dest='mgr', help='specify the GUI to connect to')
-    parser.add_argument('--lf_user', help='lanforge user name default lanforge', default='lanforge')
-    parser.add_argument('--lf_passwd', help='lanforge password defualt lanforge', default='lanforge')
-    parser.add_argument('--mgr_port', help='specify the GUI to connect to, default 8080', default='8080')
+    optional.add_argument('--lf_user', help='lanforge user name default lanforge', default='lanforge')
+    optional.add_argument('--lf_passwd', help='lanforge password defualt lanforge', default='lanforge')
 
     # creating wanpath args
-    parser.add_argument('--dest_ip', help='(add wanpath)Selection filter: Destination IP', default='0.0.0.0')
-    parser.add_argument('--dest_ip_mask', help='(add wanpath) Selection filter: Destination IP MASK', default='0.0.0.0')
-    parser.add_argument('--drop_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we purposefully drop a packet.', default='0')
-    parser.add_argument('--dup_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we purposefully duplicate a packet.', default='0')
-    parser.add_argument('--extra_buffer', help='(add wanpath) The extra amount of bytes to buffer before dropping pkts, in units of 1024, use -1 for AUTO. Default: -1', default='-1')
-    parser.add_argument('--jitter_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we apply random jitter.', default='0')
-    parser.add_argument('--latency', help='(add wanpath) The base latency added to all packets, in milliseconds (or add "us" suffix for microseconds) Default: 20', default='20')
-    parser.add_argument('--max_drop_amt', help='(add wanpath) Maximum mount of packets to drop in a row. Default: 1', default='1')
-    parser.add_argument('--max_jitter', help='(add wanpath) The maximum jitter, in milliseconds (or ad "us" suffix for microseconds) Default: 10', default='10')
-    parser.add_argument('--max_lateness', help='(add wanpath) Maximum amount of un-intentional delay before pkt is dropped. Default: AUTO', default='AUTO')
-    parser.add_argument('--max_reorder_amt', help='(add wanpath) Maximum amount of packets by which to reorder, Default is 1.', default='1')
-    parser.add_argument('--min_drop_amt', help='(add wanpath) Minimum amount of packets to drop in a row. Default: 1', default='1')
-    parser.add_argument('--min_reorder_amt', help='(add wanpath) Minimum amount of packets by which to reorder, Default is 1.', default='1')
-    parser.add_argument('--playback_capture', help='(add wanpath) ON or OFF, should we play back a WAN capture file?', default=None)
-    parser.add_argument('--playback_capture_file', help='(add wanpath) Name of the WAN capture file to play back. Deafault = None', default=None)
-    parser.add_argument('--reorder_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we make a packet out of order.', default=None)
-    parser.add_argument('--source_ip', help='(add wanpath) Selection filter: Source IP', default='0.0.0.0')
-    parser.add_argument('--source_ip_mask', help='(add wanpath) Selection filter: Source IP MASK', default='0.0.0.0')
-    parser.add_argument('--speed', help='(add wanpath The maximum speed this WanLink will accept (bps).', default=1000000)
-    parser.add_argument('--test_mgr', help='(add wanpath) The name of the Test-Manager this WanPath is to use. Leave blank for no restrictions.', default=None)
-    parser.add_argument('--wanlink', '--wl_endp', dest='wanlink', help='(add wanpath) The name of the wanlink endpoint to which we are adding this WanPath.', required=True)
-    parser.add_argument('--wp_name', '--alias', dest='wp_name', help='(add wanpath) Name of the WanPath', required=True)
+    optional.add_argument('--dest_ip', help='(add wanpath)Selection filter: Destination IP', default='0.0.0.0')
+    optional.add_argument('--dest_ip_mask', help='(add wanpath) Selection filter: Destination IP MASK', default='0.0.0.0')
+    optional.add_argument('--drop_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we purposefully drop a packet.', default='0')
+    optional.add_argument('--dup_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we purposefully duplicate a packet.', default='0')
+    optional.add_argument('--extra_buffer', help='(add wanpath) The extra amount of bytes to buffer before dropping pkts, in units of 1024, use -1 for AUTO. Default: -1', default='-1')
+    optional.add_argument('--jitter_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we apply random jitter.', default='0')
+    optional.add_argument('--latency', help='(add wanpath) The base latency added to all packets, in milliseconds (or add "us" suffix for microseconds) Default: 20', default='20')
+    optional.add_argument('--max_drop_amt', help='(add wanpath) Maximum mount of packets to drop in a row. Default: 1', default='1')
+    optional.add_argument('--max_jitter', help='(add wanpath) The maximum jitter, in milliseconds (or ad "us" suffix for microseconds) Default: 10', default='10')
+    optional.add_argument('--max_lateness', help='(add wanpath) Maximum amount of un-intentional delay before pkt is dropped. Default: AUTO', default='AUTO')
+    optional.add_argument('--max_reorder_amt', help='(add wanpath) Maximum amount of packets by which to reorder, Default is 1.', default='1')
+    optional.add_argument('--min_drop_amt', help='(add wanpath) Minimum amount of packets to drop in a row. Default: 1', default='1')
+    optional.add_argument('--min_reorder_amt', help='(add wanpath) Minimum amount of packets by which to reorder, Default is 1.', default='1')
+    optional.add_argument('--playback_capture', help='(add wanpath) ON or OFF, should we play back a WAN capture file?', default=None)
+    optional.add_argument('--playback_capture_file', help='(add wanpath) Name of the WAN capture file to play back. Deafault = None', default=None)
+    optional.add_argument('--reorder_freq', help='(add wanpath) How often, out of 1,000,000 packets, should we make a packet out of order.', default=None)
+    optional.add_argument('--source_ip', help='(add wanpath) Selection filter: Source IP', default='0.0.0.0')
+    optional.add_argument('--source_ip_mask', help='(add wanpath) Selection filter: Source IP MASK', default='0.0.0.0')
+    optional.add_argument('--speed', help='(add wanpath The maximum speed this WanLink will accept (bps).', default=1000000)
+    optional.add_argument('--test_mgr', help='(add wanpath) The name of the Test-Manager this WanPath is to use. Leave blank for no restrictions.', default=None)
 
     # wanpath flag args
-    parser.add_argument('--drop_every_xth_pkt', help='(set wanpath flag) Periodically drop every Xth pkt, Default: drop packets randomly.', action='store_true')
-    parser.add_argument('--dup_every_xth_pkt', help='(set wanpath flag) Periodically duplicate every Xth pkt, Default: duplicate packets randomly.', action='store_true')
-    parser.add_argument('--follow_binomial', help='(set wanpath flag) Have ok/drop burst lengths follow a binomial distribution.', action='store_true')
-    parser.add_argument('--ignore_bandwidth', help='(set wanpath flag) Should we ignore the bandwidth wsettings from the playback file? Default = "False" action="store_true"', action='store_true')
-    parser.add_argument('--ignore_dup', help='(set wanpath flag) Should we ignore the Duplicate Packet settings from the playback file? Default = "False" action="store_true"', action='store_true')
-    parser.add_argument('--ignore_latency', help='(set wanpath flag) Should we ignore the packet-loss settings from the playback file? Default = "False" action="store_true"', action='store_true')
-    parser.add_argument('-ignore_loss', help='Should we ignore the packet-loss settings from the playback file? YES, NO, or NA.', default=None)
-    parser.add_argument('--playback_loop', help='(set wanpath flag) Should we loop the playback file', action='store_true')
-    parser.add_argument('--reorder_every_xth_pkt', help='(set wanpath flag) Periodically reorder every Xth pkt, Default: reorder packets randomly.', action='store_true')
+    optional.add_argument('--drop_every_xth_pkt', help='(set wanpath flag) Periodically drop every Xth pkt, Default: drop packets randomly.', action='store_true')
+    optional.add_argument('--dup_every_xth_pkt', help='(set wanpath flag) Periodically duplicate every Xth pkt, Default: duplicate packets randomly.', action='store_true')
+    optional.add_argument('--follow_binomial', help='(set wanpath flag) Have ok/drop burst lengths follow a binomial distribution.', action='store_true')
+    optional.add_argument('--ignore_bandwidth', help='(set wanpath flag) Should we ignore the bandwidth wsettings from the playback file? Default = "False" action="store_true"', action='store_true')
+    optional.add_argument('--ignore_dup', help='(set wanpath flag) Should we ignore the Duplicate Packet settings from the playback file? Default = "False" action="store_true"', action='store_true')
+    optional.add_argument('--ignore_latency', help='(set wanpath flag) Should we ignore the packet-loss settings from the playback file? Default = "False" action="store_true"', action='store_true')
+    optional.add_argument('-ignore_loss', help='Should we ignore the packet-loss settings from the playback file? YES, NO, or NA.', default=None)
+    optional.add_argument('--playback_loop', help='(set wanpath flag) Should we loop the playback file', action='store_true')
+    optional.add_argument('--reorder_every_xth_pkt', help='(set wanpath flag) Periodically reorder every Xth pkt, Default: reorder packets randomly.', action='store_true')
 
-    # Logging Configuration
-    parser.add_argument('--debug', help='Legacy debug flag', action='store_true')
-    parser.add_argument('--log_level', default=None, help='Set logging level: debug | info | warning | error | critical')
-    parser.add_argument('--lf_logger_config_json', help='--lf_logger_config_json <json file> , json configuration of logger')
+    return parser.parse_args()
 
-    args = parser.parse_args()
 
+def validate_args(args):
+    '''Validate CLI arguments.'''
+    if args.wanlink is None:
+        logger.error('--wanlink required')
+        exit(1)
+    elif args.wp_name is None:
+        logger.error('--alias required')
+        exit(1)
+
+
+def main():
+
+    args = parse_args()
+
+    validate_args(args)
+
+    # Configure logging
     logger_config = lf_logger_config.lf_logger_config()
-    if args.log_level:
-        logger_config.set_level(level=args.log_level)
-
-    # lf_logger_config_json will take presidence to changing debug levels
-    if args.lf_logger_config_json:
-        logger_config.lf_logger_config_json = args.lf_logger_config_json
-        logger_config.load_lf_logger_config()
-
+    logger_config.set_level(level=args.log_level)
+    logger_config.set_json(json_file=args.lf_logger_config_json)
     # initialize wanlink
     wanpath = lf_create_wanpath(lf_mgr=args.mgr,
                                 lf_port=8080,

--- a/py-scripts/lf_create_wanpath.py
+++ b/py-scripts/lf_create_wanpath.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-'''
+r'''
 NAME:       lf_create_wanpath.py
 
 PURPOSE:    Create a wanpath using the lanforge api given an existing wanlink endpoint
@@ -35,6 +35,8 @@ NOTES:
 
             # Lanforge api expects 'wanlink' but it is really looking for the endpoint name
                 ie. wanlink test_wl has endpoints test_wl-A and test_wl-B.
+
+            # Note: endp_A is associated with _tx_endp and endp_B is associated with _rx_endp
 
 SCRIPT_CLASSIFICATION:
             Creation
@@ -189,14 +191,6 @@ class lf_create_wanpath():
             wanlink:                   Name of WanLink endpoint [R]
         '''
 
-        # check for required arguments
-        if wanlink is None:
-            logger.error('wanlink is None. wanlink must be set to a valid existing wanlink. Exiting')
-            exit(1)
-        elif alias is None:
-            logger.error('alias is None. alias must be set to the desired name of the wanpath. Exiting')
-            exit(1)
-
         # add wanpath via cli command post_add_wanpath
         self.command.post_add_wanpath(alias=alias,
                                       dest_ip=dest_ip,
@@ -239,7 +233,7 @@ def parse_args():
         epilog='''\
             Create Wanpaths
             ''',
-        description='''\
+        description=r'''\
             NAME:       lf_create_wanpath.py
 
             PURPOSE:    Create a wanpath using the lanforge api given an existing wanlink endpoint
@@ -372,6 +366,7 @@ def main():
     logger_config = lf_logger_config.lf_logger_config()
     logger_config.set_level(level=args.log_level)
     logger_config.set_json(json_file=args.lf_logger_config_json)
+
     # initialize wanlink
     wanpath = lf_create_wanpath(lf_mgr=args.mgr,
                                 lf_port=8080,
@@ -413,5 +408,5 @@ def main():
                         wanlink=args.wanlink)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/py-scripts/lf_create_wanpath.py
+++ b/py-scripts/lf_create_wanpath.py
@@ -360,6 +360,12 @@ def main():
 
     args = parse_args()
 
+    help_summary = 'This script will create and configure a wanpath given an existing wanlink endpoint.'
+
+    if args.help_summary:
+        print(help_summary)
+        exit(0)
+
     validate_args(args)
 
     # Configure logging


### PR DESCRIPTION
Corrected issue where lf_create_wanpath.py did not support help summary and reconfigured argument parsing to be similar to create_station.py.

Verified with:
./lf_create_wanpath.py --help_summary

./lf_create_wanpath.py --mgr 192.168.102.158 --mgr_port 8080\
                --wp_name test_wp-A --wl_endp test_wl-A\
                --speed 102400 --latency 25 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
                --log_level debug --debug