### PR TITLE
Updates to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,14 @@ repos:
         - id: flake8
           #additional_dependencies:
           #    - "flake8-bugbear"
+
+    #- repo: https://github.com/shellcheck-py/shellcheck-py
+    #  rev: v0.9.0.5
+    #  hooks:
+    #      - id: shellcheck
+
+    #- repo: https://github.com/igorshubovych/markdownlint-cli
+    #  rev: v0.33.0
+    #  hooks:
+    #      - id: markdownlint
+    #        args: ['--fix']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,9 @@ repos:
           - id: end-of-file-fixer
           - id: trailing-whitespace
 
-    -   repo: https://github.com/PyCQA/flake8
-        rev: 7.0.0
-        hooks:
-        -   id: flake8
-            #additional_dependencies:
-            #    - "flake8-bugbear"
+    - repo: https://github.com/PyCQA/flake8
+      rev: 7.0.0
+      hooks:
+        - id: flake8
+          #additional_dependencies:
+          #    - "flake8-bugbear"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.3.0
+      rev: v5.0.0
       hooks:
           - id: check-yaml
           - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
           - id: check-yaml
           - id: end-of-file-fixer
           - id: trailing-whitespace
+          - id: check-executables-have-shebangs
 
     - repo: https://github.com/PyCQA/flake8
       rev: 7.0.0


### PR DESCRIPTION
This PR updates pre-commit to the latest version in addition of a shebang and shell linting checks.
The shebang check is simple and does a common sense check. The shell linting check maybe not so much.

Inspiration for this series comes from the [linux-firmware](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tree/.pre-commit-config.yaml) repository's pre-commit config. It includes several more checks than we do here (like the opinionated Python formatter `black`), some of which I feel are appropriate to introduce.

@memnochproxy do you mind reviewing this as well? Given that primarily you and @smileyrekiere develop the newer Bash scripts in this repository, I want to make sure you're on board with this before we introduce it. I don't know that you (@memnochproxy) are you using the pre-commit config yet or much, but this would likely impact you and Chuck the most.

In my limited experience using the shellcheck utility, I've seen good warnings with some common issues, in addition to some more "niche" warnings. However, I am proposing it as more food for thought for now, and am happy to remove that patch (or re-submit it w/ the config commented out) if desired.

In the last patch where I submit the addition of the `shellchecker` pre-commit check, I also included a commented out configuration for Markdown linting. I'm interested in including this, as it also does common sense checks, but I want to play with it more (and address the vast amount of warnings it gives in our repo) before introducing it.