### PR TITLE
Cleanup/refactoring for 'test_l3.py'

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1292,76 +1292,76 @@ class L3VariableTime(Realm):
                     self.anqp_3gpp_cell_net_list,
                     self.ieee80211w_list
             ):
-                self.station_profile = self.new_station_profile()
-                self.station_profile.lfclient_url = self.lfclient_url
-                self.station_profile.ssid = ssid_
-                self.station_profile.ssid_pass = ssid_password_
-                self.station_profile.security = ssid_security_
-                self.station_profile.number_template = self.number_template
-                self.station_profile.mode = mode_
-                self.station_profile.desired_add_sta_flags = enable_flags_.copy()
-                self.station_profile.desired_add_sta_flags_mask = enable_flags_.copy()
+                station_profile = self.new_station_profile()
+                station_profile.lfclient_url = self.lfclient_url
+                station_profile.ssid = ssid_
+                station_profile.ssid_pass = ssid_password_
+                station_profile.security = ssid_security_
+                station_profile.number_template = self.number_template
+                station_profile.mode = mode_
+                station_profile.desired_add_sta_flags = enable_flags_.copy()
+                station_profile.desired_add_sta_flags_mask = enable_flags_.copy()
 
                 # set_wifi_extra
                 if key_mgmt_ != '[BLANK]':
-                    self.station_profile.set_wifi_extra(key_mgmt=key_mgmt_,
-                                                        pairwise=pairwise_,
-                                                        group=group_,
-                                                        psk=psk_,
-                                                        wep_key=wep_key_,
-                                                        ca_cert=ca_cert_,
-                                                        eap=eap_,
-                                                        identity=identity_,
-                                                        anonymous_identity=anonymous_identity_,
-                                                        phase1=phase1_,
-                                                        phase2=phase2_,
-                                                        passwd=passwd_,
-                                                        pin=pin_,
-                                                        pac_file=pac_file_,
-                                                        private_key=private_key_,
-                                                        pk_password=pk_password_,
-                                                        hessid=hessid_,
-                                                        realm=realm_,
-                                                        client_cert=client_cert_,
-                                                        imsi=imsi_,
-                                                        milenage=milenage_,
-                                                        domain=domain_,
-                                                        roaming_consortium=roaming_consortium_,
-                                                        venue_group=venue_group_,
-                                                        network_type=network_type_,
-                                                        ipaddr_type_avail=ipaddr_type_avail_,
-                                                        network_auth_type=network_auth_type_,
-                                                        anqp_3gpp_cell_net=anqp_3gpp_cell_net_)
+                    station_profile.set_wifi_extra(key_mgmt=key_mgmt_,
+                                                   pairwise=pairwise_,
+                                                   group=group_,
+                                                   psk=psk_,
+                                                   wep_key=wep_key_,
+                                                   ca_cert=ca_cert_,
+                                                   eap=eap_,
+                                                   identity=identity_,
+                                                   anonymous_identity=anonymous_identity_,
+                                                   phase1=phase1_,
+                                                   phase2=phase2_,
+                                                   passwd=passwd_,
+                                                   pin=pin_,
+                                                   pac_file=pac_file_,
+                                                   private_key=private_key_,
+                                                   pk_password=pk_password_,
+                                                   hessid=hessid_,
+                                                   realm=realm_,
+                                                   client_cert=client_cert_,
+                                                   imsi=imsi_,
+                                                   milenage=milenage_,
+                                                   domain=domain_,
+                                                   roaming_consortium=roaming_consortium_,
+                                                   venue_group=venue_group_,
+                                                   network_type=network_type_,
+                                                   ipaddr_type_avail=ipaddr_type_avail_,
+                                                   network_auth_type=network_auth_type_,
+                                                   anqp_3gpp_cell_net=anqp_3gpp_cell_net_)
 
                     # Configure protected management frames (PMF)
                     if ieee80211w_.lower() == 'disabled':
-                        self.station_profile.set_command_param("add_sta", "ieee80211w", 0)
+                        station_profile.set_command_param("add_sta", "ieee80211w", 0)
                     elif ieee80211w_.lower() == 'required':
-                        self.station_profile.set_command_param("add_sta", "ieee80211w", 2)
+                        station_profile.set_command_param("add_sta", "ieee80211w", 2)
                     else:
                         # may want to set an error if not optional yet for now default to optional
-                        self.station_profile.set_command_param("add_sta", "ieee80211w", 1)
+                        station_profile.set_command_param("add_sta", "ieee80211w", 1)
 
                 # place the enable and disable flags
-                # self.station_profile.desired_add_sta_flags = self.enable_flags
-                # self.station_profile.desired_add_sta_flags_mask = self.enable_flags
+                # station_profile.desired_add_sta_flags = self.enable_flags
+                # station_profile.desired_add_sta_flags_mask = self.enable_flags
                 test_duration_sec = self.duration_time_to_seconds(self.test_duration)
                 reset_port_min_time_sec = self.duration_time_to_seconds(reset_port_time_min_)
                 reset_port_max_time_sec = self.duration_time_to_seconds(reset_port_time_max_)
 
-                self.station_profile.set_reset_extra(reset_port_enable=reset_port_enable_,
-                                                     test_duration=test_duration_sec,
-                                                     reset_port_min_time=reset_port_min_time_sec,
-                                                     reset_port_max_time=reset_port_max_time_sec)
-                self.station_profiles.append(self.station_profile)
+                station_profile.set_reset_extra(reset_port_enable=reset_port_enable_,
+                                                test_duration=test_duration_sec,
+                                                reset_port_min_time=reset_port_min_time_sec,
+                                                reset_port_max_time=reset_port_max_time_sec)
+                self.station_profiles.append(station_profile)
 
             # Use existing station list is similiar to no rebuild
             if self.use_existing_station_lists:
-                self.station_profile = self.new_station_profile()
+                station_profile = self.new_station_profile()
                 for existing_station_list in self.existing_station_lists:
-                    self.station_profile.station_names.append(existing_station_list)
+                    station_profile.station_names.append(existing_station_list)
 
-                self.station_profiles.append(self.station_profile)
+                self.station_profiles.append(station_profile)
         else:
             # Dataplane style test
             pass

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """
 NAME: test_l3.py
 
@@ -544,37 +543,31 @@ if sys.version_info[0] != 3:
     print("This script requires Python 3")
     exit(1)
 
-
 sys.path.append(os.path.join(os.path.abspath(__file__ + "../../../")))
 
+# LANforge automation-specific imports
 lf_report = importlib.import_module("py-scripts.lf_report")
 lf_graph = importlib.import_module("py-scripts.lf_graph")
 lf_kpi_csv = importlib.import_module("py-scripts.lf_kpi_csv")
 lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
 LFUtils = importlib.import_module("py-json.LANforge.LFUtils")
 realm = importlib.import_module("py-json.realm")
-
-# from lf_graph import lf_bar_graph_horizontal
-# from lf_graph import lf_bar_graph
-
-
-# additional imports for testing with vap
 lf_attenuator = importlib.import_module("py-scripts.lf_atten_mod_test")
 modify_vap = importlib.import_module("py-scripts.modify_vap")
 lf_modify_radio = importlib.import_module("py-scripts.lf_modify_radio")
-
-# cleanup library
 lf_cleanup = importlib.import_module("py-scripts.lf_cleanup")
-
-
 Realm = realm.Realm
 
 logger = logging.getLogger(__name__)
 
 
-# This class handles running the test and generating reports.
 class L3VariableTime(Realm):
-    # May raise an exception if incorrect values specified
+    """Test class for variable-time Layer-3 traffic tests.
+
+    This test class provides methods to run the configured test,
+    query data for relevant LANforge ports and traffic pairs during
+    the test, and generate reports upon completion.
+    """
     def __init__(self,
                  endp_types,
                  args,

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -6798,8 +6798,6 @@ INCLUDE_IN_README: False
 #
 # Safe to exit in this function, as this should only be called by this script
 def main():
-    lfjson_host = "localhost"
-    lfjson_port = 8080
     endp_types = "lf_udp"
 
     help_summary = '''\
@@ -6842,8 +6840,6 @@ and generate a report.
         logger_config.lf_logger_config_json = args.lf_logger_config_json
         logger_config.load_lf_logger_config()
 
-    debug = args.debug
-
     # Validate existing station list configuration if specified before starting test
     if not args.use_existing_station_list and args.existing_station_list:
         logger.error("Existing stations specified, but argument \'--use_existing_station_list\' not specified")
@@ -6857,28 +6853,8 @@ and generate a report.
     logger.info("Read in command line paramaters")
     interopt_mode = args.interopt_mode
 
-    if args.test_duration:
-        test_duration = args.test_duration
-
-    if args.polling_interval:
-        polling_interval = args.polling_interval
-
     if args.endp_type:
         endp_types = args.endp_type
-
-    if args.lfmgr:
-        lfjson_host = args.lfmgr
-
-    if args.lfmgr_port:
-        lfjson_port = args.lfmgr_port
-
-    if args.upstream_port:
-        side_b = args.upstream_port
-
-    if args.downstream_port:
-        side_a = args.downstream_port
-    else:
-        side_a = None
 
     if args.radio:
         radios = args.radio
@@ -7354,8 +7330,8 @@ and generate a report.
         endp_types=endp_types,
         args=args,
         tos=args.tos,
-        side_b=side_b,
-        side_a=side_a,
+        side_b=args.upstream_port,
+        side_a=args.downstream_port,
         radio_name_list=radio_name_list,
         number_of_stations_per_radio_list=number_of_stations_per_radio_list,
         ssid_list=ssid_list,
@@ -7378,11 +7354,11 @@ and generate a report.
         attenuators=attenuators,
         atten_vals=atten_vals,
         number_template="00",
-        test_duration=test_duration,
-        polling_interval=polling_interval,
-        lfclient_host=lfjson_host,
-        lfclient_port=lfjson_port,
-        debug=debug,
+        test_duration=args.test_duration,
+        polling_interval=args.polling_interval,
+        lfclient_host=args.lfmgr,
+        lfclient_port=args.lfmgr_port,
+        debug=args.debug,
         kpi_csv=kpi_csv,
         no_cleanup=args.no_cleanup,
         use_existing_station_lists=args.use_existing_station_list,

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1304,8 +1304,6 @@ class L3VariableTime(Realm):
 
                 # set_wifi_extra
                 if key_mgmt_ != '[BLANK]':
-                    # for teesting
-                    # if key_mgmt_ == '[BLANK]':
                     self.station_profile.set_wifi_extra(key_mgmt=key_mgmt_,
                                                         pairwise=pairwise_,
                                                         group=group_,
@@ -1333,38 +1331,39 @@ class L3VariableTime(Realm):
                                                         network_type=network_type_,
                                                         ipaddr_type_avail=ipaddr_type_avail_,
                                                         network_auth_type=network_auth_type_,
-                                                        anqp_3gpp_cell_net=anqp_3gpp_cell_net_
-                                                        )
+                                                        anqp_3gpp_cell_net=anqp_3gpp_cell_net_)
+
+                    # Configure protected management frames (PMF)
                     if ieee80211w_.lower() == 'disabled':
-                        self.station_profile.set_command_param(
-                            "add_sta", "ieee80211w", 0)
+                        self.station_profile.set_command_param("add_sta", "ieee80211w", 0)
                     elif ieee80211w_.lower() == 'required':
-                        self.station_profile.set_command_param(
-                            "add_sta", "ieee80211w", 2)
-                    # may want to set an error if not optional yet for now default to optional
+                        self.station_profile.set_command_param("add_sta", "ieee80211w", 2)
                     else:
-                        self.station_profile.set_command_param(
-                            "add_sta", "ieee80211w", 1)
+                        # may want to set an error if not optional yet for now default to optional
+                        self.station_profile.set_command_param("add_sta", "ieee80211w", 1)
 
                 # place the enable and disable flags
                 # self.station_profile.desired_add_sta_flags = self.enable_flags
                 # self.station_profile.desired_add_sta_flags_mask = self.enable_flags
-                self.station_profile.set_reset_extra(
-                    reset_port_enable=reset_port_enable_,
-                    test_duration=self.duration_time_to_seconds(
-                        self.test_duration),
-                    reset_port_min_time=self.duration_time_to_seconds(
-                        reset_port_time_min_),
-                    reset_port_max_time=self.duration_time_to_seconds(reset_port_time_max_))
+                test_duration_sec = self.duration_time_to_seconds(self.test_duration)
+                reset_port_min_time_sec = self.duration_time_to_seconds(reset_port_time_min_)
+                reset_port_max_time_sec = self.duration_time_to_seconds(reset_port_time_max_)
+
+                self.station_profile.set_reset_extra(reset_port_enable=reset_port_enable_,
+                                                     test_duration=test_duration_sec,
+                                                     reset_port_min_time=reset_port_min_time_sec,
+                                                     reset_port_max_time=reset_port_max_time_sec)
                 self.station_profiles.append(self.station_profile)
+
             # Use existing station list is similiar to no rebuild
             if self.use_existing_station_lists:
                 self.station_profile = self.new_station_profile()
                 for existing_station_list in self.existing_station_lists:
-                    self.station_profile.station_names.append(
-                        existing_station_list)
+                    self.station_profile.station_names.append(existing_station_list)
+
                 self.station_profiles.append(self.station_profile)
         else:
+            # Dataplane style test
             pass
 
         self.multicast_profile.host = self.lfclient_host
@@ -1976,8 +1975,6 @@ class L3VariableTime(Realm):
                 self.multicast_profile.side_a_max_pdu = ul_pdu
                 self.multicast_profile.side_b_min_pdu = dl_pdu
                 self.multicast_profile.side_b_max_pdu = dl_pdu
-
-                self
 
                 # Update connections with the new rate and pdu size config.
                 self.build(rebuild=True)


### PR DESCRIPTION
More cleanup/refactoring for `test_l3.py`. Time permitting, I intend to submit a few more patch series for this script.
There's some churn here, so please keep an eye for regressions. I moved some WebGUI code to a helper in one of the commits, but that change seemed pretty low risk comparatively.

Series rebased on current master (includes other `test_l3.py` changes) is tested with the following CLI, as detailed in the final commit in the series:
```Bash
    Verified:
    ./test_l3.py \
        --test_duration    1m \
        --endp_type        mc_udp \
        --download_min_bps 1000000 \
        --upstream_port    1.3.eth2 \
        --radio "radio==1.1.wiphy0,stations==5,ssid==Mesh,ssid_pw==lanforge,security==wpa2"
    
    ./test_l3.py \
        --test_duration     1m \
        --endp_type         lf_udp \
        --download_min_bps  1000000 \
        --upstream_port     1.3.eth2 \
        --downstream_port   1.1.sta0000 \
        --no_pre_cleanup
    
    ./test_l3.py \
        --test_duration             1m \
        --endp_type                 lf_udp \
        --download_min_bps          1000000 \
        --upstream_port             1.3.eth2 \
        --use_existing_station_list \
        --existing_station_list     1.1.sta0000
```

CC: @goyalsaurabh06 