### PR TITLE
lf_interop_real_browser_test.py: refactor upstream port usage, enhanc…

### DIFF
--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -1079,6 +1079,42 @@ class RealBrowserTest(Realm):
 
         except Exception as e:
             logging.error(f"An error occurred while updating status: {e}")
+    
+    def change_port_to_ip(self, upstream_port):
+        """
+        Convert a given port name to its corresponding IP address if it's not already an IP.
+
+        This function checks whether the provided `upstream_port` is a valid IPv4 address.
+        If it's not, it attempts to extract the IP address of the port by resolving it
+        via the internal `name_to_eid()` method and then querying the IP using `json_get()`.
+
+        Args:
+            upstream_port (str): The name or IP of the upstream port. This could be a
+            LANforge port name like '1.1.eth1' or an IP address.
+
+        Returns:
+            str: The resolved IP address if the port name was converted successfully,
+            otherwise returns the original input if it was already an IP or
+            if resolution fails.
+
+        Logs:
+            - A warning if the port is not Ethernet or IP resolution fails.
+            - Info logs for the resolved or passed IP.
+
+        """
+        if upstream_port.count('.') != 3:
+            target_port_list = self.name_to_eid(upstream_port)
+            shelf, resource, port, _ = target_port_list
+            try:
+                target_port_ip = self.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
+                upstream_port = target_port_ip
+            except BaseException:
+                logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
+            logging.info(f"Upstream port IP {upstream_port}")
+        else:
+            logging.info(f"Upstream port IP {upstream_port}")
+
+        return upstream_port
 
     def create_report(self,):
         if self.dowebgui:

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -910,7 +910,7 @@ class RealBrowserTest(Realm):
                 }
                 self.updating_webui_runningjson(data_obj)
         return True
-    
+
     def process_incremental_values(self, available_resources):
         """
         Process resource IDs and incremental values if specified.
@@ -1031,13 +1031,11 @@ class RealBrowserTest(Realm):
             logging.error("Specify either expected_passfail_value or device_csv_name")
             os._exit(1)
 
-
         if len(self.selected_groups) != len(self.selected_profiles):
             logging.error("Number of groups should match number of profiles")
             os._exit(1)
 
-
-        if self.group_name and self.profile_name  and self.file_name  and self.resource_ids:
+        if self.group_name and self.profile_name and self.file_name and self.resource_ids:
             logging.error("Either group name or device list should be entered not both")
             os._exit(1)
 
@@ -1049,19 +1047,16 @@ class RealBrowserTest(Realm):
             logging.error("Please enter the correct set of arguments")
             os._exit(1)
 
-
         if self.config and ((self.ssid is None or
                             (self.passwd is None and self.encryp and self.encryp.lower() != 'open') or
                             (self.passwd is None and self.encryp is None))):
             logging.error("Please provide ssid password and security for configuration of devices")
             os._exit(1)
 
-        
         if self.file_name:
             self.file_name = self.file_name.removesuffix(".csv")
         else:
             self.file_name = None
-
 
     def process_group_profiles(self):
         """
@@ -1149,7 +1144,7 @@ class RealBrowserTest(Realm):
 
         return available_resources
 
-    def update_passfail_value(self,available_resources):
+    def update_passfail_value(self, available_resources):
         """
         If no expected_passfail_value and no device_csv_name provided, ask for expected values
         and update the device CSV.
@@ -1408,7 +1403,7 @@ class RealBrowserTest(Realm):
 
         except Exception as e:
             logging.error(f"An error occurred while updating status: {e}")
-    
+
     def change_port_to_ip(self):
         """
         Convert a given port name to its corresponding IP address if it's not already an IP.
@@ -1444,7 +1439,7 @@ class RealBrowserTest(Realm):
             logging.info(f"Upstream port IP {self.upstream_port}")
 
         return self.upstream_port
-    
+
     def filter_ios_devices(self, device_list):
         """
         Filters out iOS devices from the given device list based on hardware and software identifiers.
@@ -1519,12 +1514,12 @@ class RealBrowserTest(Realm):
 
         self.device_list = filtered_list
         return filtered_list
-    
+
     def generate_test_setup_info(self):
         """
         Generate a dictionary containing the test setup information
         based on the configuration mode or selected group/profile mapping.
-        
+
         Returns:
             dict: Test setup information.
         """
@@ -1564,9 +1559,9 @@ class RealBrowserTest(Realm):
                 'URL': self.url,
                 'Test Duration (min)': self.duration,
             }
-        
+
         return test_setup_info
-    
+
     def generate_pass_fail_list(self, device_type_data, device_names, total_urls):
         """
         Generate the pass/fail list and expected URL count list for the devices.
@@ -1776,7 +1771,7 @@ class RealBrowserTest(Realm):
             report.build_table_title()
             if self.expected_passfail_value or self.device_csv_name:
                 pass_fail_list, test_input_list = self.generate_pass_fail_list(device_type_data, device_names, total_urls)
-                
+
                 final_test_results = {
 
                     "Device Type": device_type_data,
@@ -2148,9 +2143,6 @@ def main():
         obj.handle_incremental(args, obj, available_resources, available_resources)
         obj.handle_duration()
         obj.run_test(available_resources)
-        
-
-            
 
     except Exception as e:
         logging.error("Error occured", e)
@@ -2161,7 +2153,6 @@ def main():
             if (obj.dowebgui):
                 obj.webui_stop()
             obj.stop()
-            
 
             if args.postcleanup:
                 obj.postcleanup()

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -5,50 +5,67 @@ Purpose: To be generic script for LANforge-Interop devices(Real clients) which r
 
 Pre-requisites: Real clients should be connected to the LANforge MGR and Interop app should be open on the real clients which are connected to Lanforge
 
+            Name: lf_interop_real_browser_test.py
 
-Example: (python3 or ./)lf_interop_real_browser_test.py --mgr 192.168.214.219 --duration 1m --url "https://google.com" --flask_ip 192.168.214.131
---server_ip 192.168.214.131  --postcleanup --expected_passfail_value 8"
+            Example-1 :
+            Command Line Interface to run url in the Browser with specified URL and duration:
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --debug --upstream_port 1.1.eth1
 
-Example-1 :
-Command Line Interface to run url in the Browser with specified URL and duration:
-python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --duration 1m --url "https://google.com" --flask_ip 192.168.214.131 --server_ip 192.168.214.131  --postcleanup --expected_passfail_value 8
+                CASE-1:
+                If not specified it takes the default url (default url is www.google.com)
 
-    CASE-1:
-    If not specified it takes the default url (default url is https://google.com)
+            Example-2:
+            Command Line Interface to run url in the Browser with specified Resources:
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --debug --upstream_port 1.1.eth1
 
-Example-2:
-Command Line Interface to run url in the Browser with specified Resources:
-python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --duration 1m --url "https://google.com" --flask_ip 192.168.214.131 --server_ip 192.168.214.131
---postcleanup --expected_passfail_value 8 --device_list 1.92,1.95,1.22
+            Example-3:
+            Command Line Interface to run url in the Browser with specified urls_per_tennm (specify the number of url you want to test in the given duration):
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug --upstream_port 1.1.eth1
 
-Example-3:
-Command Line Interface to run url in the Browser with specified urls_per_tennm (specify the number of url you want to test in the given duration):
-python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --duration 1m --url "https://google.com" --flask_ip 192.168.214.131 --server_ip 192.168.214.131
---postcleanup --expected_passfail_value 8 --device_list 1.92,1.95,1.22 --count 10
-
-    CASE-1:
-    If not specified it takes the default count value (default count is 1)
+                CASE-1:
+                If not specified it takes the default count value (default count is 1)
 
 
-SCRIPT CLASSIFICATION: Test
+            Example-4:
+            Command Line Interface to run url in the Browser with precleanup:
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --precleanup --debug --upstream_port 1.1.eth1
 
-SCRIPT_CATEGORIES:   Performance,  Functional, Report Generation
+            Example-5:
+            Command Line Interface to run url in the Browser with postcleanup:
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --postcleanup --debug --upstream_port 1.1.eth1
 
-NOTES:
-    1. Use './lf_interop_real_browser_test.py --help' to see command line usage and options.
-    2. Always specify the duration in minutes (for example: --duration 3m indicates a duration of 3 minutes).
-    3. If --device_list are not given after passing the CLI, a list of available devices will be displayed on the terminal.
-    4. For --url, you can specify the URL (e.g., https://google.com).
+            Example-4:
+            Command Line Interface to run the Real Browser Test with Device Configuration
+            python3 lf_interop_real_browser_test.py --mgr 192.168.204.74 --url "https://google.com" --duration 1m --debug --upstream_port 1.1.eth1
+            --ssid NETGEAR_5G_wpa2 --passwd Password@123 --encryp wpa2 --config
 
-STATUS: BETA RELEASE
+            Example-5:
+            Command Line Interface to run the Real Browser Test with groups and profiles
+            python3 lf_interop_real_browser_test.py --mgr 192.168.204.74 --url "https://google.com" --duration 1m --debug --upstream_port 1.1.eth1
+            --file_name grplaptops --group_name group1,group2 --profile_name netgear2g,netgear2g
 
-VERIFIED_ON:
-Working date - 12/02/2024
-Build version - 5.4.9
-kernel version - 6.2.16+
 
-License: Free to distribute and modify. LANforge systems must be licensed.
-Copyright 2023 Candela Technologies Inc.
+            SCRIPT CLASSIFICATION: Test
+
+            SCRIPT_CATEGORIES:   Performance,  Functional, Report Generation
+
+            NOTES:
+                1. Use './lf_interop_real_browser_test.py --help' to see command line usage and options.
+                2. Always specify the duration in minutes (for example: --duration 3 indicates a duration of 3 minutes).
+                3. If --device_list are not given after passing the CLI, a list of available devices will be displayed on the terminal.
+                4. Enter the resource numbers separated by commas (,) in the resource argument and also enclose in double quotes (e.g. : 1.10,1.12).
+                5. For --url, you can specify the URL (e.g., www.google.com).
+                6. To run the test by specifying the incremental capacity, enable the --incremental flag.
+
+            STATUS: BETA RELEASE
+
+            VERIFIED_ON:
+            Working date - 29/07/2024
+            Build version - 5.4.8
+            kernel version - 6.2.16+
+
+            License: Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2023 Candela Technologies Inc.
 
 
 
@@ -1906,41 +1923,41 @@ def main():
 
             Example-1 :
             Command Line Interface to run url in the Browser with specified URL and duration:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --debug
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --debug --upstream_port 1.1.eth1
 
                 CASE-1:
                 If not specified it takes the default url (default url is www.google.com)
 
             Example-2:
             Command Line Interface to run url in the Browser with specified Resources:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --debug
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --debug --upstream_port 1.1.eth1
 
             Example-3:
             Command Line Interface to run url in the Browser with specified urls_per_tennm (specify the number of url you want to test in the given duration):
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug --upstream_port 1.1.eth1
 
                 CASE-1:
-                If not specified it takes the default count value (default count is 100)
+                If not specified it takes the default count value (default count is 1)
+
 
             Example-4:
-            Command Line Interface to run the the Real Browser test with incremental Capacity by specifying the --incremental flag
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --incremental --debug
+            Command Line Interface to run url in the Browser with precleanup:
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --precleanup --debug --upstream_port 1.1.eth1
 
             Example-5:
-            Command Line Interface to run the the Real Browser test in webGUI by specifying the --dowebgui flag
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --dowebgui --debug
-
-            Example-6:
-            Command Line Interface to run url in the Browser with precleanup:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --precleanup --debug
-
-            Example-7:
             Command Line Interface to run url in the Browser with postcleanup:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --postcleanup --debug
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --postcleanup --debug --upstream_port 1.1.eth1
 
-            Example-8:
-            Command Line Interface to run url in the Browser with incremental capacity:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --incremental_capacity 1 --debug
+            Example-4:
+            Command Line Interface to run the Real Browser Test with Device Configuration
+            python3 lf_interop_real_browser_test.py --mgr 192.168.204.74 --url "https://google.com" --duration 1m --debug --upstream_port 1.1.eth1
+            --ssid NETGEAR_5G_wpa2 --passwd Password@123 --encryp wpa2 --config
+
+            Example-5:
+            Command Line Interface to run the Real Browser Test with groups and profiles
+            python3 lf_interop_real_browser_test.py --mgr 192.168.204.74 --url "https://google.com" --duration 1m --debug --upstream_port 1.1.eth1
+            --file_name grplaptops --group_name group1,group2 --profile_name netgear2g,netgear2g
+
 
             SCRIPT CLASSIFICATION: Test
 
@@ -1996,26 +2013,27 @@ def main():
         parser.add_argument('--file_name', type=str, help='specify the file name')
         parser.add_argument('--group_name', type=str, help='specify the group name')
         parser.add_argument('--profile_name', type=str, help='specify the profile name')
-        parser.add_argument("--eap_method", type=str, default='DEFAULT')
-        parser.add_argument("--eap_identity", type=str, default='')
-        parser.add_argument("--ieee80211", action="store_true")
-        parser.add_argument("--ieee80211u", action="store_true")
-        parser.add_argument("--ieee80211w", type=int, default=1)
-        parser.add_argument("--enable_pkc", action="store_true")
-        parser.add_argument("--bss_transition", action="store_true")
-        parser.add_argument("--power_save", action="store_true")
-        parser.add_argument("--disable_ofdma", action="store_true")
-        parser.add_argument("--roam_ft_ds", action="store_true")
-        parser.add_argument("--key_management", type=str, default='DEFAULT')
-        parser.add_argument("--pairwise", type=str, default='[BLANK]')
-        parser.add_argument("--private_key", type=str, default='[BLANK]')
-        parser.add_argument("--ca_cert", type=str, default='[BLANK]')
-        parser.add_argument("--client_cert", type=str, default='[BLANK]')
-        parser.add_argument("--pk_passwd", type=str, default='[BLANK]')
-        parser.add_argument("--pac_file", type=str, default='[BLANK]')
+
+        parser.add_argument("--eap_method", type=str, default='DEFAULT', help="Specify the EAP method for authentication.")
+        parser.add_argument("--eap_identity", type=str, default='DEFAULT', help="Specify the EAP identity for authentication.")
+        parser.add_argument("--ieee80211", action="store_true", help='Enables IEEE 802.11 support.')
+        parser.add_argument("--ieee80211u", action="store_true", help='Enables IEEE 802.11u (Hotspot 2.0) support.')
+        parser.add_argument("--ieee80211w", type=int, default=1, help='Enables IEEE 802.11w (Management Frame Protection) support.')
+        parser.add_argument("--enable_pkc", action="store_true", help='Enables pkc support.')
+        parser.add_argument("--bss_transition", action="store_true", help='Enables BSS transition support.')
+        parser.add_argument("--power_save", action="store_true", help='Enables power-saving features.')
+        parser.add_argument("--disable_ofdma", action="store_true", help='Disables OFDMA support.')
+        parser.add_argument("--roam_ft_ds", action="store_true", help='Enables fast BSS transition (FT) support')
+        parser.add_argument("--key_management", type=str, default='DEFAULT', help='Specify the key management method (e.g., WPA-PSK, WPA-EAP)')
+        parser.add_argument("--pairwise", type=str, default='NA', help="Specify the pairwise cipher")
+        parser.add_argument("--private_key", type=str, default='NA', help='Specify EAP private key certificate file.')
+        parser.add_argument("--ca_cert", type=str, default='NA', help='Specify the CA certificate file name')
+        parser.add_argument("--client_cert", type=str, default='NA', help='Specify the client certificate file name')
+        parser.add_argument("--pk_passwd", type=str, default='NA', help='Specify the password for the private key')
+        parser.add_argument("--pac_file", type=str, default='NA', help='Specify the pac file name')
         parser.add_argument("--upstream_port", type=str, default='NA', help='Specify the Upstream Port', required=True)
         parser.add_argument('--help_summary', help='Show summary of what this script does', default=None)
-        parser.add_argument("--expected_passfail_value", help="Specify the expected urlcount value for pass/fail", default=5)
+        parser.add_argument("--expected_passfail_value", help="Specify the expected urlcount value for pass/fail")
         parser.add_argument("--device_csv_name", type=str, help="Specify the device csv name for pass/fail", default=None)
         parser.add_argument("--wait_time", type=int, help="Specify the time for configuration", default=60)
         parser.add_argument('--config', action='store_true', help='specify this flag whether to config devices or not')
@@ -2033,6 +2051,10 @@ def main():
         if args.lf_logger_config_json:
             logger_config.lf_logger_config_json = args.lf_logger_config_json
             logger_config.load_lf_logger_config()
+        if args.url.lower().startswith("www."):
+            args.url = "https://" + args.url
+        if args.url.lower().startswith("http://"):
+            args.url = "https://" + args.url.removeprefix("http://")
 
         # Initialize an instance of RealBrowserTest with various parameters
         obj = RealBrowserTest(host=args.host,
@@ -2134,14 +2156,15 @@ def main():
         logging.error("Error occured", e)
         traceback.print_exc()
     finally:
-        obj.create_report()
-        if (obj.dowebgui):
-            obj.webui_stop()
-        obj.stop()
-        
+        if not ('--help' in sys.argv or '-h' in sys.argv):
+            obj.create_report()
+            if (obj.dowebgui):
+                obj.webui_stop()
+            obj.stop()
+            
 
-        if args.postcleanup:
-            obj.postcleanup()
+            if args.postcleanup:
+                obj.postcleanup()
 
 
 if __name__ == '__main__':

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -25,15 +25,6 @@ Pre-requisites: Real clients should be connected to the LANforge MGR and Interop
                 CASE-1:
                 If not specified it takes the default count value (default count is 1)
 
-
-            Example-4:
-            Command Line Interface to run url in the Browser with precleanup:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --precleanup --debug --upstream_port 1.1.eth1
-
-            Example-5:
-            Command Line Interface to run url in the Browser with postcleanup:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --postcleanup --debug --upstream_port 1.1.eth1
-
             Example-4:
             Command Line Interface to run the Real Browser Test with Device Configuration
             python3 lf_interop_real_browser_test.py --mgr 192.168.204.74 --url "https://google.com" --duration 1m --debug --upstream_port 1.1.eth1
@@ -143,8 +134,8 @@ class RealBrowserTest(Realm):
                  result_dir="",
                  test_name=None,
                  incremental=None,
-                 postcleanup=False,
-                 precleanup=False,
+                 no_postcleanup=False,
+                 no_precleanup=False,
                  file_name=None,
                  group_name=None,
                  profile_name=None,
@@ -189,8 +180,8 @@ class RealBrowserTest(Realm):
         self.result_dir = result_dir
         self.test_name = test_name
         self.incremental = incremental
-        self.postCleanUp = postcleanup
-        self.preCleanUp = precleanup
+        self.no_postcleanup = no_postcleanup
+        self.no_precleanup = no_precleanup
         self.direction = "dl"
         self.dest = "/dev/null"
 
@@ -324,13 +315,13 @@ class RealBrowserTest(Realm):
         self.max_speed = self.max_speed
         self.requests_per_ten = 100
         self.created_cx = self.http_profile.created_cx = self.convert_to_dict(self.phone_data)
-        if self.preCleanUp:
+        if not self.no_precleanup:
             self.precleanup()
         self.http_profile.created_cx.clear()
 
         self.new_port_list = [item.split('.')[2] for item in self.laptops]
 
-        if (self.generic_endps_profile.create(ports=self.laptops, sleep_time=.5, real_client_os_types=self.laptop_os_types,)):
+        if self.generic_endps_profile.create(ports=self.laptops, sleep_time=.5, real_client_os_types=self.laptop_os_types,):
 
             logging.info('Real client generic endpoint creation completed.')
         else:
@@ -919,7 +910,7 @@ class RealBrowserTest(Realm):
             incremental_capacity_list_values = self.get_incremental_capacity_list()
             if incremental_capacity_list_values[-1] != len(available_resources):
                 logger.error("Incremental capacity doesn't match available devices")
-                if self.postCleanUp:
+                if not self.no_postcleanup:
                     self.postcleanup()
                 exit(1)
 
@@ -1153,7 +1144,7 @@ class RealBrowserTest(Realm):
             logging.info("There are no devices available which are selected")
             exit()
         device_map = {}
-        if (not self.expected_passfail_value) and (self.device_csv_name is None):
+        if not self.expected_passfail_value and self.device_csv_name is None:
             expected_val = input("Enter the expected value for the following devices {} eg 8,6,2: ".format(available_resources)).split(',')
             if len(available_resources) == len(expected_val):
                 for i in range(len(available_resources)):
@@ -1180,7 +1171,7 @@ class RealBrowserTest(Realm):
                 args.webgui_incremental = str(len(available_resources))
             incremental = [int(x) for x in args.webgui_incremental.split(',')]
             # Validate length and assign incremental values
-            if (len(args.webgui_incremental) == 1 and incremental[0] != len(resource_list_sorted)) or (len(args.webgui_incremental) > 1):
+            if len(args.webgui_incremental) == 1 and incremental[0] != len(resource_list_sorted) or len(args.webgui_incremental) > 1:
                 obj.incremental = incremental
             elif len(args.webgui_incremental) == 1:
                 obj.incremental = incremental
@@ -1873,7 +1864,7 @@ class RealBrowserTest(Realm):
                         device_type_data[i] = value["device type"]
 
         # Collect port data for each eid
-        logging.info(f"Checking final eid data {final_eid_data}")
+        # logging.info(f"Checking final eid data {final_eid_data}")
         for eid in final_eid_data:
             port_data = self.local_realm.json_get("port/list?fields=ssid,mac,parent dev,signal,tx-rate,channel,down,ip")
             for interface in port_data['interfaces']:
@@ -1881,7 +1872,7 @@ class RealBrowserTest(Realm):
                     temp_eid = key.split(".")
                     comb_eid = temp_eid[0] + "." + temp_eid[1]
                     if (comb_eid == eid) and (value["parent dev"] != "") and (not value["down"]) and (value["ip"] != "0.0.0.0"):
-                        logging.info("checking whether we are able to fetch device data from port manager")
+                        # logging.info("checking whether we are able to fetch device data from port manager")
                         mac_data.append(value.get("mac", 'None'))
                         channel_data.append(value.get("channel", 'None'))
                         signal_data.append(value.get("signal", 'None'))
@@ -1934,14 +1925,6 @@ def main():
                 CASE-1:
                 If not specified it takes the default count value (default count is 1)
 
-
-            Example-4:
-            Command Line Interface to run url in the Browser with precleanup:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --precleanup --debug --upstream_port 1.1.eth1
-
-            Example-5:
-            Command Line Interface to run url in the Browser with postcleanup:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --postcleanup --debug --upstream_port 1.1.eth1
 
             Example-4:
             Command Line Interface to run the Real Browser Test with Device Configuration
@@ -2003,8 +1986,8 @@ def main():
         parser.add_argument('--webgui_incremental', '--incremental_capacity', help="Specify the incremental values <1,2,3..>", dest='webgui_incremental', type=str)
         parser.add_argument('--incremental', help="to add incremental capacity to run the test", action='store_true')
         optional.add_argument('--no_laptops', help="run the test without laptop devices", action='store_false')
-        parser.add_argument('--postcleanup', help="Cleanup the cross connections after test is stopped", action='store_true')
-        parser.add_argument('--precleanup', help="Cleanup the cross connections before test is started", action='store_true')
+        parser.add_argument('--no_postcleanup', help="Do not Cleanup the cross connections after test is stopped", action='store_true')
+        parser.add_argument('--no_precleanup', help="Do not Cleanup the cross connections before test is started", action='store_true')
         parser.add_argument('--file_name', type=str, help='specify the file name')
         parser.add_argument('--group_name', type=str, help='specify the group name')
         parser.add_argument('--profile_name', type=str, help='specify the profile name')
@@ -2065,8 +2048,8 @@ def main():
                               result_dir=args.result_dir,
                               test_name=args.test_name,
                               incremental=args.incremental,
-                              postcleanup=args.postcleanup,
-                              precleanup=args.precleanup,
+                              no_postcleanup=args.no_postcleanup,
+                              no_precleanup=args.no_precleanup,
                               file_name=args.file_name,
                               group_name=args.group_name,
                               profile_name=args.profile_name,
@@ -2148,13 +2131,13 @@ def main():
         logging.error("Error occured", e)
         traceback.print_exc()
     finally:
-        if not ('--help' in sys.argv or '-h' in sys.argv):
+        if '--help' not in sys.argv and '-h' not in sys.argv:
             obj.create_report()
-            if (obj.dowebgui):
+            if obj.dowebgui:
                 obj.webui_stop()
             obj.stop()
 
-            if args.postcleanup:
+            if not args.no_postcleanup:
                 obj.postcleanup()
 
 

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -1502,66 +1502,25 @@ class RealBrowserTest(Realm):
 
         self.device_list = filtered_list
         return filtered_list
-
-    def create_report(self,):
-        if self.dowebgui:
-            report = lf_report(_output_pdf='Real_Browser_Report',
-                               _output_html='Real_Browser_Report.html',
-                               _results_dir_name="Real_Browser_Report",
-                               _path=self.result_dir)
-            self.report_path_date_time = report.get_path_date_time()
-        else:
-
-            report = lf_report(_output_pdf='Real_Browser_Report',
-                               _output_html='Real_Browser_Report.html',
-                               _results_dir_name="Real_Browser_Report",
-                               _path='')
-            self.report_path_date_time = report.get_path_date_time()
-
-        report.set_title("Web Browser Test")
-        report.build_banner()
-
-        report.set_table_title("Objective:")
-        report.build_table_title()
-        report.set_text("The Candela Web browser test is designed to measure the Access Point performance and stability by browsing multiple websites in real clients like android, Linux, windows" +
-                        "and IOS which are connected to the access point. This test allows the user to choose the options like website link," +
-                        "the number of times the page has to browse, and the Time taken to browse the page." +
-                        "The expected behavior is for the AP to be able to handle several stations(within the limitations of the AP specs) and make sure all clients can browse the page.")
-        report.build_text_simple()
-
-        report.set_table_title("Test Parameters:")
-        report.build_table_title()
-
-        final_eid_data = []
-        mac_data = []
-        channel_data = []
-        signal_data = []
-        ssid_data = []
-        tx_rate_data = []
-        device_type_data = []
-        device_names = []
-        total_urls = []
-        time_to_target_urls = []
-        uc_min_data = []
-        uc_max_data = []
-        uc_avg_data = []
-        total_err_data = []
-
-        final_eid_data, mac_data, channel_data, signal_data, ssid_data, tx_rate_data, device_names, device_type_data = self.extract_device_data('real_time_data.csv')
-
+    
+    def generate_test_setup_info(self):
+        """
+        Generate a dictionary containing the test setup information
+        based on the configuration mode or selected group/profile mapping.
+        
+        Returns:
+            dict: Test setup information.
+        """
         if self.config:
-
-            # Test setup info
             test_setup_info = {
                 'Configured Devies': self.hostname_os_combination,
                 'No of Clients': f'W({self.windows}),L({self.linux}),M({self.mac}), A({self.android})',
-                'Incremental Values': self.test_setup_info_incremental_values,
+                # 'Incremental Values': self.test_setup_info_incremental_values,
                 'Required URL Count': self.count,
                 'URL': self.url,
                 'Test Duration (min)': self.duration,
                 'SSID': self.report_ssid,
                 "Security": self.encryp
-
             }
         elif len(self.selected_groups) > 0 and len(self.selected_profiles) > 0:
             # Map each group with a profile
@@ -1570,150 +1529,46 @@ class RealBrowserTest(Realm):
             # Create a string by joining the mapped pairs
             gp_map = ", ".join(f"{group} -> {profile}" for group, profile in gp_pairs)
 
-            # Test setup info
             test_setup_info = {
                 'Configuration': gp_map,
                 'Configured Devies': self.hostname_os_combination,
                 'No of Clients': f'W({self.windows}),L({self.linux}),M({self.mac}), A({self.android})',
-                'Incremental Values': self.test_setup_info_incremental_values,
+                # 'Incremental Values': self.test_setup_info_incremental_values,
                 'Required URL Count': self.count,
                 'URL': self.url,
                 'Test Duration (min)': self.duration,
-
             }
         else:
-            # Test setup info
             test_setup_info = {
-
                 'Configured Devies': self.hostname_os_combination,
                 'No of Clients': f'W({self.windows}),L({self.linux}),M({self.mac}), A({self.android})',
-                'Incremental Values': self.test_setup_info_incremental_values,
+                # 'Incremental Values': self.test_setup_info_incremental_values,
                 'Required URL Count': self.count,
                 'URL': self.url,
                 'Test Duration (min)': self.duration,
-
             }
+        
+        return test_setup_info
+    
+    def generate_pass_fail_list(self, device_type_data, device_names, total_urls):
+        """
+        Generate the pass/fail list and expected URL count list for the devices.
 
-        report.test_setup_table(
-            test_setup_data=test_setup_info, value='Test Parameters')
+        Args:
+            device_type_data (list): List of device types (e.g., Android, Windows).
+            device_names (list): List of device names.
+            total_urls (list): List of total URLs accessed by each device.
 
-        for i in range(0, len(self.csv_file_names)):
+        Returns:
+            tuple: (pass_fail_list, test_input_list)
+        """
+        pass_fail_list = []
+        test_input_list = []
 
-            final_eid_data, mac_data, channel_data, signal_data, ssid_data, tx_rate_data, device_names, device_type_data = self.extract_device_data(self.csv_file_names[i])
-            report.set_graph_title(f"Iteration {i + 1} Successful URL's per Device")
-            report.build_graph_title()
-
-            data = pd.read_csv(self.csv_file_names[i])
-
-            # Extract device names from CSV
-            if 'total_urls' in data.columns:
-                total_urls = data['total_urls'].tolist()
-            else:
-                raise ValueError("The 'total_urls' column was not found in the CSV file.")
-
-            x_fig_size = 18
-            y_fig_size = len(device_type_data) * 1 + 4
-            bar_graph_horizontal = lf_bar_graph_horizontal(
-                _data_set=[total_urls],
-                _xaxis_name="URL",
-                _yaxis_name="Devices",
-                _yaxis_label=device_names,
-                _yaxis_categories=device_names,
-                _yaxis_step=1,
-                _yticks_font=8,
-                _bar_height=.20,
-                _show_bar_value=True,
-                _figsize=(x_fig_size, y_fig_size),
-                _graph_title="URLs",
-                _graph_image_name=f"{self.csv_file_names[i]}_urls_per_device",
-                _label=["URLs"]
-            )
-            graph_image = bar_graph_horizontal.build_bar_graph_horizontal()
-            report.set_graph_image(graph_image)
-            report.move_graph_image()
-            report.build_graph()
-
-            report.set_graph_title(f"Iteration {i + 1} - Time Taken Vs Device For Completing {self.count} RealTime URLs")
-            report.build_graph_title()
-
-            # Extract device names from CSV
-            if 'time_to_target_urls' in data.columns:
-                time_to_target_urls = data['time_to_target_urls'].tolist()
-            else:
-                raise ValueError("The 'time_to_target_urls' column was not found in the CSV file.")
-
-            x_fig_size = 18
-            y_fig_size = len(device_type_data) * 1 + 4
-            bar_graph_horizontal = lf_bar_graph_horizontal(
-                _data_set=[time_to_target_urls],
-                _xaxis_name="Time (in Seconds)",
-                _yaxis_name="Devices",
-                _yaxis_label=device_names,
-                _yaxis_categories=device_names,
-                _yaxis_step=1,
-                _yticks_font=8,
-                _bar_height=.20,
-                _show_bar_value=True,
-                _figsize=(x_fig_size, y_fig_size),
-                _graph_title="Time Taken",
-                _graph_image_name=f"{self.csv_file_names[i]}_time_taken_for_urls",
-                _label=["Time (in sec)"]
-            )
-            graph_image = bar_graph_horizontal.build_bar_graph_horizontal()
-            report.set_graph_image(graph_image)
-            report.move_graph_image()
-            report.build_graph()
-
-            report.set_table_title(f"Detailed Result Table - Iteration {i + 1}")
-            report.build_table_title()
-
-            if 'uc_min' in data.columns:
-                uc_min_data = data['uc_min'].tolist()
-            else:
-                raise ValueError("The 'uc_min' column was not found in the CSV file.")
-
-            if 'uc_max' in data.columns:
-                uc_max_data = data['uc_max'].tolist()
-            else:
-                raise ValueError("The 'uc_max' column was not found in the CSV file.")
-
-            if 'uc_avg' in data.columns:
-                uc_avg_data = data['uc_avg'].tolist()
-            else:
-                raise ValueError("The 'uc_avg' column was not found in the CSV file.")
-
-            if 'total_err' in data.columns:
-                total_err_data = data['total_err'].tolist()
-            else:
-                raise ValueError("The 'total_err' column was not found in the CSV file.")
-
-            test_results = {
-
-                "Device Type": device_type_data,
-                "Hostname": device_names,
-                "SSID": ssid_data,
-                "MAC": mac_data,
-                "Channel": channel_data,
-                "UC-MIN (ms)": uc_min_data,
-                "UC-MAX (ms)": uc_max_data,
-                "UC-AVG (ms)": uc_avg_data,
-                "Total Successful URLs": total_urls,
-                "Total Erros": total_err_data,
-                "RSSI": signal_data,
-                "Link Speed": tx_rate_data
-
-            }
-            test_results_df = pd.DataFrame(test_results)
-            report.set_table_dataframe(test_results_df)
-            report.build_table()
-
-        report.set_table_title("Final Test Results")
-        report.build_table_title()
         if not self.expected_passfail_value:
             res_list = []
-            test_input_list = []
-            pass_fail_list = []
             interop_tab_data = self.json_get('/adb/')["devices"]
+
             for i in range(len(device_type_data)):
                 if device_type_data[i] != 'Android':
                     res_list.append(device_names[i])
@@ -1723,85 +1578,250 @@ class RealBrowserTest(Realm):
                             if item['user-name'] in device_names:
                                 name_to_append = item['name'].split('.')[2]
                                 if name_to_append not in res_list:
-                                    res_list.append(item['name'].split('.')[2])
+                                    res_list.append(name_to_append)
 
             if self.dowebgui:
                 os.chdir(self.original_dir)
 
             if self.device_csv_name is None:
                 self.device_csv_name = "device.csv"
-            with open(self.device_csv_name, mode='r') as file:
+
+            file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../", self.device_csv_name))
+            with open(file_path, mode='r') as file:
                 reader = csv.DictReader(file)
                 rows = list(reader)
 
-            for row in rows:
-                device = row['DeviceList']
-                if device in res_list:
-                    test_input_list.append(row['RealBrowser URLcount'])
-            for j in range(len(test_input_list)):
-                if float(test_input_list[j]) <= float(total_urls[j]):
-                    pass_fail_list.append('PASS')
+            for device in res_list:
+                found = False
+                for row in rows:
+                    if row['DeviceList'] == device and row['RealBrowser URLcount'].strip() != '':
+                        test_input_list.append(row['RealBrowser URLcount'])
+                        found = True
+                        break
+                if not found:
+                    logging.info(f"Pass Fail Value for Device {device} not found in CSV. Using default value 5")
+                    test_input_list.append(5)  # Default value
+
+            if self.dowebgui:
+                os.chdir(self.result_dir)
+
+        else:
+            test_input_list = [self.expected_passfail_value for _ in range(len(device_type_data))]
+
+        for j in range(len(test_input_list)):
+            if float(test_input_list[j]) <= float(total_urls[j]):
+                pass_fail_list.append('PASS')
+            else:
+                pass_fail_list.append('FAIL')
+
+        return pass_fail_list, test_input_list
+
+    def create_report(self):
+        try:
+            if self.dowebgui:
+                report = lf_report(_output_pdf='Real_Browser_Report',
+                                   _output_html='Real_Browser_Report.html',
+                                   _results_dir_name="Real_Browser_Report",
+                                   _path=self.result_dir)
+                self.report_path_date_time = report.get_path_date_time()
+            else:
+
+                report = lf_report(_output_pdf='Real_Browser_Report',
+                                   _output_html='Real_Browser_Report.html',
+                                   _results_dir_name="Real_Browser_Report",
+                                   _path='')
+                self.report_path_date_time = report.get_path_date_time()
+
+            report.set_title("Web Browser Test")
+            report.build_banner()
+
+            report.set_table_title("Objective:")
+            report.build_table_title()
+            report.set_text("The Candela Web browser test is designed to measure the Access Point performance and stability by browsing multiple websites in real clients" +
+                            " like android, Linux, windows" +
+                            "and IOS which are connected to the access point. This test allows the user to choose the options like website link," +
+                            "the number of times the page has to browse, and the Time taken to browse the page." +
+                            "The expected behavior is for the AP to be able to handle several stations(within the limitations of the AP specs) and make sure all clients can browse the page.")
+            report.build_text_simple()
+
+            report.set_table_title("Test Parameters:")
+            report.build_table_title()
+
+            final_eid_data = []
+            mac_data = []
+            channel_data = []
+            signal_data = []
+            ssid_data = []
+            tx_rate_data = []
+            device_type_data = []
+            device_names = []
+            total_urls = []
+            time_to_target_urls = []
+            uc_min_data = []
+            uc_max_data = []
+            uc_avg_data = []
+            total_err_data = []
+
+            final_eid_data, mac_data, channel_data, signal_data, ssid_data, tx_rate_data, device_names, device_type_data = self.extract_device_data('real_time_data.csv')
+
+            test_setup_info = self.generate_test_setup_info()
+            report.test_setup_table(
+                test_setup_data=test_setup_info, value='Test Parameters')
+
+            for i in range(0, len(self.csv_file_names)):
+
+                final_eid_data, mac_data, channel_data, signal_data, ssid_data, tx_rate_data, device_names, device_type_data = self.extract_device_data(self.csv_file_names[i])
+                report.set_graph_title("Successful URL's per Device")
+                report.build_graph_title()
+
+                data = pd.read_csv(self.csv_file_names[i])
+
+                # Extract device names from CSV
+                if 'total_urls' in data.columns:
+                    total_urls = data['total_urls'].tolist()
                 else:
-                    pass_fail_list.append('FAIL')
+                    raise ValueError("The 'total_urls' column was not found in the CSV file.")
+
+                x_fig_size = 18
+                y_fig_size = len(device_type_data) * 1 + 4
+                bar_graph_horizontal = lf_bar_graph_horizontal(
+                    _data_set=[total_urls],
+                    _xaxis_name="URL",
+                    _yaxis_name="Devices",
+                    _yaxis_label=device_names,
+                    _yaxis_categories=device_names,
+                    _yaxis_step=1,
+                    _yticks_font=8,
+                    _bar_height=.20,
+                    _show_bar_value=True,
+                    _figsize=(x_fig_size, y_fig_size),
+                    _graph_title="URLs",
+                    _graph_image_name=f"{self.csv_file_names[i]}_urls_per_device",
+                    _label=["URLs"]
+                )
+                graph_image = bar_graph_horizontal.build_bar_graph_horizontal()
+                report.set_graph_image(graph_image)
+                report.move_graph_image()
+                report.build_graph()
+
+                report.set_graph_title(f"Time Taken Vs Device For Completing {self.count} RealTime URLs")
+                report.build_graph_title()
+
+                # Extract device names from CSV
+                if 'time_to_target_urls' in data.columns:
+                    time_to_target_urls = data['time_to_target_urls'].tolist()
+                else:
+                    raise ValueError("The 'time_to_target_urls' column was not found in the CSV file.")
+
+                x_fig_size = 18
+                y_fig_size = len(device_type_data) * 1 + 4
+                bar_graph_horizontal = lf_bar_graph_horizontal(
+                    _data_set=[time_to_target_urls],
+                    _xaxis_name="Time (in Seconds)",
+                    _yaxis_name="Devices",
+                    _yaxis_label=device_names,
+                    _yaxis_categories=device_names,
+                    _yaxis_step=1,
+                    _yticks_font=8,
+                    _bar_height=.20,
+                    _show_bar_value=True,
+                    _figsize=(x_fig_size, y_fig_size),
+                    _graph_title="Time Taken",
+                    _graph_image_name=f"{self.csv_file_names[i]}_time_taken_for_urls",
+                    _label=["Time (in sec)"]
+                )
+                graph_image = bar_graph_horizontal.build_bar_graph_horizontal()
+                report.set_graph_image(graph_image)
+                report.move_graph_image()
+                report.build_graph()
+
+                if 'uc_min' in data.columns:
+                    uc_min_data = data['uc_min'].tolist()
+                else:
+                    raise ValueError("The 'uc_min' column was not found in the CSV file.")
+
+                if 'uc_max' in data.columns:
+                    uc_max_data = data['uc_max'].tolist()
+                else:
+                    raise ValueError("The 'uc_max' column was not found in the CSV file.")
+
+                if 'uc_avg' in data.columns:
+                    uc_avg_data = data['uc_avg'].tolist()
+                else:
+                    raise ValueError("The 'uc_avg' column was not found in the CSV file.")
+
+                if 'total_err' in data.columns:
+                    total_err_data = data['total_err'].tolist()
+                else:
+                    raise ValueError("The 'total_err' column was not found in the CSV file.")
+
+            report.set_table_title("Final Test Results")
+            report.build_table_title()
+            if self.expected_passfail_value or self.device_csv_name:
+                pass_fail_list, test_input_list = self.generate_pass_fail_list(device_type_data, device_names, total_urls)
+                
+                final_test_results = {
+
+                    "Device Type": device_type_data,
+                    "Hostname": device_names,
+                    "SSID": ssid_data,
+                    "MAC": mac_data,
+                    "Channel": channel_data,
+                    "UC-MIN (ms)": uc_min_data,
+                    "UC-MAX (ms)": uc_max_data,
+                    "UC-AVG (ms)": uc_avg_data,
+                    "Total Successful URLs": total_urls,
+                    "Expected URLS": test_input_list,
+                    "Total Erros": total_err_data,
+                    "RSSI": signal_data,
+                    "Link Speed": tx_rate_data,
+                    "Status ": pass_fail_list
+
+                }
+            else:
+                final_test_results = {
+
+                    "Device Type": device_type_data,
+                    "Hostname": device_names,
+                    "SSID": ssid_data,
+                    "MAC": mac_data,
+                    "Channel": channel_data,
+                    "UC-MIN (ms)": uc_min_data,
+                    "UC-MAX (ms)": uc_max_data,
+                    "UC-AVG (ms)": uc_avg_data,
+                    "Total Successful URLs": total_urls,
+                    "Total Erros": total_err_data,
+                    "RSSI": signal_data,
+                    "Link Speed": tx_rate_data,
+
+                }
+            test_results_df = pd.DataFrame(final_test_results)
+            report.set_table_dataframe(test_results_df)
+            report.build_table()
+
             if self.dowebgui:
 
-                os.chdir(self.result_dir)
-        else:
-            test_input_list = [self.expected_passfail_value for val in range(len(device_type_data))]
-            pass_fail_list = []
-            for j in range(len(test_input_list)):
-                if float(self.expected_passfail_value) <= float(total_urls[j]):
-                    pass_fail_list.append("PASS")
-                else:
-                    pass_fail_list.append("FAIL")
+                os.chdir(self.original_dir)
 
-        final_test_results = {
-
-            "Device Type": device_type_data,
-            "Hostname": device_names,
-            "SSID": ssid_data,
-            "MAC": mac_data,
-            "Channel": channel_data,
-            "UC-MIN (ms)": uc_min_data,
-            "UC-MAX (ms)": uc_max_data,
-            "UC-AVG (ms)": uc_avg_data,
-            "Total Successful URLs": total_urls,
-            "Expected URLS": test_input_list,
-            "Total Erros": total_err_data,
-            "RSSI": signal_data,
-            "Link Speed": tx_rate_data,
-            "Status ": pass_fail_list
-
-        }
-        test_results_df = pd.DataFrame(final_test_results)
-        report.set_table_dataframe(test_results_df)
-        report.build_table()
-
-        if self.dowebgui:
-
-            os.chdir(self.original_dir)
-
-        report.build_custom()
-        report.build_footer()
-        report.write_html()
-        report.write_pdf()
-
-        if not self.dowebgui:
-            source_dir = "."
-            destination_dir = self.report_path_date_time
-
-            # Stop the test execution
-            self.csv_file_names.append('real_time_data.csv')
-
-            for filename in self.csv_file_names:
-                source_path = os.path.join(source_dir, filename)
-                destination_path = os.path.join(destination_dir, filename)
-
-                if os.path.isfile(source_path):
-                    shutil.move(source_path, destination_path)
-                    logging.info(f"Moved {filename} to {destination_dir}")
-                else:
-                    logging.info(f"{filename} not found in the current directory")
+            report.build_custom()
+            report.build_footer()
+            report.write_html()
+            report.write_pdf()
+        except Exception as e:
+            logging.error(f"Error in create_report function {e}", exc_info=True)
+        finally:
+            if not self.dowebgui:
+                source_dir = "."
+                destination_dir = self.report_path_date_time
+                self.csv_file_names.append('real_time_data.csv')
+                for filename in self.csv_file_names:
+                    source_path = os.path.join(source_dir, filename)
+                    destination_path = os.path.join(destination_dir, filename)
+                    if os.path.isfile(source_path):
+                        shutil.move(source_path, destination_path)
+                        logging.info(f"Moved {filename} to {destination_dir}")
+                    else:
+                        logging.info(f"{filename} not found in the current directory")
 
     def extract_device_data(self, file_path):
         # Load the CSV file

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -148,10 +148,10 @@ class RealBrowserTest(Realm):
                  client_cert=None,
                  pk_passwd=None,
                  pac_file=None,
-                 server_ip=None, device_csv_name=None,
+                 upstream_port=None,
+                 device_csv_name=None,
                  expected_passfail_value=None,
                  wait_time=60,
-                 flask_ip=None,
                  config=None,
                  selected_groups=None,
                  selected_profiles=None):
@@ -236,11 +236,10 @@ class RealBrowserTest(Realm):
         self.client_cert = client_cert
         self.pk_passwd = pk_passwd
         self.pac_file = pac_file
-        self.server_ip = server_ip
+        self.upstream_port = upstream_port
         self.expected_passfail_value = expected_passfail_value
         self.device_csv_name = device_csv_name
         self.wait_time = wait_time
-        self.flask_ip = flask_ip
         self.config = config
         self.selected_groups = selected_groups
         self.selected_profiles = selected_profiles
@@ -322,13 +321,13 @@ class RealBrowserTest(Realm):
 
         for i in range(0, len(self.laptop_os_types)):
             if self.laptop_os_types[i] == 'windows':
-                cmd = "real_browser.bat --url %s --server %s --duration %s" % (self.url, self.flask_ip, self.duration)
+                cmd = "real_browser.bat --url %s --server %s --duration %s" % (self.url, self.upstream_port, self.duration)
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
             elif self.laptop_os_types[i] == 'linux':
-                cmd = "su -l lanforge  ctrb.bash %s %s %s %s" % (self.new_port_list[i], self.url, self.flask_ip, self.duration)
+                cmd = "su -l lanforge  ctrb.bash %s %s %s %s" % (self.new_port_list[i], self.url, self.upstream_port, self.duration)
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
             elif self.laptop_os_types[i] == 'macos':
-                cmd = "sudo bash ctrb.bash --url %s --server %s  --duration %s" % (self.url, self.flask_ip, self.duration)
+                cmd = "sudo bash ctrb.bash --url %s --server %s  --duration %s" % (self.url, self.upstream_port, self.duration)
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
 
         if len(self.phone_data) != 0:
@@ -1549,8 +1548,7 @@ def main():
         parser.add_argument("--client_cert", type=str, default='[BLANK]')
         parser.add_argument("--pk_passwd", type=str, default='[BLANK]')
         parser.add_argument("--pac_file", type=str, default='[BLANK]')
-        parser.add_argument("--server_ip", type=str, default=None)
-        parser.add_argument("--flask_ip", type=str, default=None)
+        parser.add_argument("--upstream_port", type=str, default='NA', help='Specify the Upstream Port', required=True)
         parser.add_argument('--help_summary', help='Show summary of what this script does', default=None)
         parser.add_argument("--expected_passfail_value", help="Specify the expected urlcount value for pass/fail", default=5)
         parser.add_argument("--device_csv_name", type=str, help="Specify the device csv name for pass/fail", default=None)
@@ -1666,11 +1664,10 @@ def main():
                                   client_cert=args.client_cert,
                                   pk_passwd=args.pk_passwd,
                                   pac_file=args.pac_file,
-                                  server_ip=args.server_ip,
+                                  upstream_port=args.upstream_port,
                                   expected_passfail_value=args.expected_passfail_value,
                                   device_csv_name=args.device_csv_name,
                                   wait_time=args.wait_time,
-                                  flask_ip=args.flask_ip,
                                   config=args.config,
                                   selected_groups=selected_groups,
                                   selected_profiles=selected_profiles


### PR DESCRIPTION
lf_interop_real_browser_test.py: refactor upstream port usage, enhance iOS filtering
    - Replaced flask IP and server IP with upstream_port  for consistent test parameters
    - Added health check route  and wait_for_flask() to ensure Flask server readiness
    - Implement webui_stop() to update the test completion status on the web UI.
    - Implemented  change_port_to_ip() to resolve port names to IPs
    - Implemented filter_ios_devices() to skip iOS devices during test

    Verified CLI:
    python3 lf_interop_real_browser_test.py --mgr 192.168.204.74 --url https://google.com --duration 1m --debug --upstream_port 1.1.eth1 --ssid NETGEAR_5G_wpa2 --passwd Password@123 --encryp wpa2 --config