### PR TITLE
Add GitHub Actions-based Help Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,28 @@ jobs:
         uses: py-actions/flake8@v2
         #with:
         #  plugins: "flake8-bugbear"
+
+  help-check:
+    # Tie runner to Ubuntu 22.04 LTS, as it still supports Python 3.7
+    # Minimum Python version on Ubuntu 24.04 LTS is Python 3.9.
+    runs-on: ubuntu-22.04
+    name: Help Check
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v4
+
+      # Cached for subsequent steps, see:
+      # https://github.com/actions/setup-python#caching-packages-dependencies
+      - name: Set up Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.7"
+          cache: "pip"
+
+      - name: Install all py-scripts dependencies
+        run: python py-scripts/update_dependencies.py
+
+      - name: Run help check
+        run: |
+          cd py-scripts
+          bash lf_help_check.bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Run help check
         run: |
           cd py-scripts
-          bash lf_help_check.bash
+          python tools/lf_help_check.py

--- a/py-scripts/lf_help_check.bash
+++ b/py-scripts/lf_help_check.bash
@@ -1,8 +1,21 @@
 #!/bin/bash
 
+ANY_FAILED=0
 FILES=`ls *.py`
 for FILE in $FILES
 do
 	echo $FILE
-	(timeout 10 env DISPLAY=:1 python3 ./${FILE} --help > /dev/null  && echo PASSED) || echo "ERROR: FAILED ${FILE}"
+	timeout 10 env DISPLAY=:1 python3 ./${FILE} --help > /dev/null
+	if [[ $? -eq 0 ]]; then
+		echo "PASSED"
+	else
+		echo "ERROR: FAILED ${FILE}"
+		ANY_FAILED=1
+	fi
 done
+
+if [[ $ANY_FAILED -eq 1 ]]; then
+	exit 1
+else
+	exit 0
+fi

--- a/py-scripts/tools/lf_help_check.py
+++ b/py-scripts/tools/lf_help_check.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+This script is designed to perform a simple "help check" on all
+Python scripts located in the 'py-scripts/' directory.
+
+A "help check" primarily serves as an indicator for larger issues.
+It is not meant to replace proper testing.
+"""
+import argparse
+import logging
+import os
+import subprocess
+from time import sleep, time
+
+THIS_SCRIPT_NAME = os.path.basename(__file__)
+
+
+def parse_args():
+    """Configure and perform argument parsing for help check script"""
+    parser = argparse.ArgumentParser(
+        description="Help check script for LANforge Python scripts in "
+                    "the \'py-scripts\' directory of the LANforge "
+                    "scripts repository"
+    )
+    parser.add_argument(
+        "--parallelism",
+        dest="group_size",
+        help="Number of scripts to invoke in parallel",
+        type=int,
+        default=10,
+    )
+    parser.add_argument("--debug", help="Enable verbose logging", action="store_true")
+    return parser.parse_args()
+
+
+def configure_logging(debug: bool = False):
+    """Configure logging for the help check script"""
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s: %(message)s"
+    )
+
+    # Configure this modules' logger
+    global logger
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    # If debugging specified, then increase logging verbosity
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
+
+def main(scripts: list, group_size: int, **kwargs):
+    """
+    Run help parallelized help check on provided scripts
+
+    :param scripts: List of scripts to run help check
+    :param group_size: Maximum number of scripts to group together
+                       for parallelized help checks
+    :return int, list: Integer representing pass or fail (0 or 1),
+                       list of failed scripts (if any)
+    :rtype tuple:
+    """
+    script_groups = generate_script_groups(scripts, group_size)
+    script_data = run_checks(script_groups)
+
+    failed_scripts = []
+    for script, data in script_data.items():
+        if data["timed_out"] or data["return_code"] != 0:
+            failed_scripts.append(script)
+            logger.error(f"Script \'{script}\' failed")
+            logger.error(f"Script \'{script}\' stdout:\n{data['stdout']}")
+            logger.error(f"Script \'{script}\' stderr:\n{data['stderr']}")
+
+    if len(failed_scripts) == 0:
+        return 0, None
+    else:
+        return 1, failed_scripts
+
+
+def desired_script(file):
+    """
+    Filtering function to match only desired scripts.
+
+    Mainly serves to check that the script is a Python file
+    and is not the help check script (don't want to start a
+    recursion doom loop).
+
+    :param file: Script to check
+    :return bool: Keep script if true, otherwise ignore
+    :rtype bool:
+    """
+
+    if not os.path.isfile(file):
+        return False
+    elif not file.endswith(".py"):
+        return False
+    elif file == THIS_SCRIPT_NAME:
+        return False
+
+    return True
+
+
+def generate_script_groups(scripts: list,
+                           group_size: int) -> list:
+    """
+    Separate scripts into groups to run in parallel
+
+    :param scripts: List of scripts to segment based on group size
+    :param group_size: Maximum number of scripts to group together
+                       for parallelized help checks
+    :return script_groups: List of list of strings where each sub-list
+                           contains a list of scripts to check in parallel
+    :rtype list:
+    """
+    num_pyscripts = len(scripts)
+    script_groups = []
+
+    # Call to 'int()' will floor (round down) the resulting value
+    for ix in range(int(num_pyscripts / group_size)):
+        lower_ix = ix * group_size
+        upper_ix = (ix + 1) * group_size
+        script_groups.append(scripts[lower_ix:upper_ix])
+
+    # Group any remaining scripts into final group
+    num_remain_scripts = num_pyscripts % group_size
+    if num_remain_scripts != 0:
+        script_groups.append(scripts[-num_remain_scripts:])
+
+    return script_groups
+
+
+def run_checks(script_groups: list):
+    """
+    Run help checks on segmented script groups, returning post-check
+    status after completion.
+
+    :param script_groups: List of list of strings where each sub-list
+                          contains a list of scripts to check in parallel
+    :return: Dictionary containing script help check data, where the script
+             name is the key and the following data are the values:
+             'timed_out', 'return_code', 'stdout', 'stderr'
+    :rtype dict:
+    """
+    # Start checks in parallel, indicating success/failure
+    # based on return code and if script timed out
+    all_start_time = time()
+
+    script_data = {script: None for script in scripts}
+    for group in script_groups:
+        group_start_time = time()
+
+        # Start scripts in parallel
+        logger.debug(f"Running check for script group: {group}")
+        script_procs = {}
+        for script in group:
+            # Start the script in the background, ignoring any output
+            # and only checking the return code when complete
+            proc = subprocess.Popen(
+                ["python3", script, "--help"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            script_procs[script] = proc
+
+        # Wait up to timeout seconds, checking all scripts for completion periodically
+        wait_ms = 100
+        num_iters = (1_000 * 10) // wait_ms
+        for _ in range(num_iters):
+            sleep(wait_ms / 1_000)
+
+            iter_script_procs = script_procs.copy()
+            for script, proc in iter_script_procs.items():
+                # Poll to see if complete. If not, will return None
+                ret = proc.poll()
+                if ret is not None:
+                    # Remove script from tracking dict for active scripts
+                    del script_procs[script]
+
+                    stdout, stderr = proc.communicate()
+                    script_data[script] = {
+                        "timed_out": False,
+                        "return_code": proc.returncode,
+                        "stdout": stdout.decode('utf-8'),
+                        "stderr": stderr.decode('utf-8'),
+                    }
+
+            # Check if all scripts complete
+            if len(script_procs) == 0:
+                break
+
+        # Any remaining scripts in 'scripts_proc' dictionary timed out
+        # All others were removed when they completed in above check
+        for script, proc in script_procs.items():
+            # Kill process and save stderr
+            # Need to convert data from byte array
+            proc.kill()
+            stdout, stderr = proc.communicate()
+
+            script_data[script] = {
+                "timed_out": True,
+                "return_code": proc.returncode,
+                "stdout": stdout.decode("UTF-8"),
+                "stderr": stderr.decode("UTF-8"),
+            }
+
+        group_elapsed_time = time() - group_start_time
+        logger.debug(
+            f"Script group checks took {group_elapsed_time:.2f} seconds to complete"
+        )
+
+    all_elapsed_time = time() - all_start_time
+    logger.debug(
+        f"All script checks took {all_elapsed_time:.2f} seconds to complete"
+    )
+
+    return script_data
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    configure_logging(debug=args.debug)
+    logger.info("Running LANforge scripts \'py-scripts\' parallelized help checks")
+
+    # Scripts need to run w/ CWD set to 'py-scripts/'
+    cwd = os.getcwd()
+    if os.path.basename(cwd) != "py-scripts":
+        logger.error("This script must be run from the 'py-scripts' directory")
+        exit(2)
+
+    # Gather all Python scripts
+    scripts = [file for file in os.listdir(".") if desired_script(file)]
+    logger.debug(f"Running help check on the following scripts: {scripts}")
+
+    # Run parallelized help checks
+    ret, failed_scripts = main(scripts=scripts, **vars(args))
+
+    # Summarize checks and exit
+    if ret == 0:
+        logger.info("All scripts passed help check")
+    else:
+        logger.error(f"The following scripts failed help check: {failed_scripts}")
+    exit(ret)


### PR DESCRIPTION
In line with performing more sanity checks using available GitHub Actions-based automation, this patch series implements a new GitHub Actions-based help check using a new Python help check script.

This PR updates the existing CI action to run the help check in parallel with the existing linting check, minimizing delay in action results. Additionally, the new Python script is designed to run help checks in parallel, speeding up the process and reducing the number of GitHub runner minutes utilized. Additional fixes are added to the existing Bash help check script to exit on failure if any of the scripts fail, rather than only logging the failures.

I intend to update the Python script to support checking help summaries as well, but I have not yet implemented that.