### PR TITLE
Address linting failures flagged by flake8-bugbear

### DIFF
--- a/py-scripts/lf_cleanup.py
+++ b/py-scripts/lf_cleanup.py
@@ -1,66 +1,68 @@
 #!/usr/bin/env python3
-"""
-NAME: lf_cleanup.py
+r"""
+NAME:       lf_cleanup.py
 
-PURPOSE:
-    clean up stations, cross connects and endpoints
+PURPOSE:    Remove present test configuration, resetting system(s) to a reproducible base state.
 
 EXAMPLE:
-    clear all stations:
-        ./lf_cleanup.py --mgr localhost --resource 1 --sta
+            # Remove all stations with CLI
+            ./lf_cleanup.py --sta
 
-    This example will clean the Port Mgr, Layer-3, L3 Endps, and Layer 4-7 LF GUI tabs:
-        ./lf_cleanup.py --mgr localhost --resource 1 --sanitize
+            # Remove all stations with CLI for a specific resource
+            ./lf_cleanup.py --sta --resource 2
 
-    clear all cxs and enps:
-        ./lf_cleanup.py --mgr localhost --resource 1 --cxs
+            # Full cleanup (ports, L3 CXs/endpoints, L4-7 endpoints with CLI
+            ./lf_cleanup.py --sanitize
 
-    clear all endps:
-        ./lf_cleanup.py --mgr localhost --resource 1 --endp
+            # Remove all CXs and endpoints with CLI
+            ./lf_cleanup.py --cxs
 
-    clear all bridges:
-        ./lf_cleanup.py --mgr localhost --resource 1 --br
+            # Remove all endpoints with CLI
+            ./lf_cleanup.py --endp
 
-    clear sta with names phy (not wiphy) and 1.1.eth stations:
-        ./lf_cleanup.py --mgr localhost --resource 1 --misc
+            # Remove all bridge with CLI
+            ./lf_cleanup.py --br
 
-JSON EXAMPLE:
-    clear all stations:
-        "args": ["--mgr","192.168.30.12","--resource","1","--sta"]
+            # Remove all STAs with unexpected names with CLI (often from misuse of or bugs in automation)
+            # This includes names 'phy' (not 'wiphy') and '1.1.eth'
+            ./lf_cleanup.py --misc
 
-    This example will clean the Port Mgr, Layer-3, L3 Endps, and Layer 4-7 LF GUI tabs:
-        "args": ["--mgr","192.168.30.12","--resource","1","--sanitize"]
+            # Remove all stations with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--sta"]
 
-    clear all cxs and enps:
-        "args": ["--mgr","192.168.30.12","--resource","1","--cxs"]
+            # Full cleanup (ports, L3 CXs/endpoints, L4-7 endpoints with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--sanitize"]
 
-    clear all endps:
-        "args": ["--mgr","192.168.30.12","--resource","1","--endp"]
+            # Remove all CXs and endpoints with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--cxs"]
 
-    clear all bridges:
-        "args": ["--mgr","192.168.30.12","--resource","1","--br"]
+            # Remove all endpoints with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--endp"]
 
-    clear sta with names phy (not wiphy) and 1.1.eth stations:
-        "args": ["--mgr","192.168.30.12","--resource","1","--misc"]
+            # Remove all bridge with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--br"]
 
-SCRIPT_CLASSIFICATION:  Deletion
+            # Remove all STAs with unexpected names with CLI (often from misuse of or bugs in automation)
+            # This includes names 'phy' (not 'wiphy') and '1.1.eth'
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--misc"]
 
-SCRIPT_CATEGORIES:  Functional
+SCRIPT_CLASSIFICATION:
+            Deletion
 
-NOTES:
+SCRIPT_CATEGORIES:
+            Functional
 
-    The default port is 8080
-    The script will only cleanup what is present in the GUI,
-     so it will need to iterate multiple times with script
+NOTES:      The script will only cleanup what is present in the GUI. If object creation (e.g. port or CX)
+            is in process but the object is not yet present in the GUI, then this script may need to be run
+            multiple times for deletion to take effect.
 
 VERIFIED_ON:
-    Tested on 03/17/2023:
-        kernel version: 5.19.17+
-        gui version: 5.4.6
+            Working date:   03/17/2023
+            Build version:  5.4.6
+            Kernel version: 5.19.17+
 
-LICENSE:
-          Free to distribute and modify. LANforge systems must be licensed.
-          Copyright 2023 Candela Technologies Inc
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2025 Candela Technologies Inc
 """
 import sys
 import os
@@ -579,69 +581,71 @@ def parse_args():
         epilog='''\
             Clean up cxs and endpoints
             ''',
-        description='''\
-NAME: lf_cleanup.py
+        description=r'''
+NAME:       lf_cleanup.py
 
-PURPOSE:
-    clean up stations, cross connects and endpoints
+PURPOSE:    Remove present test configuration, resetting system(s) to
+            a reproducible base state.
 
 EXAMPLE:
-    clear all stations:
-        ./lf_cleanup.py --mgr localhost --resource 1 --sta
+            # Remove all stations with CLI
+            ./lf_cleanup.py --sta
 
-    This example will clean the Port Mgr, Layer-3, L3 Endps, and Layer 4-7 LF GUI tabs:
-        ./lf_cleanup.py --mgr localhost --resource 1 --sanitize
+            # Remove all stations with CLI for a specific resource
+            ./lf_cleanup.py --sta --resource 2
 
-    clear all cxs and enps:
-        ./lf_cleanup.py --mgr localhost --resource 1 --cxs
+            # Full cleanup (ports, L3 CXs/endpoints, L4-7 endpoints with CLI
+            ./lf_cleanup.py --sanitize
 
-    clear all endps:
-        ./lf_cleanup.py --mgr localhost --resource 1 --endp
+            # Remove all CXs and endpoints with CLI
+            ./lf_cleanup.py --cxs
 
-    clear all bridges:
-        ./lf_cleanup.py --mgr localhost --resource 1 --br
+            # Remove all endpoints with CLI
+            ./lf_cleanup.py --endp
 
-    clear sta with names phy (not wiphy) and 1.1.eth stations:
-        ./lf_cleanup.py --mgr localhost --resource 1 --misc
+            # Remove all bridge with CLI
+            ./lf_cleanup.py --br
 
-JSON EXAMPLE:
-    clear all stations:
-        "args": ["--mgr","192.168.30.12","--resource","1","--sta"]
+            # Remove all STAs with unexpected names with CLI (often from misuse of or bugs in automation)
+            # This includes names 'phy' (not 'wiphy') and '1.1.eth'
+            ./lf_cleanup.py --misc
 
-    This example will clean the Port Mgr, Layer-3, L3 Endps, and Layer 4-7 LF GUI tabs:
-        "args": ["--mgr","192.168.30.12","--resource","1","--sanitize"]
+            # Remove all stations with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--sta"]
 
-    clear all cxs and enps:
-        "args": ["--mgr","192.168.30.12","--resource","1","--cxs"]
+            # Full cleanup (ports, L3 CXs/endpoints, L4-7 endpoints with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--sanitize"]
 
-    clear all endps:
-        "args": ["--mgr","192.168.30.12","--resource","1","--endp"]
+            # Remove all CXs and endpoints with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--cxs"]
 
-    clear all bridges:
-        "args": ["--mgr","192.168.30.12","--resource","1","--br"]
+            # Remove all endpoints with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--endp"]
 
-    clear sta with names phy (not wiphy) and 1.1.eth stations:
-        "args": ["--mgr","192.168.30.12","--resource","1","--misc"]
+            # Remove all bridge with JSON
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--br"]
 
-SCRIPT_CLASSIFICATION:  Deletion
+            # Remove all STAs with unexpected names with CLI (often from misuse of or bugs in automation)
+            # This includes names 'phy' (not 'wiphy') and '1.1.eth'
+            "args": ["--mgr", "192.168.30.12", "--resource", "1", "--misc"]
 
-SCRIPT_CATEGORIES:  Functional
+SCRIPT_CLASSIFICATION:
+            Deletion
 
-NOTES:
+SCRIPT_CATEGORIES:
+            Functional
 
-    The default port is 8080
-    The script will only cleanup what is present in the GUI,
-     so it will need to iterate multiple times with script
+NOTES:      The script will only cleanup what is present in the GUI. If object creation (e.g. port or CX)
+            is in process but the object is not yet present in the GUI, then this script may need to be run
+            multiple times for deletion to take effect.
 
 VERIFIED_ON:
-    Tested on 03/17/2023:
-        kernel version: 5.19.17+
-        gui version: 5.4.6
+            Working date:   03/17/2023
+            Build version:  5.4.6
+            Kernel version: 5.19.17+
 
-LICENSE:
-          Free to distribute and modify. LANforge systems must be licensed.
-          Copyright 2023 Candela Technologies Inc
-
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2025 Candela Technologies Inc
             ''')
     # Base options
     parser.add_argument('--mgr',

--- a/py-scripts/lf_cleanup.py
+++ b/py-scripts/lf_cleanup.py
@@ -92,8 +92,8 @@ class lf_clean(Realm):
                  clean_sta=None,
                  clean_port_mgr=None,
                  clean_misc=None):
-        super().__init__(lfclient_host=host,
-                         lfclient_port=port),
+        super().__init__(lfclient_host=host, lfclient_port=port)
+
         self.host = host
         self.port = port
         self.resource = resource

--- a/py-scripts/lf_client_visualization.py
+++ b/py-scripts/lf_client_visualization.py
@@ -317,7 +317,7 @@ class Client_Visualization(cv_test):
                                      self.config_name, self.sets,
                                      self.pull_report, self.lfclient_host, self.lf_user, self.lf_password,
                                      cv_cmds, ssh_port=self.ssh_port, graph_groups_file=self.graph_groups, local_lf_report_dir=self.local_lf_report_dir)
-        except:  # noqa: E722
+        except:  # noqa: E722, B001
             logger.info("There is already an instance of 'Client Visualization' present in GUI. "
                         "To delete the existing window, use --delete_existing_instance")
             logger.info("Before deleting, make sure to save the report of running instance if needed.")

--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -165,7 +165,7 @@ class create_vap_cv(cv_test):
         profile_data = requests.get(url="http://{}:{}/profile/all".format(self.lfclient_host, self.lf_port))
         data = profile_data.json()
         for profile in data['profiles']:
-            for key, value in profile.items():
+            for _, value in profile.items():
                 if scenario_name in value['name']:
                     requests.post(url=post_url, json=post_data)
                 else:

--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -1,78 +1,73 @@
 #!/usr/bin/env python3
+r"""
+NAME:       lf_create_vap_cv.py
 
-"""
-NAME: lf_create_vap_cv.py
+PURPOSE:    Create a VAP (virtual access point) using LANforge Chamber View
 
-PURPOSE:
-    This script will create a vap using chamberview based upon a user defined frequency.
+EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and options
 
-EXAMPLE:
-    Use './lf_create_vap_cv.py --help' to see command line usage and options
+            # Configure a basic 2.4GHz vAP with default DHCP server capabilities
+            ./lf_create_vap_cv.py --mgr localhost --port 8080 --lf_user lanforge --lf_password lanforge
+                --delete_old_scenario --scenario_name Automation --vap_radio wiphy0 --set_upstream True
+                --vap_freq 2437 --vap_ssid routed-AP --vap_passwd something --vap_security wpa2 --vap_bw 20
 
-    ./lf_create_vap_cv.py --mgr localhost --port 8080 --lf_user lanforge --lf_password lanforge
-        --delete_old_scenario --scenario_name Automation --vap_radio wiphy0 --set_upstream True
-        --vap_freq 2437 --vap_ssid routed-AP --vap_passwd something --vap_security wpa2 --vap_bw 20
+            # Configure a 2.4GHz vAP with adjusted DHCP server capabilities (namely larger subnet mask and lease range)
+            ./lf_create_vap_cv.py --mgr 192.168.200.138 --port 8080 --delete_old_scenario --scenario_name hello
+            --vap_radio 1.1.wiphy0 --vap_freq 2437 --vap_ssid testings --vap_passwd Password@123 --vap_security wpa2 --num_vaps 2
+            --vap_bw 20 --vap_ip 192.168.0.16 --vap_ip_mask 255.255.0.0 --dhcp_min_range 192.168.0.5 --dhcp_max_range 192.168.0.200
 
-    # For modify the net-smith dhcp min and max range
-    python3 ./lf_create_vap_cv.py --mgr 192.168.200.138 --port 8080 --delete_old_scenario --scenario_name hello
-    --vap_radio 1.1.wiphy0 --vap_freq 2437 --vap_ssid testings --vap_passwd Password@123 --vap_security wpa2 --num_vaps 2
-    --vap_bw 20 --vap_ip 192.168.0.16 --vap_ip_mask 255.255.0.0 --dhcp_min_range 192.168.0.5 --dhcp_max_range 192.168.0.200
+            # Load an existing Chamber View scenario
+            ./lf_create_vap_cv.py --mgr 192.168.200.222 --port 8080 --load_existing_scenario --old_scenario_name hello --instance_name oldscenario
 
-    vs_code launch.json example:
-    "args": ["--mgr","localhost",
-             "--port","8080",
-             "--lf_user","lanforge",
-             "--lf_password","lanforge",
-             "--vap_radio","wiphy0",
-             "--vap_freq","36",
-             "--vap_ssid","test_vap",
-             "--vap_passwd","password",
-             "--vap_security","wpa2",
-             "--vap_upstream_port","1.1.eth1"
+            # Basic 2.4GHz vAP configuration using VSCode launch JSON
+            "args": ["--mgr","localhost",
+                "--port", "8080",
+                "--lf_user", "lanforge",
+                "--lf_password", "lanforge",
+                "--vap_radio", "wiphy0",
+                "--vap_freq", "36",
+                "--vap_ssid", "test_vap",
+                "--vap_passwd", "password",
+                "--vap_security", "wpa2",
+                "--vap_upstream_port", "1.1.eth1"
             ]
 
+            # Basic 5GHz vAP configuration using VSCode launch JSON
             "args": ["--mgr","192.168.0.104",
-            "--port","8080",
-            "--lf_user","lanforge",
-            "--lf_password","lanforge",
-            "--delete_old_scenario",
-            "--scenario_name","dfs",
-            "--vap_radio","wiphy3",
-            "--vap_freq","5660",
-            "--vap_ssid","mtk7915_5g",
-            "--vap_passwd","lf_mtk7915_5g",
-            "--vap_security","wpa2",
-            "--vap_bw","20",
-            "--vap_upstream_port","1.1.eth2"
+                "--port", "8080",
+                "--lf_user", "lanforge",
+                "--lf_password", "lanforge",
+                "--delete_old_scenario",
+                "--scenario_name", "dfs",
+                "--vap_radio", "wiphy3",
+                "--vap_freq", "5660",
+                "--vap_ssid", "mtk7915_5g",
+                "--vap_passwd", "lf_mtk7915_5g",
+                "--vap_security", "wpa2",
+                "--vap_bw", "20",
+                "--vap_upstream_port", "1.1.eth2"
             ]
 
-    # for loading existing scenario use
-    python3 ./lf_create_vap_cv.py --mgr 192.168.200.222 --port 8080  --load_existing_scenario --old_scenario_name hello --instance_name oldscenario
+SCRIPT_CLASSIFICATION:
+            Creation
 
-SCRIPT_CLASSIFICATION:  Creation
+SCRIPT_CATEGORIES:
+            Functional
 
-SCRIPT_CATEGORIES: Functional
+NOTES:      This script leverages LANforge Chamber View automation, including profiles
+            and Chamber View Scenarios in order to create and configure the desired vAP.
 
-
-NOTES:
-
-This script creates
-1. Chamber view scenario for vap
-2. Vap profile with given parameters
-
-STATUS:   BETA RELEASE
+STATUS:     BETA RELEASE
 
 VERIFIED_ON:
-Working date : 05-July-2023
-Build version: 5.4.6
-Kernel version: 6.2.16+
+            Working date:   05-July-2023
+            Build version:  5.4.6
+            Kernel version: 6.2.16+
 
-LICENSE:
-    Free to distribute and modify. LANforge systems must be licensed.
-    Copyright 2023 Candela Technologies Inc
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2025 Candela Technologies Inc
 
 INCLUDE_IN_README: False
-
 """
 import sys
 import os
@@ -301,77 +296,75 @@ def main():
     parser = argparse.ArgumentParser(
         prog="lf_create_vap_cv.py",
         formatter_class=argparse.RawTextHelpFormatter,
-        description="""
+        description=r"""
+NAME:       lf_create_vap_cv.py
 
-NAME: lf_create_vap_cv.py
+PURPOSE:    Create a VAP (virtual access point) using LANforge Chamber View
 
-PURPOSE:
-    This script will create a vap using chamberview based upon a user defined frequency.
+EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and options
 
-EXAMPLE:
-    Use './lf_create_vap_cv.py --help' to see command line usage and options
+            # Configure a basic 2.4GHz vAP with default DHCP server capabilities
+            ./lf_create_vap_cv.py --mgr localhost --port 8080 --lf_user lanforge --lf_password lanforge
+                --delete_old_scenario --scenario_name Automation --vap_radio wiphy0 --set_upstream True
+                --vap_freq 2437 --vap_ssid routed-AP --vap_passwd something --vap_security wpa2 --vap_bw 20
 
-    ./lf_create_vap_cv.py --mgr localhost --port 8080 --lf_user lanforge --lf_password lanforge
-        --delete_old_scenario --scenario_name Automation --vap_radio wiphy0 --set_upstream True
-        --vap_freq 2437 --vap_ssid routed-AP --vap_passwd something --vap_security wpa2 --vap_bw 20
+            # Configure a 2.4GHz vAP with adjusted DHCP server capabilities (namely larger subnet mask and lease range)
+            ./lf_create_vap_cv.py --mgr 192.168.200.138 --port 8080 --delete_old_scenario --scenario_name hello
+            --vap_radio 1.1.wiphy0 --vap_freq 2437 --vap_ssid testings --vap_passwd Password@123 --vap_security wpa2 --num_vaps 2
+            --vap_bw 20 --vap_ip 192.168.0.16 --vap_ip_mask 255.255.0.0 --dhcp_min_range 192.168.0.5 --dhcp_max_range 192.168.0.200
 
-    # For modify the net-smith dhcp min and max range
-    python3 ./lf_create_vap_cv.py --mgr 192.168.200.138 --port 8080 --delete_old_scenario --scenario_name hello
-    --vap_radio 1.1.wiphy0 --vap_freq 2437 --vap_ssid testings --vap_passwd Password@123 --vap_security wpa2 --num_vaps 2
-    --vap_bw 20 --vap_ip 192.168.0.16 --vap_ip_mask 255.255.0.0 --dhcp_min_range 192.168.0.5 --dhcp_max_range 192.168.0.200
+            # Load an existing Chamber View scenario
+            ./lf_create_vap_cv.py --mgr 192.168.200.222 --port 8080 --load_existing_scenario --old_scenario_name hello --instance_name oldscenario
 
-    vs_code launch.json example:
-    "args": ["--mgr","localhost",
-             "--port","8080",
-             "--lf_user","lanforge",
-             "--lf_password","lanforge",
-             "--vap_radio","wiphy0",
-             "--vap_freq","36",
-             "--vap_ssid","test_vap",
-             "--vap_passwd","password",
-             "--vap_security","wpa2",
-             "--vap_upstream_port","1.1.eth1"
+            # Basic 2.4GHz vAP configuration using VSCode launch JSON
+            "args": ["--mgr","localhost",
+                "--port", "8080",
+                "--lf_user", "lanforge",
+                "--lf_password", "lanforge",
+                "--vap_radio", "wiphy0",
+                "--vap_freq", "36",
+                "--vap_ssid", "test_vap",
+                "--vap_passwd", "password",
+                "--vap_security", "wpa2",
+                "--vap_upstream_port", "1.1.eth1"
             ]
 
+            # Basic 5GHz vAP configuration using VSCode launch JSON
             "args": ["--mgr","192.168.0.104",
-            "--port","8080",
-            "--lf_user","lanforge",
-            "--lf_password","lanforge",
-            "--delete_old_scenario",
-            "--scenario_name","dfs",
-            "--vap_radio","wiphy3",
-            "--vap_freq","5660",
-            "--vap_ssid","mtk7915_5g",
-            "--vap_passwd","lf_mtk7915_5g",
-            "--vap_security","wpa2",
-            "--vap_bw","20",
-            "--vap_upstream_port","1.1.eth2"
+                "--port", "8080",
+                "--lf_user", "lanforge",
+                "--lf_password", "lanforge",
+                "--delete_old_scenario",
+                "--scenario_name", "dfs",
+                "--vap_radio", "wiphy3",
+                "--vap_freq", "5660",
+                "--vap_ssid", "mtk7915_5g",
+                "--vap_passwd", "lf_mtk7915_5g",
+                "--vap_security", "wpa2",
+                "--vap_bw", "20",
+                "--vap_upstream_port", "1.1.eth2"
             ]
 
-SCRIPT_CLASSIFICATION:  Creation
+SCRIPT_CLASSIFICATION:
+            Creation
 
-SCRIPT_CATEGORIES: Functional
+SCRIPT_CATEGORIES:
+            Functional
 
+NOTES:      This script leverages LANforge Chamber View automation, including profiles
+            and Chamber View Scenarios in order to create and configure the desired vAP.
 
-NOTES:
-
-This script creates
-1. Chamber view scenario for vap
-2. Vap profile with given parameters
-
-STATUS:   BETA RELEASE
+STATUS:     BETA RELEASE
 
 VERIFIED_ON:
-Working date : 05-July-2023
-Build version: 5.4.6
-Kernel version: 6.2.16+
+            Working date:   05-July-2023
+            Build version:  5.4.6
+            Kernel version: 6.2.16+
 
-LICENSE:
-    Free to distribute and modify. LANforge systems must be licensed.
-    Copyright 2023 Candela Technologies Inc
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2025 Candela Technologies Inc
 
 INCLUDE_IN_README: False
-
         """)
 
     cv_add_base_parser(parser)  # see cv_test_manager.py

--- a/py-scripts/lf_create_wanlink.py
+++ b/py-scripts/lf_create_wanlink.py
@@ -238,7 +238,7 @@ class lf_create_wanlink():
                                        errors_warnings=ewarn_list,
                                        debug=self.debug)
             logger.debug(pformat(result))
-        except BaseException:
+        except BaseException:  # noqa: B036
             logger.warning(pformat(ewarn_list))
         return result
 
@@ -479,7 +479,7 @@ ip-address must be assigned to the wanlink endpoints in the LANforge gui for sce
                                       requested_col_names=("name", "eid"),
                                       debug=args.debug,
                                       _errors_warnings=ewarns)
-    except BaseException:
+    except BaseException:  # noqa: B036
         logger.warning(ewarns)
     wl_exists = (False, True)[result is not None]
     if wl_exists:
@@ -492,7 +492,7 @@ ip-address must be assigned to the wanlink endpoints in the LANforge gui for sce
                                           cx_state='STOPPED',
                                           test_mgr='all',
                                           debug=args.debug)
-        for n in range(1, 60):
+        for _ in range(1, 60):
             result = wanlink.query.get_wl(eid_list=args.wl_name,
                                           requested_col_names=("name", "eid", "running"),
                                           debug=False)

--- a/py-scripts/lf_create_wanlink.py
+++ b/py-scripts/lf_create_wanlink.py
@@ -1,28 +1,35 @@
 #!/usr/bin/env python3
+r"""
+NAME:       lf_create_wanlink.py
 
-"""
-NAME: lf_create_wanlink.py
+PURPOSE:    Create and configure a LANforge WANLink used for network impairment.
 
-PURPOSE: This script creates a wanlink using the lanforge api.
+NOTES:      Underlying port IP addresses must be configured in order for wanlink endpoints
+            to become active
 
-EXAMPLE:
-Both port_A and port_B have the same configuraiton
-$ ./lf_create_wanlink.py --mgr 192.168.0.104 --mgr_port 8080 --port_A eth1 --port_B eth2\
-    --speed 1024000 --wl_name wanlink --latency 24 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
-    --log_level debug --debug
+EXAMPLE:    # Duplicate configuration for both ends of the WANLink
+            ./lf_create_wanlink.py \
+                --wl_name       wanlink \
+                --port_A        eth1 \
+                --port_B        eth2 \
+                --speed         1024000 \
+                --latency       24 \
+                --max_jitter    50 \
+                --jitter_freq   6 \
+                --drop_freq     12
 
-Mixed configuration for port_A and port_B
-$ ./lf_create_wanlink.py --mgr 192.168.0.104 --mgr_port 8080 --port_A eth1 --port_B eth2\
-    --speed_A 1024000 --speed_B 2048000 --wl_name wanlink --latency_A 24 --latency_B 32 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
-    --log_level debug --debug
-
-
-
-NOTES:
-ip-address must be assigned to the wanlink endpoints in the LANforge gui for scenario to run.
-
-TO DO NOTES:
-
+            # Mixed configuration, each end of WANLink has specific config
+            ./lf_create_wanlink.py \
+                --wl_name       wanlink \
+                --port_A        eth1 \
+                --port_B        eth2 \
+                --speed_A       1024000 \
+                --speed_B       2048000 \
+                --latency_A     24 \
+                --latency_B     32 \
+                --max_jitter    50 \
+                --jitter_freq   6 \
+                --drop_freq     12
 """
 import sys
 import time
@@ -269,26 +276,37 @@ def main():
     parser = argparse.ArgumentParser(
         prog=__file__,
         formatter_class=argparse.RawTextHelpFormatter,
-        description='''\
-NAME: lf_create_wanlink.py
+        description=r'''\
+NAME:       lf_create_wanlink.py
 
-PURPOSE: creates a wanlink using the lanforge api.
+PURPOSE:    Create and configure a LANforge WANLink used for network impairment.
 
-EXAMPLE:
-Both port_A and port_B have the same configuraiton
-$ ./lf_create_wanlink.py --mgr 192.168.0.104 --mgr_port 8080 --port_A eth1 --port_B eth2\
-    --speed 1024000 --wl_name wanlink --latency 24 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
-    --log_level debug --debug
+NOTES:      Underlying port IP addresses must be configured in order for wanlink endpoints
+            to become active
 
-Mixed configuration for port_A and port_B
-$ ./lf_create_wanlink.py --mgr 192.168.0.104 --mgr_port 8080 --port_A eth1 --port_B eth2\
-    --speed_A 1024000 --speed_B 2048000 --wl_name wanlink --latency_A 24 --latency_B 32 --max_jitter 50 --jitter_freq 6 --drop_freq 12\
-    --log_level debug --debug
+EXAMPLE:    # Duplicate configuration for both ends of the WANLink
+            ./lf_create_wanlink.py \
+                --wl_name       wanlink \
+                --port_A        eth1 \
+                --port_B        eth2 \
+                --speed         1024000 \
+                --latency       24 \
+                --max_jitter    50 \
+                --jitter_freq   6 \
+                --drop_freq     12
 
-
-NOTES:
-ip-address must be assigned to the wanlink endpoints in the LANforge gui for scenario to run.
-
+            # Mixed configuration, each end of WANLink has specific config
+            ./lf_create_wanlink.py \
+                --wl_name       wanlink \
+                --port_A        eth1 \
+                --port_B        eth2 \
+                --speed_A       1024000 \
+                --speed_B       2048000 \
+                --latency_A     24 \
+                --latency_B     32 \
+                --max_jitter    50 \
+                --jitter_freq   6 \
+                --drop_freq     12
             ''')
     # http://www.candelatech.com/lfcli_ug.php#add_wl_endp
     parser.add_argument("--host", "--mgr", dest='mgr', help='specify the GUI to connect to')

--- a/py-scripts/lf_create_wanlink.py
+++ b/py-scripts/lf_create_wanlink.py
@@ -272,7 +272,7 @@ class lf_create_wanlink():
 # ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- #
 
 
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         prog=__file__,
         formatter_class=argparse.RawTextHelpFormatter,
@@ -389,7 +389,11 @@ EXAMPLE:    # Duplicate configuration for both ends of the WANLink
     # Help Summary
     parser.add_argument('--help_summary', default=None, action="store_true", help='Show summary of what this script does')
 
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
 
     help_summary = "This script creates a wanlink using the lanforge api."
     if args.help_summary:

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1213,7 +1213,7 @@ class L3VariableTime(Realm):
         # if side_a is None then side_a is radios
         if not self.dataplane:
             for (
-                    radio_,
+                    _radio_,
                     ssid_,
                     ssid_password_,
                     ssid_security_,
@@ -2012,7 +2012,7 @@ class L3VariableTime(Realm):
 
                 for atten_val in self.atten_vals:
                     if atten_val != -1:
-                        for atten_idx in self.attenuators:
+                        for _ in self.attenuators:
                             atten_mod_test = lf_attenuator.CreateAttenuator(
                                 host=self.lfclient_host, port=self.lfclient_port, serno='all', idx='all', val=atten_val, _debug_on=self.debug)
                             atten_mod_test.build()
@@ -5618,13 +5618,13 @@ class L3VariableTime(Realm):
         for (
                 radio_,
                 ssid_,
-                ssid_password_,  # do not print password
+                _ssid_password_,  # do not print password
                 ssid_security_,
                 mode_,
                 wifi_enable_flags_list_,
-                reset_port_enable_,
-                reset_port_time_min_,
-                reset_port_time_max_) in zip(
+                _reset_port_enable_,
+                _reset_port_time_min_,
+                _reset_port_time_max_) in zip(
                 self.radio_name_list,
                 self.ssid_list,
                 self.ssid_password_list,

--- a/py-scripts/tools/lf_cli_to_testjson.py
+++ b/py-scripts/tools/lf_cli_to_testjson.py
@@ -87,10 +87,15 @@ sys.path.append(os.path.join(os.path.abspath(__file__ + "../../../")))
 
 class clitojson():
     def __init__(self,
-                 cli_list=["--mgr 192.168.200.147 --port 8080 --lf_user lanforge --lf_password lanforge --instance_name scenario_wpa2_wc --upstream 1.1.eth1 --batch_size 1,3,5 --loop_iter 1 --protocol TCP-IPv4 --duration 20000 --download_rate 10Mbps --upload_rate 10Mbps --pull_report --delete_old_scenario --local_lf_report_dir /home/lanforge/html-scripts --test_tag WCT_MTK7915_W1_5G_40_UDP_BD_AT --test_rig TEST_RIG --set DUT_SET_NAME"],  # noqa: E501
-                 list=[],
-                 length_of_cli=[]
-                 ):
+                 cli_list=None,
+                 list=None,
+                 length_of_cli=None):
+        if not cli_list:
+            cli_list = ["--mgr 192.168.200.147 --port 8080 --lf_user lanforge --lf_password lanforge --instance_name scenario_wpa2_wc --upstream 1.1.eth1 --batch_size 1,3,5 --loop_iter 1 --protocol TCP-IPv4 --duration 20000 --download_rate 10Mbps --upload_rate 10Mbps --pull_report --delete_old_scenario --local_lf_report_dir /home/lanforge/html-scripts --test_tag WCT_MTK7915_W1_5G_40_UDP_BD_AT --test_rig TEST_RIG --set DUT_SET_NAME"]  # noqa: E501
+        if not list:
+            list = []
+        if not length_of_cli:
+            length_of_cli = []
 
         self.cli_list = cli_list
         self.list1 = list

--- a/py-scripts/tools/lf_cli_to_testjson.py
+++ b/py-scripts/tools/lf_cli_to_testjson.py
@@ -1,76 +1,66 @@
 #!/usr/bin/env python3
+r"""
+NAME:       lf_cli_to_testjson.py
 
-"""
-NAME: lf_cli_to_testjson.py
+PURPOSE:    Convert cli command into test.json format
 
-PURPOSE: To convert cli command into test.json format
+EXAMPLE:    Use './lf_cli_to_testjson.py --help' to see command line usage and options
 
-EXAMPLE:
-    Use './lf_cli_to_testjson.py --help' to see command line usage and options
+SCRIPT_CLASSIFICATION:
+            Tool
 
-    ./lf_cli_to_testjson.py --cli
+SCRIPT_CATEGORIES:
+            Creation
 
-SCRIPT_CLASSIFICATION: Tool
+NOTES:      Enter the cli of the script as an input to the script.  --cli "<cli of particular script>"
 
-SCRIPT_CATEGORIES: Creation
+            ./lf_cli_to_testjson.py \
+            --cli "--lfmgr 192.168.100.116\
+            --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
+            --test_duration 15s\
+            --polling_interval 5s\
+            --upstream_port 1.1.eth2\
+            --radio 'radio==wiphy4,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --radio 'radio==wiphy5,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --radio 'radio==wiphy6,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --radio 'radio==wiphy7,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --endp_type lf_udp\
+            --rates_are_totals\
+            --side_a_min_bps=20000\
+            --side_b_min_bps=300000000\
+            --test_rig CT-US-001\
+            --test_tag 'test_l3'\
+            --dut_model_num  ASUSRT-AX88U\
+            --dut_sw_version 3.0.0.4.386_44266\
+            --dut_hw_version 1.0 --dut_serial_num 12345678"
 
-NOTES:
-Enter the cli of the script as an input to the script.  --cli "<cli of particular script>"
-Example:
-./lf_cli_to_testjson.py \
- --cli "--lfmgr 192.168.100.116\
- --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
- --test_duration 15s\
- --polling_interval 5s\
- --upstream_port 1.1.eth2\
- --radio 'radio==wiphy4,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --radio 'radio==wiphy5,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --radio 'radio==wiphy6,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --radio 'radio==wiphy7,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --endp_type lf_udp\
- --rates_are_totals\
- --side_a_min_bps=20000\
- --side_b_min_bps=300000000\
- --test_rig CT-US-001\
- --test_tag 'test_l3'\
- --dut_model_num  ASUSRT-AX88U\
- --dut_sw_version 3.0.0.4.386_44266\
- --dut_hw_version 1.0 --dut_serial_num 12345678"
+            ./lf_cli_to_testjson.py \
+            --cli "--lfmgr 192.168.0.31\
+            --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
+            --test_duration 15s\
+            --polling_interval 5s\
+            --upstream_port 1.1.eth2\
+            --radio 'radio==wiphy4,stations==1,ssid==ax1800_5g,ssid_pw==lf_ax1800_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable|80211u_enable|create_admin_down)'\\ # noqa: E501
+            --endp_type lf_udp\
+            --rates_are_totals\
+            --side_a_min_bps=20000\
+            --side_b_min_bps=300000000\
+            --test_rig CT-US-001\
+            --test_tag 'test_l3'\
+            --dut_model_num  ASUSRT-AX88U\
+            --dut_sw_version 3.0.0.4.386_44266\
+            --dut_hw_version 1.0 --dut_serial_num 12345678"
 
-./lf_cli_to_testjson.py \
- --cli "--lfmgr 192.168.0.31\
- --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
- --test_duration 15s\
- --polling_interval 5s\
- --upstream_port 1.1.eth2\
- --radio 'radio==wiphy4,stations==1,ssid==ax1800_5g,ssid_pw==lf_ax1800_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable|80211u_enable|create_admin_down)'\\ # noqa: E501
- --endp_type lf_udp\
- --rates_are_totals\
- --side_a_min_bps=20000\
- --side_b_min_bps=300000000\
- --test_rig CT-US-001\
- --test_tag 'test_l3'\
- --dut_model_num  ASUSRT-AX88U\
- --dut_sw_version 3.0.0.4.386_44266\
- --dut_hw_version 1.0 --dut_serial_num 12345678"
-
-
-
-
-STATUS: Functional
+STATUS:     Functional
 
 VERIFIED_ON:
-Working date : 12/07/2023
-Build version: 5.4.6
-Kernel version: 6.2.16+
+            Working date:   12/07/2023
+            Build version:  5.4.6
+            Kernel version: 6.2.16+
 
-LICENSE:
-    Free to distribute and modify. LANforge systems must be licensed.
-    Copyright 2023 Candela Technologies Inc
-
-INCLUDE_IN_README: False
-
-     """
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2025 Candela Technologies Inc
+"""
 
 import sys
 import os
@@ -138,80 +128,68 @@ def main():
     parser = argparse.ArgumentParser(
         prog='lf_cli_to_testjson.py',
         formatter_class=argparse.RawTextHelpFormatter,
-        description="""
+        description=r"""
+NAME:       lf_cli_to_testjson.py
 
-NAME: lf_cli_to_testjson.py
+PURPOSE:    Convert cli command into test.json format
 
-PURPOSE: To convert cli command into test.json format
+EXAMPLE:    Use './lf_cli_to_testjson.py --help' to see command line usage and options
 
-EXAMPLE:
-    Use './lf_cli_to_testjson.py --help' to see command line usage and options
+SCRIPT_CLASSIFICATION:
+            Tool
 
-    ./lf_cli_to_testjson.py --cli
+SCRIPT_CATEGORIES:
+            Creation
 
-SCRIPT_CLASSIFICATION: Tool
+NOTES:      Enter the cli of the script as an input to the script.  --cli "<cli of particular script>"
 
-SCRIPT_CATEGORIES: Creation
+            ./lf_cli_to_testjson.py \
+            --cli "--lfmgr 192.168.100.116\
+            --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
+            --test_duration 15s\
+            --polling_interval 5s\
+            --upstream_port 1.1.eth2\
+            --radio 'radio==wiphy4,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --radio 'radio==wiphy5,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --radio 'radio==wiphy6,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --radio 'radio==wiphy7,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
+            --endp_type lf_udp\
+            --rates_are_totals\
+            --side_a_min_bps=20000\
+            --side_b_min_bps=300000000\
+            --test_rig CT-US-001\
+            --test_tag 'test_l3'\
+            --dut_model_num  ASUSRT-AX88U\
+            --dut_sw_version 3.0.0.4.386_44266\
+            --dut_hw_version 1.0 --dut_serial_num 12345678"
 
-NOTES:
-Enter the cli of the script as an input to the script. --cli "<cli of particular script>"
-Example:
+            ./lf_cli_to_testjson.py \
+            --cli "--lfmgr 192.168.0.31\
+            --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
+            --test_duration 15s\
+            --polling_interval 5s\
+            --upstream_port 1.1.eth2\
+            --radio 'radio==wiphy4,stations==1,ssid==ax1800_5g,ssid_pw==lf_ax1800_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable|80211u_enable|create_admin_down)'\\ # noqa: E501
+            --endp_type lf_udp\
+            --rates_are_totals\
+            --side_a_min_bps=20000\
+            --side_b_min_bps=300000000\
+            --test_rig CT-US-001\
+            --test_tag 'test_l3'\
+            --dut_model_num  ASUSRT-AX88U\
+            --dut_sw_version 3.0.0.4.386_44266\
+            --dut_hw_version 1.0 --dut_serial_num 12345678"
 
-./lf_cli_to_testjson.py \
- --cli "--lfmgr 192.168.100.116\
- --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
- --test_duration 15s\
- --polling_interval 5s\
- --upstream_port 1.1.eth2\
- --radio 'radio==wiphy4,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --radio 'radio==wiphy5,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --radio 'radio==wiphy6,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --radio 'radio==wiphy7,stations==1,ssid==asus11ax-2,ssid_pw==hello123,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable)'\
- --endp_type lf_udp\
- --rates_are_totals\
- --side_a_min_bps=20000\
- --side_b_min_bps=300000000\
- --test_rig CT-US-001\
- --test_tag 'test_l3'\
- --dut_model_num  ASUSRT-AX88U\
- --dut_sw_version 3.0.0.4.386_44266\
- --dut_hw_version 1.0 --dut_serial_num 12345678"
-
-./lf_cli_to_testjson.py \
- --cli "--lfmgr 192.168.0.31\
- --local_lf_report_dir /home/lanforge/html-reports/ct-us-001/2023-05-21-03-00-06_lf_check_suite_wc_dp_nightly\
- --test_duration 15s\
- --polling_interval 5s\
- --upstream_port 1.1.eth2\
- --radio 'radio==wiphy4,stations==1,ssid==ax1800_5g,ssid_pw==lf_ax1800_5g,security==wpa2,wifi_mode==0,wifi_settings==wifi_settings,enable_flags==(ht160_enable|wpa2_enable'\
- --endp_type lf_udp\
- --rates_are_totals\
- --side_a_min_bps=20000\
- --side_b_min_bps=300000000\
- --test_rig CT-US-001\
- --test_tag 'test_l3'\
- --dut_model_num  ASUSRT-AX88U\
- --dut_sw_version 3.0.0.4.386_44266\
- --dut_hw_version 1.0 --dut_serial_num 12345678"
-
-
-
-
-STATUS: Functional
+STATUS:     Functional
 
 VERIFIED_ON:
-Working date : 12/07/2023
-Build version: 5.4.6
-Kernel version: 6.2.16+
+            Working date:   12/07/2023
+            Build version:  5.4.6
+            Kernel version: 6.2.16+
 
-LICENSE:
-    Free to distribute and modify. LANforge systems must be licensed.
-    Copyright 2023 Candela Technologies Inc
-
-INCLUDE_IN_README: False
-
-     """
-    )
+LICENSE:    Free to distribute and modify. LANforge systems must be licensed.
+            Copyright 2025 Candela Technologies Inc
+    """)
 
     parser.add_argument("--cli", type=str, help="--cli '<command in quotes>'", required=True)
 


### PR DESCRIPTION
This series fixes (and in some cases ignores) linting failures flagged by flake8-bugbear for all scripts except those involved in interop and WebUI (will address those after current PRs are merged). **This does NOT add flake8-bugbear to linting**.