### PR TITLE
Test l3 lan-4069 Wifi 7 updates and examples

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -269,9 +269,11 @@ BK, BE, VI, VO:  Optional wifi related Tos Settings.  Or, use your preferred num
              is automatically sent to this Queue.
 
 <wifi_mode>:
-    Input       : Enum Val  : Shown by nc_show_ports
+    Input       : Enum Val  : for list ,  telnet <mgr> 4001  , help add_profile
 
-    AUTO        |  0        #  802.11
+    Wifi_Mode
+    <pre options='wifi_mode'>
+    AUTO        |  0        #  Best Available
     802.11a     |  1        #  802.11a
     b           |  2        #  802.11b
     g           |  3        #  802.11g
@@ -288,6 +290,12 @@ BK, BE, VI, VO:  Optional wifi related Tos Settings.  Or, use your preferred num
     bgnAX       | 13        #  802.11bgn-AX
     anAX        | 14        #  802.11an-AX
     aAX         | 15        #  802.11a-AX (6E disables /n and /ac)
+    abgn7       | 16        #  802.11abgn-EHT
+                            #     a/b/g/n/AC/AX/EHT (dual-band AX) support
+    bgn7        | 17        #  802.11bgn-EHT
+    an7         | 18        #  802.11an-EHT
+    a7          | 19        #  802.11a-EHT (6E disables /n and /ac)
+
 
 wifi_settings flags are currently defined as:
     wpa_enable           | 0x10         # Enable WPA
@@ -5612,7 +5620,11 @@ class L3VariableTime(Realm):
             #     a/b/g/n/AC/AX (dual-band AX) support
             13: '802.11bgnAX',  # 802.11bgn-AX
             14: '802.11anAX',  # 802.11an-AX
-            15: '802.11aAX'  # 802.11a-AX (6E disables /n and /ac)
+            15: '802.11aAX',  # 802.11a-AX (6E disables /n and /ac)
+            16: '802.11abgnEHT',  # 802.11abgn-EHT  a/b/g/n/AC/AX/EHT (dual-band AX) support
+            17: '802.11bgnEHT',  # 802.11bgn-EHT
+            18: '802.11anEHT',  # 802.11an-ETH
+            19: '802.11aBE',  # 802.11a-EHT (6E disables /n and /ac)
         }
 
         for (
@@ -6223,6 +6235,8 @@ wifi_settings==wifi_settings,wifi_mode==0,enable_flags==8021x_radius&&80211r_pms
              --dut_serial_num 12345678
              --log_level debug
 
+        # Example : Wifi 7  6G LAN-4069
+
 SCRIPT_CLASSIFICATION:  Creation & Runs Traffic
 
 SCRIPT_CATEGORIES:  Performance, Functional,  KPI Generation,  Report Generation
@@ -6269,9 +6283,12 @@ BK, BE, VI, VO:  Optional wifi related Tos Settings.  Or, use your preferred num
              is automatically sent to this Queue.
 
 <wifi_mode>:
-    Input       : Enum Val  : Shown by nc_show_ports
+    Input       : Enum Val  : for list ,  telnet <mgr> 4001  , help add_profile
 
-    AUTO        |  0        #  802.11
+    Wifi_Mode
+    Input       : Enum Val  : Shown by nc_show_ports
+    <pre options='wifi_mode'>
+    AUTO        |  0        #  Best Available
     802.11a     |  1        #  802.11a
     b           |  2        #  802.11b
     g           |  3        #  802.11g
@@ -6288,6 +6305,13 @@ BK, BE, VI, VO:  Optional wifi related Tos Settings.  Or, use your preferred num
     bgnAX       | 13        #  802.11bgn-AX
     anAX        | 14        #  802.11an-AX
     aAX         | 15        #  802.11a-AX (6E disables /n and /ac)
+    abgn7       | 16        #  802.11abgn-EHT
+                            #     a/b/g/n/AC/AX/EHT (dual-band AX) support
+    bgn7        | 17        #  802.11bgn-EHT
+    an7         | 18        #  802.11an-EHT
+    a7          | 19        #  802.11a-EHT (6E disables /n and /ac)
+
+
 
 wifi_settings flags are currently defined as:
     wpa_enable           | 0x10         # Enable WPA

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -223,6 +223,70 @@ wifi_settings==wifi_settings,wifi_mode==0,enable_flags==8021x_radius&&80211r_pms
              --dut_serial_num 12345678
              --log_level debug
 
+        # Example : Wifi 7 2G 802.11bgn-ETH
+            ./test_l3.py\
+             --lfmgr 192.168.101.137\
+             --test_duration 2m\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==1.2.wiphy0,stations==19,ssid==TPink_C672,ssid_pw==19719207,security==wpa2,wifi_settings==wifi_settings,wifi_mode==17,enable_flags==(wpa2_enable&&80211u_enable)'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=200000000\
+             --side_b_min_bps=300000000\
+             --test_rig CT-US-008\
+             --test_tag 'test_l3_a7'\
+             --dut_model_num TP-link\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
+             --log_level debug\
+             --debug\
+             --no_cleanup
+
+        # Example : Wifi 7 5G 802.11bgn-ETH
+            ./test_l3.py\
+             --lfmgr 192.168.101.137\
+             --test_duration 2m\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==1.2.wiphy1,stations==19,ssid==TPink_C672_5G,ssid_pw==19719207,security==wpa2,wifi_settings==wifi_settings,wifi_mode==18,enable_flags==(wpa2_enable&&80211u_enable)'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=200000000\
+             --side_b_min_bps=300000000\
+             --test_rig CT-US-008\
+             --test_tag 'test_l3_a7'\
+             --dut_model_num TP-link\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
+             --log_level debug\
+             --debug\
+             --no_cleanup
+
+        # Example : Wifi 7 6G 802.11bgn-ETH
+            ./test_l3.py\
+             --lfmgr 192.168.101.137\
+             --test_duration 2m\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==1.2.wiphy2,stations==19,ssid==TPink_C672_6G,ssid_pw==19719207,security==wpa3,wifi_settings==wifi_settings,wifi_mode==19,enable_flags==(use-wpa3&&80211u_enable)'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=200000000\
+             --side_b_min_bps=300000000\
+             --test_rig CT-US-008\
+             --test_tag 'test_l3_a7'\
+             --dut_model_num TP-link\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
+             --log_level debug\
+             --debug\
+             --no_cleanup
+
+
 SCRIPT_CLASSIFICATION:  Creation & Runs Traffic
 
 SCRIPT_CATEGORIES:  Performance, Functional,  KPI Generation,  Report Generation
@@ -6235,7 +6299,69 @@ wifi_settings==wifi_settings,wifi_mode==0,enable_flags==8021x_radius&&80211r_pms
              --dut_serial_num 12345678
              --log_level debug
 
-        # Example : Wifi 7  6G LAN-4069
+        # Example : Wifi 7 2G 802.11bgn-ETH
+            ./test_l3.py\
+             --lfmgr 192.168.101.137\
+             --test_duration 2m\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==1.2.wiphy0,stations==19,ssid==TPink_C672,ssid_pw==19719207,security==wpa2,wifi_settings==wifi_settings,wifi_mode==17,enable_flags==(wpa2_enable&&80211u_enable)'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=200000000\
+             --side_b_min_bps=300000000\
+             --test_rig CT-US-008\
+             --test_tag 'test_l3_a7'\
+             --dut_model_num TP-link\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
+             --log_level debug\
+             --debug\
+             --no_cleanup
+
+        # Example : Wifi 7 5G 802.11bgn-ETH
+            ./test_l3.py\
+             --lfmgr 192.168.101.137\
+             --test_duration 2m\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==1.2.wiphy1,stations==19,ssid==TPink_C672_5G,ssid_pw==19719207,security==wpa2,wifi_settings==wifi_settings,wifi_mode==18,enable_flags==(wpa2_enable&&80211u_enable)'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=200000000\
+             --side_b_min_bps=300000000\
+             --test_rig CT-US-008\
+             --test_tag 'test_l3_a7'\
+             --dut_model_num TP-link\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
+             --log_level debug\
+             --debug\
+             --no_cleanup
+
+        # Example : Wifi 7 6G 802.11bgn-ETH
+            ./test_l3.py\
+             --lfmgr 192.168.101.137\
+             --test_duration 2m\
+             --polling_interval 5s\
+             --upstream_port 1.1.eth2\
+             --radio 'radio==1.2.wiphy2,stations==19,ssid==TPink_C672_6G,ssid_pw==19719207,security==wpa3,wifi_settings==wifi_settings,wifi_mode==19,enable_flags==(use-wpa3&&80211u_enable)'\
+             --endp_type lf_udp\
+             --rates_are_totals\
+             --side_a_min_bps=200000000\
+             --side_b_min_bps=300000000\
+             --test_rig CT-US-008\
+             --test_tag 'test_l3_a7'\
+             --dut_model_num TP-link\
+             --dut_sw_version 3.0.0.4.386_44266\
+             --dut_hw_version 1.0\
+             --dut_serial_num 12345678\
+             --log_level debug\
+             --debug\
+             --no_cleanup
+
 
 SCRIPT_CLASSIFICATION:  Creation & Runs Traffic
 


### PR DESCRIPTION
This commit updates the comments to show how to configure the wifi 7 and updated checking to allow wifi 7
    abgn7       | 16        #  802.11abgn-EHT
                            #     a/b/g/n/AC/AX/EHT (dual-band AX) support
    bgn7        | 17        #  802.11bgn-EHT
    an7         | 18        #  802.11an-EHT
    a7          | 19        #  802.11a-EHT (6E disables /n and /ac)
    
also updated was the comments with examples