### PR TITLE
LAN 4089 vap chan: Customer Request: Comcast-India customer ./lf_create_vap_cv.py script requirement

### DIFF
--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -383,8 +383,10 @@ INCLUDE_IN_README: False
                         help="Chamberview scenario name (by default: Automation")
     parser.add_argument("-vr", "--vap_radio", default="wiphy0",
                         help="vap radio name (by default: wiphy0")
-    parser.add_argument("-vf", "--vap_freq", default="2437",
-                        help="vap frequency (by default: 2437")
+    parser.add_argument("-vf", "--vap_freq",
+                        help="vap frequency, vap_frequency or vap_channel needs to be set")
+    parser.add_argument("-vc", "--vap_channel",
+                        help="vap channel,  vap_frequency or vap_channel needs to be set")
     parser.add_argument("-vs", "--vap_ssid", default="routed-AP",
                         help="vap ssid (by default: routed-AP")
     parser.add_argument("-vp", "--vap_passwd", default=None,
@@ -442,7 +444,34 @@ INCLUDE_IN_README: False
     vap_scenario_name = args.scenario_name
     vap_radio = args.vap_radio
     vap_upstream_port = args.vap_upstream_port
-    vap_freq = args.vap_freq
+    if args.vap_freq is not None:
+        vap_freq = args.vap_freq
+        logger.info("vap frequency {freq}".format(freq=vap_freq))
+    # conversion of 6e channel to frequency
+    # ch_6e = (f - 5000 )  / 5
+    # f = (ch_6e * 5) + 5000
+    elif args.vap_channel is not None:
+        if args.vap_channel != 'AUTO':
+            if 'e' in args.vap_channel:
+                channel_6e = args.vap_channel.replace('e', '')
+                vap_freq = ((int(channel_6e) + 190) * 5) + 5000
+                lf_6e_chan = int(channel_6e) + 190
+                logger.info("6e_chan: {chan} lf_6e_chan: {lf_chan} frequency: {freq}".format(chan=args.vap_channel, lf_chan=lf_6e_chan, freq=vap_freq))
+                # self.channel = lf_6e_chan
+            else:
+                if int(args.vap_channel) <= 13:
+                    # channel 1 is 2412 ,
+                    vap_freq = 2407 + int(args.vap_channel) * 5
+                elif int(args.vap_channel) == 14:
+                    vap_freq = 2484
+                # 5g or 6g Candela numbering
+                else:
+                    vap_freq = int(args.vap_channel) * 5 + 5000
+                logger.info("channel: {chan}  frequency: {freq}".format(chan=args.vap_channel, freq=vap_freq))
+    elif args.vap_freq is None and args.vap_channel is None:
+        logger.error("vap_freq or vap_channel must be entered as an argument")
+        exit(1)
+
     vap_ssid = args.vap_ssid
     vap_passwd = args.vap_passwd
     vap_security = args.vap_security

--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -50,7 +50,7 @@ EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and opt
             --vap_bw 20\
             --vap_upstream_port 1.1.eth2
 
-            # Basic 5GHz vAP configuration using 
+            # Basic 5GHz vAP configuration using
 
             # VSCode launch JSON
             "args": ["--mgr","192.168.50.104",
@@ -400,7 +400,7 @@ EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and opt
             --vap_bw 20\
             --vap_upstream_port 1.1.eth2
 
-            # Basic 5GHz vAP configuration using 
+            # Basic 5GHz vAP configuration using
 
             # VSCode launch JSON
             "args": ["--mgr","192.168.50.104",

--- a/py-scripts/lf_create_vap_cv.py
+++ b/py-scripts/lf_create_vap_cv.py
@@ -19,21 +19,41 @@ EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and opt
             # Load an existing Chamber View scenario
             ./lf_create_vap_cv.py --mgr 192.168.200.222 --port 8080 --load_existing_scenario --old_scenario_name hello --instance_name oldscenario
 
-            # Basic 2.4GHz vAP configuration using VSCode launch JSON
-            "args": ["--mgr","localhost",
+            # Basic 2.4GHz vAP configuration
+
+            # VSCode launch JSON
+            "args": ["--mgr","192.168.50.104",
                 "--port", "8080",
                 "--lf_user", "lanforge",
                 "--lf_password", "lanforge",
-                "--vap_radio", "wiphy0",
-                "--vap_freq", "36",
+                "--delete_old_scenario",
+                "--vap_radio", "wiphy1",
+                "--vap_channel", "36",
                 "--vap_ssid", "test_vap",
                 "--vap_passwd", "password",
                 "--vap_security", "wpa2",
-                "--vap_upstream_port", "1.1.eth1"
+                "--vap_upstream_port", "1.1.eth2"
             ]
 
-            # Basic 5GHz vAP configuration using VSCode launch JSON
-            "args": ["--mgr","192.168.0.104",
+            # command line
+            ./lf_create_vap_cv.py\
+            --mgr 192.168.50.104\
+            --port 8080\
+            --lf_user lanforge\
+            --lf_password lanforge\
+            --delete_old_scenario\
+            --vap_radio wiphy1\
+            --vap_freq 36\
+            --vap_ssid test_vap\
+            --vap_passwd password\
+            --vap_security wpa2\
+            --vap_bw 20\
+            --vap_upstream_port 1.1.eth2
+
+            # Basic 5GHz vAP configuration using 
+
+            # VSCode launch JSON
+            "args": ["--mgr","192.168.50.104",
                 "--port", "8080",
                 "--lf_user", "lanforge",
                 "--lf_password", "lanforge",
@@ -47,6 +67,39 @@ EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and opt
                 "--vap_bw", "20",
                 "--vap_upstream_port", "1.1.eth2"
             ]
+
+            # command line
+            ./lf_create_vap_cv.py\
+            --mgr 192.168.50.104\
+            --port 8080\
+            --lf_user lanforge\
+            --lf_password lanforge\
+            --delete_old_scenario\
+            --vap_radio wiphy3\
+            --vap_freq 5660\
+            --vap_ssid mtk7915_5g\
+            --vap_passwd lf_mtk7915_5g\
+            --vap_security wpa2\
+            --vap_bw 20\
+            --vap_upstream_port 1.1.eth2
+
+            # 6g passing in the --vap_channel
+            # command line
+            ./lf_create_vap_cv.py\
+            --mgr 192.168.101.137\
+            --port 8080\
+            --lf_user lanforge\
+            --lf_password lanforge\
+            --delete_old_scenario\
+            --scenario_name at7_vap_chan\
+            --vap_radio 1.2.wiphy2\
+            --vap_channel 1e\
+            --vap_ssid at7_6g\
+            --vap_passwd hello123\
+            --vap_security wpa3\
+            --vap_bw 320\
+            --vap_upstream_port 1.1.eth2
+
 
 SCRIPT_CLASSIFICATION:
             Creation
@@ -316,21 +369,41 @@ EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and opt
             # Load an existing Chamber View scenario
             ./lf_create_vap_cv.py --mgr 192.168.200.222 --port 8080 --load_existing_scenario --old_scenario_name hello --instance_name oldscenario
 
-            # Basic 2.4GHz vAP configuration using VSCode launch JSON
-            "args": ["--mgr","localhost",
+            # Basic 2.4GHz vAP configuration
+
+            # VSCode launch JSON
+            "args": ["--mgr","192.168.50.104",
                 "--port", "8080",
                 "--lf_user", "lanforge",
                 "--lf_password", "lanforge",
-                "--vap_radio", "wiphy0",
-                "--vap_freq", "36",
+                "--delete_old_scenario",
+                "--vap_radio", "wiphy1",
+                "--vap_channel", "36",
                 "--vap_ssid", "test_vap",
                 "--vap_passwd", "password",
                 "--vap_security", "wpa2",
-                "--vap_upstream_port", "1.1.eth1"
+                "--vap_upstream_port", "1.1.eth2"
             ]
 
-            # Basic 5GHz vAP configuration using VSCode launch JSON
-            "args": ["--mgr","192.168.0.104",
+            # command line
+            ./lf_create_vap_cv.py\
+            --mgr 192.168.50.104\
+            --port 8080\
+            --lf_user lanforge\
+            --lf_password lanforge\
+            --delete_old_scenario\
+            --vap_radio wiphy1\
+            --vap_freq 36\
+            --vap_ssid test_vap\
+            --vap_passwd password\
+            --vap_security wpa2\
+            --vap_bw 20\
+            --vap_upstream_port 1.1.eth2
+
+            # Basic 5GHz vAP configuration using 
+
+            # VSCode launch JSON
+            "args": ["--mgr","192.168.50.104",
                 "--port", "8080",
                 "--lf_user", "lanforge",
                 "--lf_password", "lanforge",
@@ -344,6 +417,39 @@ EXAMPLE:    Use './lf_create_vap_cv.py --help' to see command line usage and opt
                 "--vap_bw", "20",
                 "--vap_upstream_port", "1.1.eth2"
             ]
+
+            # command line
+            ./lf_create_vap_cv.py\
+            --mgr 192.168.50.104\
+            --port 8080\
+            --lf_user lanforge\
+            --lf_password lanforge\
+            --delete_old_scenario\
+            --vap_radio wiphy3\
+            --vap_freq 5660\
+            --vap_ssid mtk7915_5g\
+            --vap_passwd lf_mtk7915_5g\
+            --vap_security wpa2\
+            --vap_bw 20\
+            --vap_upstream_port 1.1.eth2
+
+            # 6g passing in the --vap_channel
+            # command line
+            ./lf_create_vap_cv.py\
+            --mgr 192.168.101.137\
+            --port 8080\
+            --lf_user lanforge\
+            --lf_password lanforge\
+            --delete_old_scenario\
+            --scenario_name at7_vap_chan\
+            --vap_radio 1.2.wiphy2\
+            --vap_channel 1e\
+            --vap_ssid at7_6g\
+            --vap_passwd hello123\
+            --vap_security wpa3\
+            --vap_bw 320\
+            --vap_upstream_port 1.1.eth2
+
 
 SCRIPT_CLASSIFICATION:
             Creation


### PR DESCRIPTION
LAN-4089 : Customer Request: Comcast-India customer ./lf_create_vap_cv.py script requirement

This Jira is to add the ability to pass in a channel when creating a vap. Verified:
            # 6g passing in the --vap_channel
            # command line
            ./lf_create_vap_cv.py\
            --mgr 192.168.101.137\
            --port 8080\
            --lf_user lanforge\
            --lf_password lanforge\
            --delete_old_scenario\
            --scenario_name at7_vap_chan\
            --vap_radio 1.2.wiphy2\
            --vap_channel 1e\
            --vap_ssid at7_6g\
            --vap_passwd hello123\
            --vap_security wpa3\
            --vap_bw 320\
            --vap_upstream_port 1.1.eth2


