### PR TITLE
test_group_profile.py: fix to test profiles with only one group. Expa…

### DIFF
--- a/py-json/test_group_profile.py
+++ b/py-json/test_group_profile.py
@@ -59,8 +59,13 @@ class TestGroupProfile(LFCliBase):
         # This breaks on only one existing group, this expects an array not a single object
         if test_groups is not None and "groups" in test_groups:
             test_groups = test_groups["groups"]
+            if isinstance(test_groups, dict):
+                if test_groups['name'] == self.group_name:
+                    return True
+                else:
+                    return False
             for group in test_groups:
-                for k, v in group.items():
+                for _, v in group.items():
                     if v['name'] == self.group_name:
                         return True
         else:
@@ -87,6 +92,10 @@ class TestGroupProfile(LFCliBase):
         test_groups = self.local_realm.json_get("/testgroups/all")
         if test_groups is not None:
             test_groups = test_groups["groups"]
+            # if single test_group is not empty
+            if not isinstance(test_groups, list):
+                if test_groups['name'] == self.group_name:
+                    return test_groups['cross connects']
             for group in test_groups:
                 for k, v in group.items():
                     if v['name'] == self.group_name:


### PR DESCRIPTION
…nds fixes from d69f0e6 to the list_cxs method.

Verification:
./test_fileio.py --macvlan_parent eth1 --num_ports 2 --use_macvlans --first_mvlan_ip 192.168.48.15 --netmask 255.255.255.0 --gateway 192.168.45.24 --test_duration 1m --use_test_groups --write_only_test_group cgio-0000 --read_only_test_group cgio-0000 ./test_fileio.py --macvlan_parent eth1 --num_ports 2 --use_macvlans --first_mvlan_ip 192.168.48.15 --netmask 255.255.255.0 --gateway 192.168.45.24 --test_duration 1m --use_test_groups --write_only_test_group cgio-0000 --read_only_test_group cgio-0001
Signed-off-by: Liam Reynolds <liam.reynolds@candelatech.com>