### PR TITLE
Add bugbear linting, ignore failing file errors for now

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,3 +12,44 @@ exclude =
     virtualenv
     py-scripts/sandbox
     py-scripts/scripts_deprecated
+
+per-file-ignores =
+    # Temporarily ignore specific issues for failing scripts in
+    # 'py-scripts/tools/' directory until fixed
+    py-scripts/tools/lf_check.py: B007,B020,B036
+    py-scripts/tools/lf_cli_to_launchjson.py: B006
+    py-scripts/tools/lf_inspect.py: B006
+    py-scripts/tools/lf_test_gen/lf_test_gen.py: B006,B036
+
+    # Temporarily ignore specific issues in failing interop scripts until fixed
+    py-scripts/DeviceConfig.py: B006,B036
+    py-scripts/lf_interop_ping.py: B006,B036
+    py-scripts/lf_interop_ping_plotter.py: B036
+    py-scripts/lf_interop_port_reset_test.py: B007
+    py-scripts/lf_interop_real_browser_test.py: B006,B007,B023
+    py-scripts/lf_interop_rvr_test.py: B006,B007,B018
+    py-scripts/lf_interop_video_streaming.py: B006,B007,B036
+    py-scripts/lf_mixed_traffic.py: B015,B036
+    py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py: B006,B007,B036
+    py-scripts/real_application_tests/youtube/lf_interop_youtube.py: B006,B007,B036
+    py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py: B007,B036
+
+    # Temporarily ignore specific issues in other failing scripts
+    py-scripts/lf_graph.py: B006
+    py-scripts/lf_multipsk.py: B007,B018
+    py-scripts/lf_pcap.py: B007,B016
+    py-scripts/lf_ping_sweep.py: B036
+    py-scripts/lf_rf_char.py: B006,B007,B036
+    py-scripts/lf_roam_test.py: B007,B012
+    py-scripts/lf_rx_sensitivity_test.py: B006,B036
+    py-scripts/lf_snp_test.py: B007
+    py-scripts/run_voip_cx.py: B006
+    py-scripts/ssh_remote.py: F824
+    py-scripts/sta_connect.py: B007
+    py-scripts/sta_connect2.py: B007
+    py-scripts/sta_scan_test.py: B007,B018
+    py-scripts/test_ip_connection.py: B007
+    py-scripts/test_ip_variable_time.py: B018
+    py-scripts/test_l3_longevity.py: B007
+    py-scripts/test_l3_powersave_traffic.py: B007
+    py-scripts/test_l3_unicast_traffic_gen.py: B006,B007,B036

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: flake8 Lint
         uses: py-actions/flake8@v2
-        #with:
-        #  plugins: "flake8-bugbear"
+        with:
+          plugins: "flake8-bugbear"
 
   help-check:
     # Tie runner to Ubuntu 22.04 LTS, as it still supports Python 3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
       rev: 7.0.0
       hooks:
         - id: flake8
-          #additional_dependencies:
-          #    - "flake8-bugbear"
+          additional_dependencies:
+              - "flake8-bugbear"
 
     #- repo: https://github.com/shellcheck-py/shellcheck-py
     #  rev: v0.9.0.5


### PR DESCRIPTION
More details provided in internal chat, but this introduces use of `flake8-bugbear` plugin for more aggressive linting both in GitHub Actions linting workflow as well as in the `pre-commit` configuration.

This presently will ignore specific errors in files which fail, while still linting the rest of the file. Goal is to slowly fix these as we work on them going forward.