### PR TITLE
Add temp_graph.py to py-scripts

### DIFF
--- a/py-scripts/temp_graph.py
+++ b/py-scripts/temp_graph.py
@@ -1,7 +1,28 @@
 #!/bin/env python3
 """
-Small program that parses temperature data from an input file,
-then saves the data in a clean csv file and presents a graph of it.
+NAME: temp_graph.py
+
+PURPOSE:
+temp_graph.py will take heatmon temperature logs and create parsed CSVs
+and optional graphical reports.
+
+EXAMPLE (only creating CSVs):
+    ./temp_graph.py -i heat_log.txt
+
+EXAMPLE (rendering an interactive graph of the data):
+    ./temp_graph.py -i heat_log.txt -g
+
+EXAMPLE (creating an html report page):
+    ./temp_graph.py -i heat_log.txt -r
+
+EXAMPLE (reporting with a band chart):
+    ./temp_graph.py -i heat_log.txt -r -m band
+
+STATUS: UNDER DEVELOPMENT
+
+COPYRIGHT:
+    Copyright 2025 Candela Technologies Inc
+    License: Free to distribute and modify. LANforge systems must be licensed.
 """
 import argparse
 import re

--- a/py-scripts/temp_graph.py
+++ b/py-scripts/temp_graph.py
@@ -1,0 +1,196 @@
+#!/bin/env python3
+"""
+Small program that parses temperature data from an input file,
+then saves the data in a clean csv file and presents a graph of it.
+"""
+import argparse
+import re
+import csv
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import time
+import os
+
+_out_dir = "Temp_Graphing_"
+_max_legend_entries = 4
+
+
+def _next_table_name(num: int, timestamp: str, core=False) -> str:
+    p_num = str(num).zfill(3)
+    c = "Core" if core else ""
+    return f"{_out_dir}{timestamp}/{c}temp_csv_{p_num}.csv"
+
+
+def _next_png_name(num: int) -> str:
+    p_num = str(num).zfill(3)
+    return f"temperature_data_{p_num}.png"
+
+
+def _switch_out_files(tables, num: int, timestamp):
+    tables.append(open(_next_table_name(num, timestamp), 'w+', newline=''))
+    tables.append(open(_next_table_name(num+1, timestamp, True),
+                       'w+', newline=''))
+    rad_writer = csv.writer(tables[num])
+    core_writer = csv.writer(tables[num + 1])
+    rad_writer.writerow(['datetime', 'device', 'temperature'])
+    core_writer.writerow(['datetime', 'device', 'temperature'])
+    return rad_writer, core_writer
+
+
+def _get_graph_title(df, num, rig):
+    dt = df['datetime'].iloc
+    start_d = f"{str(dt[0].month)}/{str(dt[0].day)}"
+    start_t = f"{str(dt[0].hour)}:{str(dt[0].minute)}"
+    end_d = f"{str(dt[-1].month)}/{str(dt[-1].day)}"
+    end_t = f"{str(dt[-1].hour)}:{str(dt[-1].minute)}"
+    dev = "Cores" if num % 2 == 0 else "Radios"
+    return f"{rig} {dev} From {start_d} {start_t} to {end_d} {end_t}"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--inputfile", help="The path to the input file",
+                        default=None)
+    parser.add_argument("-g", "--graph", help="display a graph of the data",
+                        default=False, action="store_true")
+    parser.add_argument("-m", "--mode", help="change style of graph created",
+                        default="all")
+    parser.add_argument("-s", "--save_output",
+                        help="saves the output graphs as PNGs",
+                        default=False, action="store_true")
+    parser.add_argument("-r", "--report",
+                        help="create an index.html page with the graph(s)",
+                        default=False, action="store_true")
+    parser.add_argument("-c", "--cutoff", default=20,
+                        help="max time in minutes between two table entries")
+    # TODO: ADD A --HELP ARGUMENT
+    args = parser.parse_args()
+
+    # Try to safely open the files passed to us
+    try:
+        in_file = open(args.inputfile, "r")
+    except OSError:
+        print("Unable to open input file " + args.inputfile)
+        exit(1)
+
+    _tstamp = time.ctime()[4:13].replace(' ', '_')
+    try:
+        os.makedirs((_out_dir + _tstamp), exist_ok=True)
+    except OSError:
+        print("Error creating output directory")
+        exit(1)
+    """
+    TODO: update this documentation to explain the multi-charting process
+
+    Look through each line of the input file. Each line should be in the form:
+    MON DD HH:MM:SS .(*?) [({"A":"DEVICENAME", "T":(TEMP|null)})*?]
+    The number of (A,T) pairs may differ from line to line.
+    The values of T may be null due to issues in temperature reporting.
+
+    A line with n (A,T) pairs will be written into output file as n lines,
+    with each (A,T) pair having its own line. This is for ease of graphing.
+    """
+
+    rig = None
+    out_tables = []
+    table_stats = []
+    rad_writer, core_writer = _switch_out_files(out_tables,
+                                                len(out_tables), _tstamp)
+    prev_date = None
+    for line in in_file:
+        # Skip lines that we suspect don't fit our pattern
+        if line.find("heatmon") == -1 or line.find("ERROR") != -1:
+            continue
+        mon = time.strptime(line[:3], '%b').tm_mon
+        t = pd.to_datetime(line[4:15], format='%d %H:%M:%S')
+        t = t.replace(month=mon, year=time.localtime().tm_year)
+        if prev_date and (t - prev_date).seconds > (int(args.cutoff) * 60):
+            # Switch to new table
+            rad_writer, core_writer = _switch_out_files(out_tables,
+                                                        len(out_tables),
+                                                        _tstamp)
+        prev_date = t
+        if rig is None:
+            rig = re.search(r':.. .*? ', line)
+            rig = rig.group(0)[4:-1] if rig else None
+        device_matches = re.finditer(r'A":"(.*?)"', line)
+        temp_matches = re.finditer(r'T":(.*?|null)}', line)
+        devices = []
+        temps = []
+        for device_match in device_matches:
+            devices.append(device_match.group(1))
+        for temp_match in temp_matches:
+            temps.append(temp_match.group(1))
+        for i in range(len(devices)):
+            if "core" in devices[i]:
+                core_writer.writerow([t, devices[i], temps[i]])
+            else:
+                rad_writer.writerow([t, devices[i], temps[i]])
+
+    for file in out_tables:
+        file.flush()
+        file.close()
+
+    in_file.close()
+
+    date_format = mdates.DateFormatter('%H:%M')
+
+    for file_num in range(len(out_tables)):
+        file = out_tables[file_num]
+        df = pd.read_csv(file.name)
+        df['datetime'] = pd.to_datetime(df['datetime'],
+                                        format="%Y-%m-%d %H:%M:%S")
+        _, ax = plt.subplots()
+        min_temps = df.groupby('datetime')['temperature'].min()
+        max_temps = df.groupby('datetime')['temperature'].max()
+        mean_temps = df.groupby('datetime')['temperature'].mean()
+        if args.mode == "band":
+            plt.plot(mean_temps.index, mean_temps.values, color='red')
+        if args.mode == "all":
+            for device, sub_df in df.groupby('device'):
+                sub_df.plot(ax=ax, x='datetime',
+                            y='temperature', label=device, x_compat=True)
+            ax.legend(title='devices')
+            plt.legend(bbox_to_anchor=(1, 1))
+        _, labels = plt.gca().get_legend_handles_labels()
+        table_stats.append({
+            'min': df['temperature'].min(),
+            'max': df['temperature'].max(),
+            'avg': round(df['temperature'].mean(), 2)
+        })
+        ax.xaxis.set_major_formatter(date_format)
+        plt.title(_get_graph_title(df, file_num, rig))
+        plt.xlabel("Time")
+        plt.ylabel("Temperature (" + chr(176) + "C)")
+        if args.mode == "band":
+            plt.fill_between(min_temps.index,
+                             min_temps.values,
+                             max_temps.values,
+                             color='blue', alpha=0.3)
+        _, labels = plt.gca().get_legend_handles_labels()
+        if args.mode != "band" and len(labels) > _max_legend_entries:
+            plt.gca().get_legend().remove()
+        if args.save_output or args.report:
+            plt.savefig(_out_dir + _tstamp + "/" + _next_png_name(file_num))
+        if args.graph:
+            plt.show()
+
+    if args.report:
+        # write an index.html page with the graphs we made
+        with open(_out_dir + _tstamp + '/report' + '.html', 'w') as f:
+            f.write("<!DOCTYPE HTML> \n <html> \n <b>")
+            for file_num in range(len(out_tables)):
+                f.write('<img src=\"' +
+                        _next_png_name(file_num) +
+                        '\" alt=\"graph 1\">')
+                f.write('<table><tr><th>Min </th>')
+                f.write('<th> Max </th><th> Avg</th></tr>')
+                f.write(f'<td>{table_stats[file_num]['min']}</td>')
+                f.write(f'<td>{table_stats[file_num]['max']}</td>')
+                f.write(f'<td>{table_stats[file_num]['avg']}</td>')
+                f.write('</table>')
+            f.write("</b> \n </html>")
+
+
+main()

--- a/py-scripts/temp_graph.py
+++ b/py-scripts/temp_graph.py
@@ -5,6 +5,7 @@ NAME: temp_graph.py
 PURPOSE:
 temp_graph.py will take heatmon temperature logs and create parsed CSVs
 and optional graphical reports.
+First obtain heatmon output from journalctl -t heatmon > log.txt
 
 EXAMPLE (only creating CSVs):
     ./temp_graph.py -i heat_log.txt
@@ -76,7 +77,7 @@ def main():
     help_summary = '''\
 temp_graph creates a graph of device temperature data over time using
 a log file passed with -i that can be generated
-using the shell command 'journalctl -t heatmon'
+using the shell command 'journalctl -t heatmon > log.txt'
 
 This file is then parsed into a series of CSVs and optionally:
 -a set of graph pngs (-s)

--- a/py-scripts/temp_graph.py
+++ b/py-scripts/temp_graph.py
@@ -9,9 +9,6 @@ and optional graphical reports.
 EXAMPLE (only creating CSVs):
     ./temp_graph.py -i heat_log.txt
 
-EXAMPLE (rendering an interactive graph of the data):
-    ./temp_graph.py -i heat_log.txt -g
-
 EXAMPLE (creating an html report page):
     ./temp_graph.py -i heat_log.txt -r
 
@@ -82,15 +79,12 @@ a log file passed with -i that can be generated
 using the shell command 'journalctl -t heatmon'
 
 This file is then parsed into a series of CSVs and optionally:
--an interactive graph (-g)
 -a set of graph pngs (-s)
 -an html report page (-r)
 '''
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--inputfile", help="The path to the input file",
                         default=None)
-    parser.add_argument("-g", "--graph", help="display a graph of the data",
-                        default=False, action="store_true")
     parser.add_argument("-m", "--mode", help="change style of graph created",
                         default="all")
     parser.add_argument("-s", "--save_output",
@@ -215,8 +209,6 @@ This file is then parsed into a series of CSVs and optionally:
             plt.gca().get_legend().remove()
         if args.save_output or args.report:
             plt.savefig(_out_dir + _tstamp + "/" + _next_png_name(file_num))
-        if args.graph:
-            plt.show()
 
     if args.report:
         # write a report.html page with the graphs we made

--- a/py-scripts/temp_graph.py
+++ b/py-scripts/temp_graph.py
@@ -18,7 +18,13 @@ EXAMPLE (creating an html report page):
 EXAMPLE (reporting with a band chart):
     ./temp_graph.py -i heat_log.txt -r -m band
 
-STATUS: UNDER DEVELOPMENT
+SCRIPT_CATEGORIES: Report Generation
+
+STATUS: Under Development
+
+VERIFIED_ON: AUGUST 2025,
+             GUI Version: 5.5.1
+             Kernel Version: 6.11.12+
 
 COPYRIGHT:
     Copyright 2025 Candela Technologies Inc
@@ -70,6 +76,16 @@ def _get_graph_title(df, num, rig):
 
 
 def main():
+    help_summary = '''\
+temp_graph creates a graph of device temperature data over time using
+a log file passed with -i that can be generated
+using the shell command 'journalctl -t heatmon'
+
+This file is then parsed into a series of CSVs and optionally:
+-an interactive graph (-g)
+-a set of graph pngs (-s)
+-an html report page (-r)
+'''
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--inputfile", help="The path to the input file",
                         default=None)
@@ -81,12 +97,17 @@ def main():
                         help="saves the output graphs as PNGs",
                         default=False, action="store_true")
     parser.add_argument("-r", "--report",
-                        help="create an index.html page with the graph(s)",
+                        help="create a report.html page with the graph(s)",
                         default=False, action="store_true")
     parser.add_argument("-c", "--cutoff", default=20,
                         help="max time in minutes between two table entries")
-    # TODO: ADD A --HELP ARGUMENT
+    parser.add_argument("--help_summary", default=False, action="store_true")
+
     args = parser.parse_args()
+
+    if args.help_summary:
+        print(help_summary)
+        exit(0)
 
     # Try to safely open the files passed to us
     try:
@@ -102,7 +123,7 @@ def main():
         print("Error creating output directory")
         exit(1)
     """
-    TODO: update this documentation to explain the multi-charting process
+    todo: update this documentation to explain the multi-charting process
 
     Look through each line of the input file. Each line should be in the form:
     MON DD HH:MM:SS .(*?) [({"A":"DEVICENAME", "T":(TEMP|null)})*?]
@@ -198,7 +219,7 @@ def main():
             plt.show()
 
     if args.report:
-        # write an index.html page with the graphs we made
+        # write a report.html page with the graphs we made
         with open(_out_dir + _tstamp + '/report' + '.html', 'w') as f:
             f.write("<!DOCTYPE HTML> \n <html> \n <b>")
             for file_num in range(len(out_tables)):
@@ -207,9 +228,9 @@ def main():
                         '\" alt=\"graph 1\">')
                 f.write('<table><tr><th>Min </th>')
                 f.write('<th> Max </th><th> Avg</th></tr>')
-                f.write(f'<td>{table_stats[file_num]['min']}</td>')
-                f.write(f'<td>{table_stats[file_num]['max']}</td>')
-                f.write(f'<td>{table_stats[file_num]['avg']}</td>')
+                f.write(f'<td>{table_stats[file_num]["min"]}</td>')
+                f.write(f'<td>{table_stats[file_num]["max"]}</td>')
+                f.write(f'<td>{table_stats[file_num]["avg"]}</td>')
                 f.write('</table>')
             f.write("</b> \n </html>")
 


### PR DESCRIPTION
Temp_graph is a small script that parses the output from _journalctl -t heatmon_ into a series of CSVs (separated by timeframe and device type (radio/core)). It then can produce a report page with a series of graphs for each of these tables. This makes it easier to visually report temperature stats when testing systems. I originally wrote this script independently a few months before coming to CT, but have rewritten most of it in the last week to be more useful and visually appealing.

Design Notes:
-This script uses the matplotlib library to create its graphs. This library is used in other places in the lanforge codebase, but may not be the most robust option in the long run.
-The regex used to parse lines from _journalctl -t heatmon_ is pretty specific and will break (but will be easy to fix) if there is a change to the formatting of heatmon. There is currently no option to directly pass in CSV files or to specify a pattern.
-The script creates CSV files, PNG files, and HTML files. These outputs are stored in a directory named Temp_Graphing_MON_D_H. I don't know how well this fits with our design standards. 