### PR TITLE
Check large files vnc logs, and other fixes for AT7

### DIFF
--- a/check_large_files.bash
+++ b/check_large_files.bash
@@ -1084,11 +1084,11 @@ survey_pcap_files() {
 
 removable_lflogs=()
 survey_lflogs() {
-    debug "Surveying lanforge, wpa_supplicant nginx and hostapd logs"
+    debug "Surveying hostapd, lanforge, nginx, vnc and wpa_supplicant logs"
     local fsiz=0
     local fnum=0
     cd /home/lanforge
-    local directories="./vr_conf/ ./wifi/ ./l4logs/ /usr/local/lanforge/nginx/ /var/log/httpd/"
+    local directories=".vnc/ ./vr_conf/ ./wifi/ ./l4logs/ /usr/local/lanforge/nginx/"
     if [[ -d .l3helper ]]; then
       directories="$directories ./l3helper/"
     fi
@@ -1112,6 +1112,7 @@ survey_lflogs() {
             -o -iname 'wpa_supplicant_log_*'     \
             -o -iname 'gnuforge_log_*'           \
             -o -iname 'helper_shared_log_*'      \
+            -o -iname '*:1.log'                  \
         \) -print0 > /tmp/removable_lflogs.txt ||:)
     fnum=$( grep -cz '' /tmp/removable_lflogs.txt )
     #printf '      %s\n' "${removable_lflogs[@]}"

--- a/check_large_files.bash
+++ b/check_large_files.bash
@@ -743,7 +743,7 @@ survey_kernel_files() {
         done < <(echo  "${!kernel_sort_names[@]}" | sort | head -n -1)
     fi
 
-    debug "Module directories elegible for removal: "
+    debug "Module directories eligible for removal: "
     for file in "${lib_module_dirs[@]}"; do
         file=${file#/lib/modules/}
         # debug "/lib/modules/ ... $file"
@@ -779,7 +779,11 @@ survey_kernel_files() {
     #fi
     # set +veux
 
-    local boot_image_sz=$(du -hc "${kernel_files[@]}" | awk '/total/{print $1}')
+    local boot_image_sz=0
+    # On AT7 there will be none of these files
+    if (( ${#kernel_files[@]} > 0 )); then
+        boot_image_sz=$(du -hc "${kernel_files[@]}" | awk '/total/{print $1}')
+    fi
     local lib_dir_sz=$(du -hc "${lib_module_dirs[@]}" | awk '/total/{print $1}')
     totals[b]="kernels: $boot_image_sz, modules: $lib_dir_sz"
 

--- a/check_large_files.bash
+++ b/check_large_files.bash
@@ -1092,6 +1092,11 @@ survey_lflogs() {
     if [[ -d .l3helper ]]; then
       directories="$directories ./l3helper/"
     fi
+    if [[ -d /var/log/httpd ]]; then
+        directories="$directories  /var/log/httpd/"
+    elif [[ -d /var/log/apache2 ]]; then
+        directories="$directories  /var/log/apache2/"
+    fi
     mapfile -d '' removable_lflogs < <( find $directories \
         -type f -a \( \
                -iname 'error.log'                \


### PR DESCRIPTION
- Adds .vnc/*1:.log files
- Corrects apache log directory name for AT7
- fixes listing kernel used space for AT7