### PR TITLE
Lf update

### DIFF
--- a/cc_module_uci.py
+++ b/cc_module_uci.py
@@ -22,8 +22,9 @@ def get_jump_function(params: dict):
     def jump_through_vrf(conn: Driver):
         # ./vrf_exec.bash eth1 ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa root@192.168.215.113
 
+        # jump_cmd = f'./vrf_exec.bash eth1 ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa root@192.168.215.198'
         # jump_cmd = f'./vrf_exec.bash eth1 ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa root@192.168.215.113'
-        jump_cmd = f'./vrf_exec.bash {params['upstream_port']} ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa {params['auth_username']}@{params['host']}'
+        jump_cmd = f"./vrf_exec.bash {params['upstream_port']} ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa {params['auth_username']}@{params['host']}"
 
         # This happens after login completes
         conn.channel.send_input(jump_cmd, eager=True, strip_prompt=False)

--- a/lf_tx_power.py
+++ b/lf_tx_power.py
@@ -421,6 +421,7 @@ def main():
     parser.add_argument("--series", type=str, help="[controller configuration] controller series --series 9800", required=True)
     parser.add_argument("--band", type=str, help="band testing --band 6g", choices=["5g", "24g", "6g", "dual_band_5g", "dual_band_6g"])
     parser.add_argument("--module", type=str, help="[controller configuration] series module (cc_module_9800_3504.py)  --module cc_module_9800_3504 ", required=True)
+    parser.add_argument("--module_scrapli", help="[controller configuration] the module is a scrapli module so needs lanforge information for jump host ", action='store_true')
     parser.add_argument("--timeout", type=str, help="[controller configuration] controller command timeout --timeout 3 ", default=3)
 
     # AP configuration
@@ -617,19 +618,38 @@ def main():
     # dynamic import of the controller module
     series = importlib.import_module(args.module)
 
-    # create the controller , cs is controller scheme
-    cs = series.create_controller_series_object(
-        scheme=args.scheme,
-        dest=args.dest,
-        user=args.user,
-        passwd=args.passwd,
-        prompt=args.prompt,
-        series=args.series,
-        ap=args.ap,
-        ap_band_slot_6g=args.ap_band_slot_6g,
-        port=args.port,
-        band=args.band,
-        timeout=args.timeout)
+    if args.module_scrapli:
+        # create the controller , cs is controller scheme
+        cs = series.create_controller_series_object(
+            scheme=args.scheme,
+            dest=args.dest,
+            user=args.user,
+            passwd=args.passwd,
+            prompt=args.prompt,
+            series=args.series,
+            ap=args.ap,
+            ap_band_slot_6g=args.ap_band_slot_6g,
+            port=args.port,
+            band=args.band,
+            timeout=args.timeout,
+            lfmgr=args.lfmgr,
+            lfuser=args.lfuser,
+            lfpasswd=args.lfpasswd,
+            upstream_port=args.upstream_port)
+    else:
+        # create the controller , cs is controller scheme
+        cs = series.create_controller_series_object(
+            scheme=args.scheme,
+            dest=args.dest,
+            user=args.user,
+            passwd=args.passwd,
+            prompt=args.prompt,
+            series=args.series,
+            ap=args.ap,
+            ap_band_slot_6g=args.ap_band_slot_6g,
+            port=args.port,
+            band=args.band,
+            timeout=args.timeout)
     cs.wlan = args.wlan
     cs.wlanID = args.wlanID
     cs.wlanSSID = args.wlanSSID


### PR DESCRIPTION
Updates for hfcl module and lf_tx_power support
Added ability to pass is the lanforge ip, lf user, lf password and upstream port  so the hfcl module would not be hardcoded.

lf_tx_power was updated to add parameter --module_scrapli to have the additional parameters passed in.