### PR TITLE
Kpi csv

### DIFF
--- a/py-scripts/lf_ap_auto_test.py
+++ b/py-scripts/lf_ap_auto_test.py
@@ -511,7 +511,14 @@ the options and how best to input data.
     if CV_Test.kpi_results_present():
         logger.info("lf_ap_auto_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_ap_auto_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
     if CV_Test.passes():

--- a/py-scripts/lf_continuous_throughput_test.py
+++ b/py-scripts/lf_continuous_throughput_test.py
@@ -512,7 +512,14 @@ def main():
     if cv_test_inst.kpi_results_present():
         logger.info("lf_continuous_throughput_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_continuous_throughput_test did not generate kpi.csv")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
     if cv_test_inst.passes():

--- a/py-scripts/lf_dataplane_test.py
+++ b/py-scripts/lf_dataplane_test.py
@@ -968,7 +968,14 @@ def main():
     if CV_Test.kpi_results_present():
         logger.info("lf_dataplane_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_dataplane_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
     if CV_Test.passes():

--- a/py-scripts/lf_hunt_test.py
+++ b/py-scripts/lf_hunt_test.py
@@ -716,7 +716,14 @@ INCLUDE_IN_README: False
     if CV_Test.kpi_results_present():
         logger.info("lf_hunt_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_hunt_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
     if CV_Test.passes():

--- a/py-scripts/lf_port_reset_test.py
+++ b/py-scripts/lf_port_reset_test.py
@@ -432,7 +432,14 @@ INCLUDE_IN_README: False
     if CV_Test.kpi_results_present():
         logger.info("lf_port_reset_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_port_reset_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
     if CV_Test.passes():

--- a/py-scripts/lf_rvr_test.py
+++ b/py-scripts/lf_rvr_test.py
@@ -549,7 +549,14 @@ def main():
     if CV_Test.kpi_results_present():
         logger.info("lf_rvr_test_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_rvr_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
 

--- a/py-scripts/lf_scale_test.py
+++ b/py-scripts/lf_scale_test.py
@@ -841,7 +841,14 @@ INCLUDE_IN_README: False
     if CV_Test.kpi_results_present():
         logger.info("lf_scale_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_scale_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
     if CV_Test.passes():

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -433,7 +433,14 @@ INCLUDE_IN_README:
     if WFC_Test.kpi_results_present():
         logger.info("lf_wifi_capacity_test generated kpi.csv")
     else:
-        logger.info("FAILED: lf_wifi_capacity_test did not generate kpi.csv)")
+        logger.error('''\
+        The test has finished but did not complete successfully,
+        and no KPI.csv file could be generated. Possible causes
+        could be displayed by the GUI CV test, a station could
+        have the wrong SSID, passphrase or attempting to connect
+        to the wrong BSSID. Please check error messages outputted
+        earlier by this script, or check for exceptions in journalctl.
+        ''')
         exit(1)
 
 


### PR DESCRIPTION
The pull requests updated the error message on chamberview tests if the kpi.csv is not generated
        logger.error('''\
        The test has finished but did not complete successfully,
        and no KPI.csv file could be generated. Possible causes
        could be displayed by the GUI CV test, a station could
        have the wrong SSID, passphrase or attempting to connect
        to the wrong BSSID. Please check error messages outputted
        earlier by this script, or check for exceptions in journalctl.
        ''')