### PR TITLE
lf_interop_youtube.py: remove unnecessary TimeStamp sorting

### DIFF
--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -951,9 +951,6 @@ class Youtube(Realm):
                 continue
 
             data = data.drop_duplicates(subset='TimeStamp', keep='first')
-
-            data = data.sort_values(by='TimeStamp')
-
             timestamps = data['TimeStamp'].apply(lambda t: t.strftime('%H:%M:%S'))
             buffer_health = data['BufferHealth']
 


### PR DESCRIPTION
Previously, the script sorted rows by TimeStamp after removing duplicates.
This caused issues for tests crossing midnight (e.g., 23:49 → 01:39), where
times from the next day could appear before late-night values. Since the CSV
already logs data in order, sorting is unnecessary. The plot now preserves
the original logging order."