### PR TITLE
lf_interop_teams: Add robo/bandsteering support, Android automation, and refactor test orchestration

### DIFF
--- a/py-json/gen_cxprofile.py
+++ b/py-json/gen_cxprofile.py
@@ -91,6 +91,8 @@ class GenCXProfile(LFCliBase):
             pass
         elif self.type == "real_browser":
             pass
+        elif self.type == "teams":
+            pass
         else:
             logger.critical("Unknown command type")
             raise ValueError("Unknown command type")

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -20,6 +20,10 @@ EXAMPLE-4:
 Command Line Interface to run Teams on Specified Resources with Robo Functionality and Rotations Enabled:
 python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5 --rotations 30,40
 
+Example-5:
+Command Line Interface to run Teams on Specified Resources with Band Steering Functionality:
+python3 lf_interop_teams.py --mgr 192.168.207.78 --resources 1.15,1.11 --upstream_port 192.168.200.135 --audio --video --coordinates 1,4 --robo_ip 192.168.200.186 --do_bs --cycles 2 --bssids 94:A6:7E:74:26:22,94:A6:7E:74:26:33
+
 NOTES:
 1. Use 'python3 lf_interop_teams.py --help' to see command line usage and options.
 2. Always specify the duration in minutes (for example: --duration 3 indicates a duration of 3 minutes).
@@ -228,7 +232,7 @@ class TeamsAutomation(Realm):
                     "from_coordinate", "to_coordinate",
                 ])
                 self.bs_coord_result = []
-                self.robo_obj.coordinates_list = self.coordinates
+                self.robo_obj.coordinate_list = self.coordinates
                 self.robo_obj.total_cycles = self.cycles
             self.successful_coords = []
             self.failed_coords = []
@@ -462,7 +466,7 @@ class TeamsAutomation(Realm):
                         f"--devices {self.serial_list[i]} "
                         f"--meet_link '{self.meet_link}' "
                         f"--participant_name '{self.real_sta_hostname[i]}' "
-                        f"--upstream_port {self.upstream_port} "
+                        f"--upstream_port {self.lanforge_ip} "
                         f"--duration {self.duration} "
                         "--audio "
                         "--video "
@@ -2030,6 +2034,18 @@ def main():
                 EXAMPLE-2:
                 Command Line Interface to run Teams on Specified Resources:
                 python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300
+
+                EXAMPLE-3:
+                Command Line Interface to run Teams on Specified Resources with Robo Functionality:
+                python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5
+
+                EXAMPLE-4:
+                Command Line Interface to run Teams on Specified Resources with Robo Functionality and Rotations Enabled:
+                python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5 --rotations 30,40
+
+                Example-5:
+                Command Line Interface to run Teams on Specified Resources with Band Steering Functionality:
+                python3 lf_interop_teams.py --mgr 192.168.207.78 --resources 1.15,1.11 --upstream_port 192.168.200.135 --audio --video --coordinates 1,4 --robo_ip 192.168.200.186 --do_bs --cycles 2 --bssids 94:A6:7E:74:26:22,94:A6:7E:74:26:33
 
 
                 NOTES:

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1033,6 +1033,63 @@ class TeamsAutomation(Realm):
         finally:
             self.move_csv_files()
 
+    def add_live_view_images_to_report(self):
+        """
+        Waits for and adds the Video and Audio heatmap images for Floor 1.
+        """
+        live_view_dir = os.path.join(self.path, "live_view_images")
+
+        # Define the specific filenames for Floor 1
+        video_img_name = f"teams_video_{self.test_name}_floor1.png"
+        audio_img_name = f"teams_audio_{self.test_name}_floor1.png"
+
+        video_path = os.path.join(live_view_dir, video_img_name)
+        audio_path = os.path.join(live_view_dir, audio_img_name)
+
+        timeout = 90  # seconds
+        start_time = time.time()
+
+        # 1. Wait for the Video image (Primary trigger)
+        while not (os.path.exists(video_path) and os.path.exists(audio_path)):
+            if time.time() - start_time > timeout:
+                logger.error(f"Timeout: {video_img_name} not found within 60 seconds.")
+                break
+            time.sleep(1)
+
+        if os.path.exists(video_path):
+            logger.info(f"Found video heatmap image: {video_path}")
+        else:
+            logger.warning(f"Video heatmap image not found: {video_path}")
+
+        if os.path.exists(audio_path):
+            logger.info(f"Found audio heatmap image: {audio_path}")
+        else:
+            logger.warning(f"Audio heatmap image not found: {audio_path}")
+
+        # 2. Build the HTML Report Content
+        html_content = ""
+
+        # Add Video Map (if found)
+        if os.path.exists(video_path):
+            html_content += (
+                '<div style="page-break-before: always;"></div>'
+                '<h3 style="text-align:center;">Video Heatmap</h3>'
+                f'<div style="text-align:center;"><img src="file://{video_path}" style="width:1200px; height:800px;"></img></div>'
+            )
+
+        # Add Audio Map (if found)
+        if os.path.exists(audio_path):
+            html_content += (
+                '<div style="page-break-before: always;"></div>'
+                '<h3 style="text-align:center;">Audio Heatmap</h3>'
+                f'<div style="text-align:center;"><img src="file://{audio_path}" style="width:1200px; height:800px;"></img></div>'
+            )
+
+        # 3. Inject into Report
+        if html_content:
+            self.report.set_custom_html(html_content)
+            self.report.build_custom()
+
     def generate_graphs_and_tables(self, metrics):
         """
         Generate graphs and tables for the report based on the collected metrics.

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -77,7 +77,6 @@ class TeamsAutomation(Realm):
                  upstream_port=None,
                  no_pre_cleanup=None,
                  no_post_cleanup=None,
-                 participants_req=None,
                  audio=None,
                  video=None,
                  do_webui=None,
@@ -104,7 +103,6 @@ class TeamsAutomation(Realm):
         self.mac = 0
         self.meet_link = None
         self.participants_joined = 0
-        self.participants_req = participants_req
         self.start_time = None
         self.end_time = None
         self.audio = None
@@ -699,18 +697,10 @@ class TeamsAutomation(Realm):
                 self.login_completed = bool(login_completed_status)
                 return jsonify({"message": f"Updated login_completed status to {bool(login_completed_status)}"})
 
-        @self.app.route('/get_participants_joined', methods=['GET'])
-        def get_participants_joined():
-            return jsonify({"participants": self.participants_joined})
-
         @self.app.route('/set_participants_joined', methods=['GET'])
         def set_participants_joined():
             self.participants_joined += 1
             return jsonify({"message": f"Updated participants joined status to {self.participants_joined}"})
-
-        @self.app.route('/get_participants_req', methods=['GET'])
-        def get_participants_req():
-            return jsonify({"participants": self.participants_req})
 
         @self.app.route('/get_start_end_time', methods=['GET'])
         def get_start_end_time():
@@ -939,7 +929,6 @@ def main():
             upstream_port=args.upstream_port,
             no_pre_cleanup=args.no_pre_cleanup,
             no_post_cleanup=args.no_post_cleanup,
-            participants_req=args.participants,
             audio=args.audio,
             video=args.video,
             do_webui=args.do_webUI,

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1979,27 +1979,34 @@ class TeamsAutomation(Realm):
         )
 
     def stop_test_in_webui(self):
+        """
+        Updates the running_status.json file to mark the test as Completed.
+        """
         try:
-            url = f"http://{self.lanforge_ip}:5454/update_status_yt"
-            headers = {
-                'Content-Type': 'application/json',
-            }
+            json_path = os.path.join(self.path, "running_status.json")
 
-            data = {
-                'status': 'Completed',
-                'name': self.test_name
-            }
+            # 1. Load existing data or create new dict
+            data = {}
+            if os.path.exists(json_path):
+                with open(json_path, "r") as f:
+                    try:
+                        data = json.load(f)
+                    except json.JSONDecodeError:
+                        data = {}
 
-            response = requests.post(url, json=data, headers=headers)
+            # 2. Update status
+            data["status"] = "Completed"
 
-            if response.status_code == 200:
-                logging.info("Successfully updated STOP status to 'Completed'")
-                pass
-            else:
-                logging.error(f"Failed to update STOP status: {response.status_code} - {response.text}")
+            # 3. Write back to file
+            with open(json_path, "w") as f:
+                json.dump(data, f, indent=4)
+
+            logger.info(
+                f"Updated running_status.json with status Completed at {json_path}"
+            )
 
         except Exception as e:
-            logging.error(f"An error occurred while updating status: {e}")
+            logger.error(f"Error updating running_status.json: {e}")
 
 
 def main():

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -2015,9 +2015,9 @@ def main():
     try:
 
         parser = argparse.ArgumentParser(
-            prog='lf_interop_teams.py',
+            prog="lf_interop_teams.py",
             formatter_class=argparse.RawTextHelpFormatter,
-            epilog=''' Allows user to run the Microsoft Teams Call test on a target resource for the given duration. ''',
+            epilog=""" Allows user to run the Microsoft Teams Call test on a target resource for the given duration. """,
             description="""
                 NAME: lf_interop_teams.py
 
@@ -2025,11 +2025,11 @@ def main():
 
                 EXAMPLE-1:
                 Command Line Interface to run Teams:
-                python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --participants 3 --duration 1 --audio --video
+                python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --duration 1 --audio --video
 
                 EXAMPLE-2:
                 Command Line Interface to run Teams on Specified Resources:
-                python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --participants 3 --duration 1 --audio --video --resources 1.95,1.400,1.300
+                python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300
 
 
                 NOTES:
@@ -2039,39 +2039,98 @@ def main():
                 4. Enter the resource numbers separated by commas (,) in the resource argument Eg: (1.95,1.200).
 
 
-        """)
+        """,
+        )
 
         # Define required arguments group
-        required = parser.add_argument_group('Required arguments')
+        required = parser.add_argument_group("Required arguments")
         # Define optional arguments group
-        optional = parser.add_argument_group('Optional arguments')
+        optional = parser.add_argument_group("Optional arguments")
+        # Add robo related arguments
+        robo = parser.add_argument_group("Robo related arguments")
 
-        required.add_argument('--mgr', type=str, help="hostname where LANforge GUI is running", required=True)
-        required.add_argument('--duration', type=int, help='duration to run the test in min', required=True)
-        required.add_argument('--upstream_port', type=str, help='Specify The Upstream Port name or IP address', required=True)
-        required.add_argument('--participants', type=int, help='No of Devices in the test', required=True)
+        required.add_argument(
+            "--mgr",
+            type=str,
+            help="hostname where LANforge GUI is running",
+            required=True,
+        )
+        required.add_argument(
+            "--upstream_port",
+            type=str,
+            help="Specify The Upstream Port name or IP address",
+            required=True,
+        )
 
         # Add optional arguments
-        optional.add_argument('--resources', help='Specify the real device ports seperated by comma')
-        optional.add_argument('--no_pre_cleanup', action="store_true", help='specify this flag to stop cleaning up generic cxs before the test')
-        optional.add_argument('--no_post_cleanup', action="store_true", help='specify this flag to stop cleaning up generic cxs after the test')
-        optional.add_argument('--log_level', help='Level of the logs to be dispalyed', default='info')
-        optional.add_argument('--lf_logger_config_json', help='lf_logger config json')
-        optional.add_argument('--audio', action='store_true')
-        optional.add_argument('--video', action='store_true')
-        optional.add_argument('--enable_mobile_stats', action='store_true', help='specify this flag to enable mobile stats collection on Android devices')
+        optional.add_argument(
+            "--duration", type=int, help="duration to run the test in min"
+        )
+        optional.add_argument(
+            "--resources", help="Specify the real device ports seperated by comma"
+        )
+        optional.add_argument(
+            "--no_pre_cleanup",
+            action="store_true",
+            help="specify this flag to stop cleaning up generic cxs before the test",
+        )
+        optional.add_argument(
+            "--no_post_cleanup",
+            action="store_true",
+            help="specify this flag to stop cleaning up generic cxs after the test",
+        )
+        optional.add_argument(
+            "--log_level", help="Level of the logs to be dispalyed", default="info"
+        )
+        optional.add_argument("--lf_logger_config_json", help="lf_logger config json")
+        optional.add_argument("--audio", action="store_true")
+        optional.add_argument("--video", action="store_true")
+        optional.add_argument(
+            "--do_webUI",
+            action="store_true",
+            help="useful to specify whether we are running through webui or cli",
+        )
+        optional.add_argument(
+            "--testname", help="report directory while running test through web ui"
+        )
+        optional.add_argument(
+            "--report_dir", help="report directory while running test through web ui"
+        )
+        optional.add_argument(
+            "--enable_mobile_stats",
+            action="store_true",
+            help="Used to specify whether to collect mobile stats through chrome browser based UI automation or not",
+        )
 
-        robo = parser.add_argument_group('Robo / Band-steering arguments')
-        robo.add_argument('--robo_ip', type=str, help='Specify the robo ip')
-        robo.add_argument('--coordinates', help='Comma-separated list of coordinate point names (e.g. 1,2,3)')
-        robo.add_argument('--rotations', help='Comma-separated list of rotation angles (in degrees)')
-        robo.add_argument('--do_robo', action='store_true', help='specify this flag to enable robo coordinate tracking mode')
-        robo.add_argument('--do_bs', action='store_true', help='specify this flag to enable band-steering timing mode')
-        robo.add_argument('--cycles', type=int, default=1, help='Number of cycles to run the test')
-        robo.add_argument('--bssids', type=str, help='Comma-separated list of BSSIDs for bandsteering test')
-        optional.add_argument('--do_webUI', action='store_true', help='useful to specify whether we are running through webui or cli')
-        optional.add_argument('--testname', help="report directory while running test through web ui")
-        optional.add_argument('--report_dir', help="report directory while running test through web ui")
+        robo.add_argument("--robo_ip", type=str, help="Specify the robo ip")
+        robo.add_argument(
+            "--coordinates",
+            help="Comma-separated list of coordinate point names (e.g. 1,2,3), each mapping to x and y values",
+        )
+
+        robo.add_argument(
+            "--rotations",
+            help="Comma-separated list of rotation angles (in degrees) to apply at respective points",
+        )
+        robo.add_argument(
+            "--do_robo",
+            help="Specify this flag to perform the test with robo",
+            action="store_true",
+        )
+        robo.add_argument(
+            "--do_bs",
+            help="Specify this flag to perform the test with robo for band steering",
+            action="store_true",
+        )
+        robo.add_argument(
+            "--cycles", type=int, default=1, help="Number of cycles to run the test"
+        )
+
+        robo.add_argument(
+            "--bssids",
+            type=str,
+            help="Comma-separated list of BSSIDs for bandsteering test",
+        )
 
         args = parser.parse_args()
 
@@ -2087,16 +2146,17 @@ def main():
 
         rotations_enabled = False
         if args.do_robo or args.do_bs:
-            args.coordinates = args.coordinates.split(',') if args.coordinates else []
+            args.coordinates = args.coordinates.split(",") if args.coordinates else []
             args.rotations = (
-                [float(angle) for angle in args.rotations.split(',')]
+                [float(angle) for angle in args.rotations.split(",")]
                 if args.rotations
                 else []
             )
             if args.rotations:
                 rotations_enabled = True
+
             if args.bssids:
-                args.bssids = args.bssids.split(',') if args.bssids else []
+                args.bssids = args.bssids.split(",") if args.bssids else []
 
         teams = TeamsAutomation(
             lanforge_ip=args.mgr,
@@ -2109,52 +2169,57 @@ def main():
             do_webui=args.do_webUI,
             test_name=args.testname,
             report_dir=args.report_dir,
-            do_bs=args.do_bs,
-            do_robo=args.do_robo,
-            rotations_enabled=rotations_enabled,
             robo_ip=args.robo_ip,
             coordinates=args.coordinates,
             rotations=args.rotations,
+            do_robo=args.do_robo,
+            do_bs=args.do_bs,
             cycles=args.cycles,
             bssids=args.bssids,
-            enable_mobile_stats=args.enable_mobile_stats
-
+            rotations_enabled=rotations_enabled,
+            enable_mobile_stats=args.enable_mobile_stats,
         )
 
-        teams.realdevice = RealDevice(manager_ip=args.mgr,
-                                      server_ip="192.168.1.61",
-                                      ssid_2g='Test Configured',
-                                      passwd_2g='',
-                                      encryption_2g='',
-                                      ssid_5g='Test Configured',
-                                      passwd_5g='',
-                                      encryption_5g='',
-                                      ssid_6g='Test Configured',
-                                      passwd_6g='',
-                                      encryption_6g='',
-                                      selected_bands=['5G'])
+        teams.upstream_port = teams.change_port_to_ip(args.upstream_port)
+
+        teams.realdevice = RealDevice(
+            manager_ip=args.mgr,
+            server_ip="192.168.1.61",
+            ssid_2g="Test Configured",
+            passwd_2g="",
+            encryption_2g="",
+            ssid_5g="Test Configured",
+            passwd_5g="",
+            encryption_5g="",
+            ssid_6g="Test Configured",
+            passwd_6g="",
+            encryption_6g="",
+            selected_bands=["5G"],
+        )
 
         teams.select_real_devices(real_sta_list=args.resources)
         if args.do_webUI:
             teams.path = args.report_dir
             teams.update_webui_data()
         teams.load_credentials()
-        teams.run()
-        time.sleep(10)
-        teams.create_avg_data()
-
+        teams.handle_flask_server()
+        if args.do_robo:
+            teams.run_robo_test()
+        else:
+            teams.run()
+            time.sleep(10)
+            teams.create_avg_data()
     except Exception as e:
-        logging.error(f"AN ERROR OCCURED WHILE RUNNING TEST {e}")
+        logger.error(f"AN ERROR OCCURED WHILE RUNNING TEST {e}")
         traceback.print_exc()
 
     finally:
-        if args is not None and not ('--help' in sys.argv or '-h' in sys.argv):
+        if args is not None and not ("--help" in sys.argv or "-h" in sys.argv):
             if teams is not None:
                 teams.stop_signal = True
-                teams.generate_report()
-                teams.move_csv_files()
                 if args.do_webUI:
                     teams.stop_test_in_webui()
+                teams.generate_report()
                 logger.info("Waiting for Browser Cleanup at Client Side")
                 time.sleep(10)
                 logger.info("Browser Cleanup Completed")

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -60,6 +60,7 @@ lf_horizontal_stacked_graph = lf_graph.lf_horizontal_stacked_graph
 DeviceConfig = importlib.import_module("py-scripts.DeviceConfig")
 lf_base_interop_profile = importlib.import_module("py-scripts.lf_base_interop_profile")
 RealDevice = lf_base_interop_profile.RealDevice
+robo_base_class = importlib.import_module("py-scripts.lf_base_robo")
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -85,6 +86,11 @@ class TeamsAutomation(Realm):
                  do_bs=None,
                  do_robo=None,
                  rotations_enabled=False,
+                 robo_ip=None,
+                 coordinates=None,
+                 rotations=None,
+                 cycles=None,
+                 bssids=None,
                  enable_mobile_stats=False
 
                  ):
@@ -157,9 +163,31 @@ class TeamsAutomation(Realm):
             else:
                 self.header = ['timestamp'] + self.video_stats_header
         if self.do_robo or self.do_bs:
+            self.robo_ip = robo_ip
+            self.rotations = rotations
+            self.robo_obj = robo_base_class.RobotClass(
+                robo_ip=self.robo_ip,
+                angle_list=self.rotations,
+            )
+            self.coordinates = coordinates
+            self.cycles = cycles
+            self.bssids = bssids
             self.header.append("current_coordinate")
             if self.rotations_enabled:
                 self.header.append("current_rotation")
+            if self.do_bs:
+                self.from_coordinate = None
+                self.to_coordinate = None
+                self.header.extend([
+                    "x", "y", "signal", "channel", "mode",
+                    "tx_rate", "rx_rate", "bssid",
+                    "from_coordinate", "to_coordinate",
+                ])
+                self.bs_coord_result = []
+                self.robo_obj.coordinates_list = self.coordinates
+                self.robo_obj.total_cycles = self.cycles
+            self.successful_coords = []
+            self.failed_coords = []
         self.data_store = {}
         self.stop_signal = False
         self.path = os.path.join(os.getcwd(), "teams_test_results")
@@ -1333,10 +1361,16 @@ def main():
         optional.add_argument('--lf_logger_config_json', help='lf_logger config json')
         optional.add_argument('--audio', action='store_true')
         optional.add_argument('--video', action='store_true')
-        optional.add_argument('--do_bs', action='store_true', help='specify this flag to enable band-steering timing mode')
-        optional.add_argument('--do_robo', action='store_true', help='specify this flag to enable robo coordinate tracking mode')
-        optional.add_argument('--rotations_enabled', action='store_true', help='specify this flag to enable rotation tracking in robo mode')
         optional.add_argument('--enable_mobile_stats', action='store_true', help='specify this flag to enable mobile stats collection on Android devices')
+
+        robo = parser.add_argument_group('Robo / Band-steering arguments')
+        robo.add_argument('--robo_ip', type=str, help='Specify the robo ip')
+        robo.add_argument('--coordinates', help='Comma-separated list of coordinate point names (e.g. 1,2,3)')
+        robo.add_argument('--rotations', help='Comma-separated list of rotation angles (in degrees)')
+        robo.add_argument('--do_robo', action='store_true', help='specify this flag to enable robo coordinate tracking mode')
+        robo.add_argument('--do_bs', action='store_true', help='specify this flag to enable band-steering timing mode')
+        robo.add_argument('--cycles', type=int, default=1, help='Number of cycles to run the test')
+        robo.add_argument('--bssids', type=str, help='Comma-separated list of BSSIDs for bandsteering test')
         optional.add_argument('--do_webUI', action='store_true', help='useful to specify whether we are running through webui or cli')
         optional.add_argument('--testname', help="report directory while running test through web ui")
         optional.add_argument('--report_dir', help="report directory while running test through web ui")
@@ -1353,6 +1387,19 @@ def main():
             logger_config.lf_logger_config_json = args.lf_logger_config_json
             logger_config.load_lf_logger_config()
 
+        rotations_enabled = False
+        if args.do_robo or args.do_bs:
+            args.coordinates = args.coordinates.split(',') if args.coordinates else []
+            args.rotations = (
+                [float(angle) for angle in args.rotations.split(',')]
+                if args.rotations
+                else []
+            )
+            if args.rotations:
+                rotations_enabled = True
+            if args.bssids:
+                args.bssids = args.bssids.split(',') if args.bssids else []
+
         teams = TeamsAutomation(
             lanforge_ip=args.mgr,
             duration=args.duration,
@@ -1366,7 +1413,12 @@ def main():
             report_dir=args.report_dir,
             do_bs=args.do_bs,
             do_robo=args.do_robo,
-            rotations_enabled=args.rotations_enabled,
+            rotations_enabled=rotations_enabled,
+            robo_ip=args.robo_ip,
+            coordinates=args.coordinates,
+            rotations=args.rotations,
+            cycles=args.cycles,
+            bssids=args.bssids,
             enable_mobile_stats=args.enable_mobile_stats
 
         )

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -749,10 +749,7 @@ class TeamsAutomation(Realm):
             check_count += 1
             if check_count > 24:
                 logging.warning(
-                    f"Waited for 2 minutes but not all participants joined. Proceeding with the test with the participants that have joined. Joined: {
-                        self.participants_joined}, Expected: {
-                        len(
-                            self.real_sta_list)}"
+                    f"Proceeding with the test with the participants that have joined. Joined: {self.participants_joined}, Expected: {len(self.real_sta_list)}"
                 )
                 break
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -455,6 +455,81 @@ class TeamsAutomation(Realm):
             )
             logger.info(f"sending running state to.. {cx_name}")
 
+    def monitor_test(self):
+        while datetime.now(self.tz) < self.end_time or not self.check_gen_cx():
+            if self.stop_signal:
+                break
+
+            if self.do_robo:
+                pause, _ = self.robo_obj.wait_for_battery()
+                if pause:
+                    self.stop_signal = True
+                    time.sleep(10)
+                    logger.info("Waiting for browser cleanup at client Devices")
+                    if self.rotations_enabled:
+                        logger.info(
+                            f"Current run at coordinate {self.current_coord} with rotation {self.current_rotation} is Ignored due to low battery on Robo"
+                        )
+                        logger.info(
+                            f"Reinitializing the Run at coordinate {self.current_coord} with rotation {self.current_rotation}"
+                        )
+                    else:
+                        logger.info(
+                            f"Current run at coordinate {self.current_coord} is Ignored due to low battery on Robo"
+                        )
+                        logger.info(
+                            f"Reinitializing the Run at coordinate {self.current_coord}"
+                        )
+                    self.reset_variables_for_next_run()
+                    self.delete_current_csv_files()
+                    self.run()
+                    return
+
+            elif self.do_bs:
+                time.sleep(27)
+                logger.info(
+                    f"Robo will be moving through the following coordinates: {self.bs_coord_result}"
+                )
+                for coordinate in self.bs_coord_result:
+                    if not self.to_coordinate:
+                        self.to_coordinate = coordinate
+                    else:
+                        self.from_coordinate = self.to_coordinate
+                        self.to_coordinate = coordinate
+
+                    self.robo_obj.wait_for_battery()
+
+                    matched, aborted = self.robo_obj.move_to_coordinate(
+                        coord=coordinate
+                    )
+                    if matched:
+                        self.current_coord = coordinate
+                        self.successful_coords.append(coordinate)
+                    else:
+                        self.failed_coords.append(coordinate)
+
+                    if aborted:
+                        logger.error(f"Failed to reach the {coordinate}")
+                        self.failed_coords.append(coordinate)
+                        sys.exit()
+                    time.sleep(10)
+                return
+
+            time.sleep(5)
+
+    def reset_variables_for_next_run(self):
+        self.participants_joined = 0
+        self.login_completed = False
+        self.meet_link = ""
+        self.data_store = {}
+        self.cred_index = 0
+        self.generic_endps_profile.cleanup()
+        self.start_time = None
+        self.end_time = None
+        self.stop_signal = False
+        self.generic_endps_profile.created_cx = []
+        self.generic_endps_profile.created_endp = []
+
     def run(self):
         flask_thread = threading.Thread(target=self.start_flask_server)
         flask_thread.daemon = True
@@ -466,12 +541,19 @@ class TeamsAutomation(Realm):
         self.create_participants()
 
         self.wait_for_test_start()
-
-        while datetime.now(self.tz) < self.end_time or not self.check_gen_cx():
-            if self.stop_signal:
-                break
-
-            time.sleep(5)
+        self.monitor_test()
+        self.stop_signal = True
+        time.sleep(10)
+        if self.do_robo:
+            if self.rotations_enabled:
+                logger.info(
+                    f"Completed one cycle of test for coordinate {self.current_coord} with rotation {self.current_rotation}"
+                )
+            else:
+                logger.info(
+                    f"Completed one cycle of test for coordinate {self.current_coord}"
+                )
+            self.reset_variables_for_next_run()
 
     def wait_for_test_start(self):
         check_count = 0

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -14,15 +14,44 @@ python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --dura
 
 EXAMPLE-3:
 Command Line Interface to run Teams on Specified Resources with Robo Functionality:
-python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5
+python3 lf_interop_teams.py \
+--mgr 192.168.207.78 \
+--upstream_port 1.1.eth1 \
+--duration 1 \
+--audio \
+--video \
+--resources 1.95,1.400,1.300 \
+--do_robo \
+--robo_ip 192.168.200.186 \
+--coordinates 3,4,5
 
 EXAMPLE-4:
 Command Line Interface to run Teams on Specified Resources with Robo Functionality and Rotations Enabled:
-python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5 --rotations 30,40
+python3 lf_interop_teams.py \
+--mgr 192.168.207.78 \
+--upstream_port 1.1.eth1 \
+--duration 1 \
+--audio \
+--video \
+--resources 1.95,1.400,1.300 \
+--do_robo \
+--robo_ip 192.168.200.186 \
+--coordinates 3,4,5 \
+--rotations 30,40
 
-Example-5:
+EXAMPLE-5:
 Command Line Interface to run Teams on Specified Resources with Band Steering Functionality:
-python3 lf_interop_teams.py --mgr 192.168.207.78 --resources 1.15,1.11 --upstream_port 192.168.200.135 --audio --video --coordinates 1,4 --robo_ip 192.168.200.186 --do_bs --cycles 2 --bssids 94:A6:7E:74:26:22,94:A6:7E:74:26:33
+python3 lf_interop_teams.py \
+--mgr 192.168.207.78 \
+--resources 1.15,1.11 \
+--upstream_port 192.168.200.135 \
+--audio \
+--video \
+--coordinates 1,4 \
+--robo_ip 192.168.200.186 \
+--do_bs \
+--cycles 2 \
+--bssids 94:A6:7E:74:26:22,94:A6:7E:74:26:33
 
 NOTES:
 1. Use 'python3 lf_interop_teams.py --help' to see command line usage and options.
@@ -720,7 +749,10 @@ class TeamsAutomation(Realm):
             check_count += 1
             if check_count > 24:
                 logging.warning(
-                    f"Waited for 2 minutes but not all participants joined. Proceeding with the test with the participants that have joined. Joined: {self.participants_joined}, Expected: {len(self.real_sta_list)}"
+                    f"Waited for 2 minutes but not all participants joined. Proceeding with the test with the participants that have joined. Joined: {
+                        self.participants_joined}, Expected: {
+                        len(
+                            self.real_sta_list)}"
                 )
                 break
 
@@ -1942,7 +1974,7 @@ class TeamsAutomation(Realm):
                     row["Device Name"] = device_name
                     summary_rows.append(row)
         else:
-            logger.info(f"Creating average data for all devices")
+            logger.info("Creating average data for all devices")
 
             for csv_path in glob.glob(os.path.join(self.path, "*.csv")):
                 if csv_path.endswith("teams_cred.csv") or csv_path.endswith(
@@ -2037,15 +2069,44 @@ def main():
 
                 EXAMPLE-3:
                 Command Line Interface to run Teams on Specified Resources with Robo Functionality:
-                python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5
+                python3 lf_interop_teams.py \
+                --mgr 192.168.207.78 \
+                --upstream_port 1.1.eth1 \
+                --duration 1 \
+                --audio \
+                --video \
+                --resources 1.95,1.400,1.300 \
+                --do_robo \
+                --robo_ip 192.168.200.186 \
+                --coordinates 3,4,5
 
                 EXAMPLE-4:
                 Command Line Interface to run Teams on Specified Resources with Robo Functionality and Rotations Enabled:
-                python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5 --rotations 30,40
+                python3 lf_interop_teams.py \
+                --mgr 192.168.207.78 \
+                --upstream_port 1.1.eth1 \
+                --duration 1 \
+                --audio \
+                --video \
+                --resources 1.95,1.400,1.300 \
+                --do_robo \
+                --robo_ip 192.168.200.186 \
+                --coordinates 3,4,5 \
+                --rotations 30,40
 
-                Example-5:
+                EXAMPLE-5:
                 Command Line Interface to run Teams on Specified Resources with Band Steering Functionality:
-                python3 lf_interop_teams.py --mgr 192.168.207.78 --resources 1.15,1.11 --upstream_port 192.168.200.135 --audio --video --coordinates 1,4 --robo_ip 192.168.200.186 --do_bs --cycles 2 --bssids 94:A6:7E:74:26:22,94:A6:7E:74:26:33
+                python3 lf_interop_teams.py \
+                --mgr 192.168.207.78 \
+                --resources 1.15,1.11 \
+                --upstream_port 192.168.200.135 \
+                --audio \
+                --video \
+                --coordinates 1,4 \
+                --robo_ip 192.168.200.186 \
+                --do_bs \
+                --cycles 2 \
+                --bssids 94:A6:7E:74:26:22,94:A6:7E:74:26:33
 
 
                 NOTES:

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -99,28 +99,28 @@ logger = logging.getLogger(__name__)
 
 
 class TeamsAutomation(Realm):
-    def __init__(self,
-                 lanforge_ip=None,
-                 duration=None,
-                 upstream_port=None,
-                 no_pre_cleanup=None,
-                 no_post_cleanup=None,
-                 audio=None,
-                 video=None,
-                 do_webui=None,
-                 test_name=None,
-                 report_dir=None,
-                 do_bs=None,
-                 do_robo=None,
-                 rotations_enabled=False,
-                 robo_ip=None,
-                 coordinates=None,
-                 rotations=None,
-                 cycles=None,
-                 bssids=None,
-                 enable_mobile_stats=False
-
-                 ):
+    def __init__(
+        self,
+        lanforge_ip=None,
+        duration=None,
+        upstream_port=None,
+        no_pre_cleanup=None,
+        no_post_cleanup=None,
+        audio=None,
+        video=None,
+        do_webui=None,
+        test_name=None,
+        report_dir=None,
+        rotations_enabled=False,
+        robo_ip=None,
+        coordinates=None,
+        rotations=None,
+        do_robo=None,
+        do_bs=None,
+        cycles=None,
+        bssids=None,
+        enable_mobile_stats=False,
+    ):
         super().__init__(lfclient_host=lanforge_ip)
         self.app = Flask(__name__)
         self.lanforge_ip = lanforge_ip
@@ -154,12 +154,6 @@ class TeamsAutomation(Realm):
         self.generic_endps_profile.type = "teams"
         self.audio = audio
         self.video = video
-        self.do_bs = do_bs
-        self.do_robo = do_robo
-        self.rotations_enabled = rotations_enabled
-        self.current_coord = None
-        self.current_rotation = "NA"
-        self.enable_mobile_stats = enable_mobile_stats
         self.audio_stats_header = [
             'Sent Audio Bitrate(Kbps)',
             'Sent Audio Packets',
@@ -189,6 +183,26 @@ class TeamsAutomation(Realm):
                 self.header += self.video_stats_header
             else:
                 self.header = ['timestamp'] + self.video_stats_header
+        self.data_store = {}
+        self.stop_signal = False
+        self.path = os.path.join(os.getcwd(), "teams_test_results")
+        if not os.path.exists(self.path):
+            os.makedirs(self.path)
+        self.do_webui = do_webui
+        self.test_name = test_name
+        self.report_dir = report_dir
+        self.lanforge_port_list = []
+        self.serial_list = []
+        self.lanforge_os_type = []
+        self.device_names = []
+        self.user_list = []
+        self.avg_csv_files_list = []
+        self.do_robo = do_robo
+        self.do_bs = do_bs
+        self.hostname_to_station_map = {}
+        self.running_averages = {}
+        self.enable_mobile_stats = enable_mobile_stats
+
         if self.do_robo or self.do_bs:
             self.robo_ip = robo_ip
             self.rotations = rotations
@@ -196,9 +210,12 @@ class TeamsAutomation(Realm):
                 robo_ip=self.robo_ip,
                 angle_list=self.rotations,
             )
+            self.rotations_enabled = rotations_enabled
             self.coordinates = coordinates
             self.cycles = cycles
             self.bssids = bssids
+            self.current_coord = None
+            self.current_rotation = "NA"
             self.header.append("current_coordinate")
             if self.rotations_enabled:
                 self.header.append("current_rotation")
@@ -215,20 +232,6 @@ class TeamsAutomation(Realm):
                 self.robo_obj.total_cycles = self.cycles
             self.successful_coords = []
             self.failed_coords = []
-        self.data_store = {}
-        self.stop_signal = False
-        self.path = os.path.join(os.getcwd(), "teams_test_results")
-        if not os.path.exists(self.path):
-            os.makedirs(self.path)
-        self.do_webui = do_webui
-        self.test_name = test_name
-        self.report_dir = report_dir
-        self.lanforge_port_list = []
-        self.serial_list = []
-        self.lanforge_os_type = []
-        self.device_names = []
-        self.user_list = []
-        self.hostname_to_station_map = {}
 
     def updating_webui_runningjson(self, obj):
         data = {}

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -84,7 +84,8 @@ class TeamsAutomation(Realm):
                  report_dir=None,
                  do_bs=None,
                  do_robo=None,
-                 rotations_enabled=False
+                 rotations_enabled=False,
+                 enable_mobile_stats=False
 
                  ):
         super().__init__(lfclient_host=lanforge_ip)
@@ -125,6 +126,7 @@ class TeamsAutomation(Realm):
         self.rotations_enabled = rotations_enabled
         self.current_coord = None
         self.current_rotation = "NA"
+        self.enable_mobile_stats = enable_mobile_stats
         self.audio_stats_header = [
             'Sent Audio Bitrate(Kbps)',
             'Sent Audio Packets',
@@ -291,6 +293,168 @@ class TeamsAutomation(Realm):
                 logging.info(f"Error while checking login_completed status: {e}")
                 time.sleep(5)
 
+    def create_android(
+        self,
+        lanforge_res,
+        ports=None,
+        sleep_time=0.5,
+        debug_=False,
+        suppress_related_commands_=None,
+        real_client_os_types=None,
+    ):
+        if ports and real_client_os_types and len(real_client_os_types) == 0:
+            logger.error("Real client operating systems types is empty list")
+            raise ValueError("Real client operating systems types is empty list")
+        created_cx = []
+        created_endp = []
+
+        if not ports:
+            ports = []
+
+        if self.debug:
+            debug_ = True
+
+        post_data = []
+        endp_tpls = []
+        for port_name in ports:
+            port_info = self.name_to_eid(port_name)
+            resource = port_info[1]
+            shelf = port_info[0]
+            if real_client_os_types:
+                name = port_name
+            else:
+                name = port_info[2]
+
+            gen_name_a = "%s-%s" % ("teams", "_".join(port_name.split(".")))
+            endp_tpls.append((shelf, resource, name, gen_name_a))
+
+        for endp_tpl in endp_tpls:
+            shelf = endp_tpl[0]
+            resource = endp_tpl[1]
+            if real_client_os_types:
+                name = endp_tpl[2].split(".")[2]
+            else:
+                name = endp_tpl[2]
+            gen_name_a = endp_tpl[3]
+
+            data = {
+                "alias": gen_name_a,
+                "shelf": shelf,
+                "resource": lanforge_res.split(".")[1],
+                "port": "eth0",
+                "type": "gen_generic",
+            }
+            self.json_post("cli-json/add_gen_endp", data, debug_=self.debug)
+
+        self.json_post("/cli-json/nc_show_endpoints", {"endpoint": "all"})
+        if sleep_time:
+            time.sleep(sleep_time)
+
+        for endp_tpl in endp_tpls:
+            gen_name_a = endp_tpl[3]
+            self.generic_endps_profile.set_flags(gen_name_a, "ClearPortOnStart", 1)
+
+        for endp_tpl in endp_tpls:
+            name = endp_tpl[2]
+            gen_name_a = endp_tpl[3]
+            cx_name = "CX_%s-%s" % ("generic", gen_name_a)
+            data = {"alias": cx_name, "test_mgr": "default_tm", "tx_endp": gen_name_a}
+            post_data.append(data)
+            created_cx.append(cx_name)
+            created_endp.append(gen_name_a)
+
+        for data in post_data:
+            url = "/cli-json/add_cx"
+            self.json_post(
+                url,
+                data,
+                debug_=debug_,
+                suppress_related_commands_=suppress_related_commands_,
+            )
+        if sleep_time:
+            time.sleep(sleep_time)
+
+        for data in post_data:
+            self.json_post(
+                "/cli-json/show_cx",
+                {"test_mgr": "default_tm", "cross_connect": data["alias"]},
+            )
+        return True, created_cx, created_endp
+
+    def create_participants(self):
+        logger.debug(
+            "Creating participants and setting up the calls with the following details"
+        )
+        logger.debug(self.lanforge_port_list)
+        logger.debug(self.real_sta_hostname)
+        logger.debug(self.serial_list)
+        for i in range(1, len(self.real_sta_os_types)):
+            if self.real_sta_os_types[i] == "android":
+                status, created_cx, created_endp = self.create_android(
+                    lanforge_res=self.lanforge_port_list[i],
+                    ports=[self.real_sta_list[i]],
+                    real_client_os_types=["Linux"],
+                )
+                self.generic_endps_profile.created_endp.extend(created_endp)
+                self.generic_endps_profile.created_cx.extend(created_cx)
+                logger.debug(self.generic_endps_profile.created_cx)
+                if self.enable_mobile_stats:
+                    cmd = (
+                        f"python3 /home/lanforge/lanforge-scripts/py-scripts/real_application_tests/teams_automation/teams_android.py "
+                        f"--devices {self.serial_list[i]} "
+                        f"--meet_link '{self.meet_link}' "
+                        f"--participant_name '{self.real_sta_hostname[i]}' "
+                        f"--upstream_port {self.upstream_port} "
+                        f"--duration {self.duration} "
+                        "--audio "
+                        "--video "
+                    )
+                else:
+                    cmd = (
+                        f"python3 /home/lanforge/lanforge-scripts/py-scripts/real_application_tests/teams_automation/teams_android_app.py "
+                        f"--device {self.serial_list[i]} "
+                        f"--meet_link '{self.meet_link}' "
+                        f"--participant_name '{self.real_sta_hostname[i]}' "
+                        f"--upstream_port {self.lanforge_ip} "
+                        "--audio "
+                        "--video "
+                    )
+                self.generic_endps_profile.set_cmd(
+                    self.generic_endps_profile.created_endp[i], cmd
+                )
+            else:
+                self.generic_endps_profile.create(
+                    ports=[self.real_sta_list[i]],
+                    real_client_os_types=[self.real_sta_os_types[i]],
+                )
+
+        for i in range(1, len(self.real_sta_os_types)):
+            if self.real_sta_os_types[i] == "windows":
+                cmd = f"py teams_client.py --ip {self.upstream_port}"
+                self.generic_endps_profile.set_cmd(
+                    self.generic_endps_profile.created_endp[i], cmd
+                )
+            elif self.real_sta_os_types[i] == 'linux':
+                cmd = "su -l lanforge ctteams.bash %s %s %s" % (
+                    self.wifi_interfaces_list[i], self.upstream_port, "client"
+                )
+                self.generic_endps_profile.set_cmd(
+                    self.generic_endps_profile.created_endp[i], cmd
+                )
+            elif self.real_sta_os_types[i] == 'macos':
+                cmd = "sudo bash ctteams.bash %s %s" % (self.upstream_port, "client")
+                self.generic_endps_profile.set_cmd(
+                    self.generic_endps_profile.created_endp[i], cmd
+                )
+
+            cx_name = self.generic_endps_profile.created_cx[i]
+            self.json_post(
+                "/cli-json/set_cx_state",
+                {"test_mgr": "default_tm", "cx_name": cx_name, "cx_state": "RUNNING"},
+                debug_=True,
+            )
+            logger.info(f"sending running state to.. {cx_name}")
+
     def run(self):
         flask_thread = threading.Thread(target=self.start_flask_server)
         flask_thread.daemon = True
@@ -299,25 +463,7 @@ class TeamsAutomation(Realm):
 
         self.create_host()
         self.wait_for_login()
-
-        if self.generic_endps_profile.create(ports=self.real_sta_list[1:], real_client_os_types=self.real_sta_os_types[1:]):
-            logging.info('Real client generic endpoint creation completed.')
-        else:
-            logging.error('Real client generic endpoint creation failed.')
-            exit(0)
-        for i in range(1, len(self.real_sta_os_types)):
-
-            if self.real_sta_os_types[i] == "windows":
-                cmd = f"py teams_client.py --ip {self.upstream_port}"
-                self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
-            elif self.real_sta_os_types[i] == 'linux':
-                cmd = "su -l lanforge ctteams.bash %s %s %s" % (self.wifi_interfaces_list[i], self.upstream_port, "client")
-                self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
-            elif self.real_sta_os_types[i] == 'macos':
-                cmd = "sudo bash ctteams.bash %s %s" % (self.upstream_port, "client")
-                self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
-
-        self.generic_endps_profile.start_cx()
+        self.create_participants()
 
         self.wait_for_test_start()
 
@@ -1108,6 +1254,7 @@ def main():
         optional.add_argument('--do_bs', action='store_true', help='specify this flag to enable band-steering timing mode')
         optional.add_argument('--do_robo', action='store_true', help='specify this flag to enable robo coordinate tracking mode')
         optional.add_argument('--rotations_enabled', action='store_true', help='specify this flag to enable rotation tracking in robo mode')
+        optional.add_argument('--enable_mobile_stats', action='store_true', help='specify this flag to enable mobile stats collection on Android devices')
         optional.add_argument('--do_webUI', action='store_true', help='useful to specify whether we are running through webui or cli')
         optional.add_argument('--testname', help="report directory while running test through web ui")
         optional.add_argument('--report_dir', help="report directory while running test through web ui")
@@ -1137,7 +1284,8 @@ def main():
             report_dir=args.report_dir,
             do_bs=args.do_bs,
             do_robo=args.do_robo,
-            rotations_enabled=args.rotations_enabled
+            rotations_enabled=args.rotations_enabled,
+            enable_mobile_stats=args.enable_mobile_stats
 
         )
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1559,6 +1559,10 @@ class TeamsAutomation(Realm):
 
         self.stop_signal = True
         time.sleep(10)
+        self.create_avg_data()
+        self.generate_report()
+        self.generic_endps_profile.cleanup()
+        self.stop_test_in_webui()
         logging.info("Exiting the application.")
         os._exit(0)
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -103,7 +103,7 @@ class TeamsAutomation(Realm):
         self.linux = 0
         self.mac = 0
         self.meet_link = None
-        self.participants_joined = None
+        self.participants_joined = 0
         self.participants_req = participants_req
         self.test_start = False
         self.start_time = None
@@ -115,30 +115,30 @@ class TeamsAutomation(Realm):
         self.cred_index = 0
         self.tz = pytz.timezone('Asia/Kolkata')
         self.generic_endps_profile = self.new_generic_endp_profile()
-        self.generic_endps_profile.name_prefix = "zoom"
-        self.generic_endps_profile.type = "zoom"
+        self.generic_endps_profile.name_prefix = "teams"
+        self.generic_endps_profile.type = "teams"
         self.audio = audio
         self.video = video
         self.audio_stats_header = [
-            'Sent Audio bitrate(Kbps)',
+            'Sent Audio Bitrate(Kbps)',
             'Sent Audio Packets',
             'Audio RTT(ms)',
-            'sent Audio codec',
+            'Sent Audio Codec',
             'Received Audio Jitter(ms)',
-            'Receievd Audio Packet Loss(%)',
+            'Received Audio Packet Loss(%)',
             'Received Audio Packets',
-            'Recevied Audio Codec'
+            'Received Audio Codec'
         ]
 
         self.video_stats_header = [
-            'Sent video bitrate(Mbps)',
-            'Received video bitrate(Mbps)',
-            'Sent video frame rate(fps)',
-            'Sent video resolution(px)',
-            'video RTT (ms)',
-            'sent video packets',
-            'sent video codec',
-            'video processing'
+            'Sent Video Bitrate(Mbps)',
+            'Received Video Bitrate(Mbps)',
+            'Sent Video Frame Rate(fps)',
+            'Sent Video Resolution(px)',
+            'Video RTT (ms)',
+            'Sent Video Packets',
+            'Sent Video Codec',
+            'Video Processing'
         ]
 
         if self.audio:
@@ -336,25 +336,25 @@ class TeamsAutomation(Realm):
             metrics = [
                 ("Audio RTT(ms)", "Audio RTT (ms)"),
                 ("Received Audio Jitter(ms)", "Received Audio Jitter (ms)"),
-                ("Sent Audio bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
+                ("Sent Audio Bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
             ]
 
         if self.video:
             # Create bar graphs for each metric
             metrics = [
-                ("Sent video bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
-                ("Received video bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
-                ("sent video packets", "Sent Video Packets"),
+                ("Sent Video Bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
+                ("Received Video Bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
+                ("Sent Video Packets", "Sent Video Packets"),
             ]
         if self.audio and self.video:
             # Create bar graphs for each metric
             metrics = [
                 ("Audio RTT(ms)", "Audio RTT (ms)"),
                 ("Received Audio Jitter(ms)", "Received Audio Jitter (ms)"),
-                ("Sent Audio bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
-                ("Sent video bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
-                ("Received video bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
-                ("sent video packets", "Sent Video Packets"),
+                ("Sent Audio Bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
+                ("Sent Video Bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
+                ("Received Video Bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
+                ("Sent Video Packets", "Sent Video Packets"),
             ]
 
         for column, title in metrics:
@@ -385,20 +385,20 @@ class TeamsAutomation(Realm):
         if self.audio:
             selected_columns = [
                 "Device Name",
-                "Sent Audio bitrate(Kbps)",
+                "Sent Audio Bitrate(Kbps)",
                 "Sent Audio Packets",
                 "Audio RTT(ms)",
                 "Received Audio Jitter(ms)",
-                "Receievd Audio Packet Loss(%)",
+                "Received Audio Packet Loss(%)",
             ]
 
             column_headings = {
                 "Device Name": "Device Name",
-                "Sent Audio bitrate(Kbps)": "AVG Sent Audio Bitrate (Kbps)",
+                "Sent Audio Bitrate(Kbps)": "AVG Sent Audio Bitrate (Kbps)",
                 "Sent Audio Packets": "AVG Sent Audio Packets",
                 "Audio RTT(ms)": "AVG Audio RTT (ms)",
                 "Received Audio Jitter(ms)": "AVG Received Audio Jitter (ms)",
-                "Receievd Audio Packet Loss(%)": "AVG Received Audio Packet Loss (%)",
+                "Received Audio Packet Loss(%)": "AVG Received Audio Packet Loss (%)",
             }
 
             filtered_df = df[selected_columns].rename(columns=column_headings)
@@ -411,20 +411,20 @@ class TeamsAutomation(Realm):
         if self.video:
             selected_columns = [
                 "Device Name",
-                "Sent video bitrate(Mbps)",
-                "Received video bitrate(Mbps)",
-                "Sent video frame rate(fps)",
-                "video RTT (ms)",
-                "sent video packets",
+                "Sent Video Bitrate(Mbps)",
+                "Received Video Bitrate(Mbps)",
+                "Sent Video Frame Rate(fps)",
+                "Video RTT (ms)",
+                "Sent Video Packets",
             ]
 
             column_headings = {
                 "Device Name": "Device Name",
-                "Sent video bitrate(Mbps)": "AVG Sent Video Bitrate (Mbps)",
-                "Received video bitrate(Mbps)": "AVG Received Video Bitrate (Mbps)",
-                "Sent video frame rate(fps)": "AVG Sent Video Frame Rate (fps)",
-                "video RTT (ms)": "AVG Video RTT (ms)",
-                "sent video packets": "AVG Sent Video Packets",
+                "Sent Video Bitrate(Mbps)": "AVG Sent Video Bitrate (Mbps)",
+                "Received Video Bitrate(Mbps)": "AVG Received Video Bitrate (Mbps)",
+                "Sent Video Frame Rate(fps)": "AVG Sent Video Frame Rate (fps)",
+                "Video RTT (ms)": "AVG Video RTT (ms)",
+                "Sent Video Packets": "AVG Sent Video Packets",
             }
 
             filtered_df = df[selected_columns].rename(columns=column_headings)

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1298,90 +1298,215 @@ class TeamsAutomation(Realm):
             shutdown_thread.start()
             return response
 
-        @self.app.route('/upload_stats', methods=['POST'])
+        @self.app.route("/upload_stats", methods=["POST", "GET"])
         def upload_stats():
-            data = request.json
 
-            for hostname, stats in data.items():
-                if self.do_robo or self.do_bs:
-                    stats["current_coord"] = self.current_coord
-                    stats["current_rotation"] = self.current_rotation
-                    stats["rotations_enabled"] = self.rotations_enabled
+            if request.method == "POST":
+                data = request.json
 
-                self.data_store[hostname] = stats
-
-                if self.do_robo:
-                    csv_file = (
-                        os.path.join(self.path, f"{hostname}_{self.current_coord}_{self.current_rotation}.csv")
-                        if self.rotations_enabled
-                        else os.path.join(self.path, f"{hostname}_{self.current_coord}.csv")
-                    )
-                else:
-                    csv_file = os.path.join(self.path, f'{hostname}.csv')
-                with open(csv_file, mode='a', newline='') as file:
-                    writer = csv.writer(file)
-
-                    if os.path.getsize(csv_file) == 0:
-                        writer.writerow(
-                            self.header
-                        )
-                    timestamp = stats.get('timestamp', '')
-                    if self.audio and self.video:
-                        audio = stats.get('audio_stats', {})
-                        video = stats.get('video_stats', {})
-                        row = [
-                            timestamp,
-                            audio.get("au_sent_bitrate", 0),
-                            audio.get("au_sent_pkts", 0),
-                            audio.get("au_rtt", 0),
-                            audio.get("au_sent_codec", "NA"),
-                            audio.get("au_recv_jitter", 0),
-                            audio.get("au_recv_pkt_loss", 0),
-                            audio.get("au_recv_pkts", 0),
-                            audio.get("au_recv_codec", "NA"),
-                            video.get("vi_sent_bitrate", 0),
-                            video.get("vi_recv_bitrate", 0),
-                            video.get("vi_sent_frame_rate", 0),
-                            video.get("vi_sent_res", "NA"),
-                            video.get("vi_rtt", 0),
-                            video.get("vi_sent_pkts", 0),
-                            video.get("vi_sent_codec", "NA"),
-                            video.get("vi_processing", "NA"),
-                        ]
-                    elif self.audio:
-                        audio = stats.get('audio_stats', {})
-                        row = [
-                            timestamp,
-                            audio.get("au_sent_bitrate", 0),
-                            audio.get("au_sent_pkts", 0),
-                            audio.get("au_rtt", 0),
-                            audio.get("au_sent_codec", "NA"),
-                            audio.get("au_recv_jitter", 0),
-                            audio.get("au_recv_pkt_loss", 0),
-                            audio.get("au_recv_pkts", 0),
-                            audio.get("au_recv_codec", "NA"),
-                        ]
-
-                    elif self.video:
-                        video = stats.get('video_stats', {})
-                        row = [
-                            timestamp,
-                            video.get("vi_sent_bitrate", 0),
-                            video.get("vi_recv_bitrate", 0),
-                            video.get("vi_sent_frame_rate", 0),
-                            video.get("vi_sent_res", "NA"),
-                            video.get("vi_rtt", 0),
-                            video.get("vi_sent_pkts", 0),
-                            video.get("vi_sent_codec", "NA"),
-                            video.get("vi_processing", "NA"),
-                        ]
+                for hostname, stats in data.items():
                     if self.do_robo or self.do_bs:
-                        row.append(self.current_coord)
-                        if self.rotations_enabled:
-                            row.append(self.current_rotation)
-                    writer.writerow(row)
+                        stats["current_coord"] = self.current_coord
+                        stats["current_rotation"] = self.current_rotation
+                        stats["rotations_enabled"] = self.rotations_enabled
+                    self.data_store[hostname] = stats
 
-            return jsonify({"status": "success"}), 200
+                    if self.do_robo:
+                        csv_file = (
+                            os.path.join(
+                                self.path,
+                                f"{hostname}_{self.current_coord}_{self.current_rotation}.csv",
+                            )
+                            if self.rotations_enabled
+                            else os.path.join(
+                                self.path, f"{hostname}_{self.current_coord}.csv"
+                            )
+                        )
+                    else:
+                        csv_file = os.path.join(self.path, f"{hostname}.csv")
+                    with open(csv_file, mode="a", newline="") as file:
+                        writer = csv.writer(file)
+
+                        if os.path.getsize(csv_file) == 0:
+                            writer.writerow(self.header)
+                        timestamp = stats.get("timestamp", "")
+                        if self.audio and self.video:
+                            audio = stats.get("audio_stats", {})
+                            video = stats.get("video_stats", {})
+                            row = [
+                                timestamp,
+                                audio.get("au_sent_bitrate", 0),
+                                audio.get("au_sent_pkts", 0),
+                                audio.get("au_rtt", 0),
+                                audio.get("au_sent_codec", "NA"),
+                                audio.get("au_recv_jitter", 0),
+                                audio.get("au_recv_pkt_loss", 0),
+                                audio.get("au_recv_pkts", 0),
+                                audio.get("au_recv_codec", "NA"),
+                                video.get("vi_sent_bitrate", 0),
+                                video.get("vi_recv_bitrate", 0),
+                                video.get("vi_sent_frame_rate", 0),
+                                video.get("vi_sent_res", "NA"),
+                                video.get("vi_rtt", 0),
+                                video.get("vi_sent_pkts", 0),
+                                video.get("vi_sent_codec", "NA"),
+                                video.get("vi_processing", "NA"),
+                            ]
+                        elif self.audio:
+                            audio = stats.get("audio_stats", {})
+                            row = [
+                                timestamp,
+                                audio.get("au_sent_bitrate", 0),
+                                audio.get("au_sent_pkts", 0),
+                                audio.get("au_rtt", 0),
+                                audio.get("au_sent_codec", "NA"),
+                                audio.get("au_recv_jitter", 0),
+                                audio.get("au_recv_pkt_loss", 0),
+                                audio.get("au_recv_pkts", 0),
+                                audio.get("au_recv_codec", "NA"),
+                            ]
+
+                        elif self.video:
+                            video = stats.get("video_stats", {})
+                            row = [
+                                timestamp,
+                                video.get("vi_sent_bitrate", 0),
+                                video.get("vi_recv_bitrate", 0),
+                                video.get("vi_sent_frame_rate", 0),
+                                video.get("vi_sent_res", "NA"),
+                                video.get("vi_rtt", 0),
+                                video.get("vi_sent_pkts", 0),
+                                video.get("vi_sent_codec", "NA"),
+                                video.get("vi_processing", "NA"),
+                            ]
+
+                        if self.do_robo or self.do_bs:
+                            row.append(self.current_coord)
+                            if self.rotations_enabled:
+                                row.append(self.current_rotation)
+                        if self.do_bs:
+                            # Pre-fill exactly 10 default values to ensure CSV alignment never breaks
+                            bs_data = [
+                                "NA",
+                                "NA",
+                                "NA",
+                                "NA",
+                                "NA",
+                                "NA",
+                                "NA",
+                                "NA",
+                                self.from_coordinate,
+                                self.to_coordinate,
+                            ]
+
+                            try:
+                                x, y, _, _ = self.robo_obj.get_robot_pose()
+                                bs_data[0] = x
+                                bs_data[1] = y
+
+                                lf_wifi_data = self.get_signal_and_channel_data()
+                                sta_id = self.hostname_to_station_map.get(
+                                    hostname, None
+                                )
+
+                                if sta_id and sta_id in lf_wifi_data:
+                                    bs_data[2] = lf_wifi_data[sta_id]["signal"]
+                                    bs_data[3] = lf_wifi_data[sta_id]["channel"]
+                                    bs_data[4] = lf_wifi_data[sta_id]["mode"]
+                                    bs_data[5] = lf_wifi_data[sta_id]["tx_rate"]
+                                    bs_data[6] = lf_wifi_data[sta_id]["rx_rate"]
+                                    bs_data[7] = lf_wifi_data[sta_id]["bssid"]
+
+                            except Exception as e:
+                                logger.error(
+                                    f"Error getting data related to BandSteering: {e}"
+                                )
+
+                            # Extend the main row with exactly 10 items, whether the API calls passed or failed
+                            row.extend(bs_data)
+
+                        writer.writerow(row)
+
+                return jsonify({"status": "success"}), 200
+
+            elif request.method == "GET":
+                result = {}
+
+                for hostname, stats in self.data_store.items():
+                    audio = stats.get("audio_stats", {})
+                    video = stats.get("video_stats", {})
+
+                    # Grab current timestamp to prevent double-counting during GET polling
+                    current_timestamp = stats.get("timestamp", "")
+
+                    # Grab current values
+                    au_bitrate = audio.get("au_sent_bitrate", 0)
+                    au_rtt = audio.get("au_rtt", 0)
+                    vi_bitrate = video.get("vi_sent_bitrate", 0)
+                    vi_rtt = video.get("vi_rtt", 0)
+
+                    # 2. If this is the first time seeing this device, initialize its averages
+                    if hostname not in self.running_averages:
+                        self.running_averages[hostname] = {
+                            "Sent Audio bitrate(Kbps)": au_bitrate,
+                            "Audio RTT(ms)": au_rtt,
+                            "Sent video bitrate(Mbps)": vi_bitrate,
+                            "video RTT (ms)": vi_rtt,
+                            "count": 1,
+                            "last_timestamp": current_timestamp,
+                        }
+                    else:
+                        prev = self.running_averages[hostname]
+
+                        # 3. Only calculate a new average if the data point is actually NEW
+                        if prev["last_timestamp"] != current_timestamp:
+                            count = prev["count"]
+                            new_count = count + 1
+
+                            # Update the true running average using the previous value
+                            prev["Sent Audio bitrate(Kbps)"] = (
+                                prev["Sent Audio bitrate(Kbps)"] * count + au_bitrate
+                            ) / new_count
+                            prev["Audio RTT(ms)"] = (
+                                prev["Audio RTT(ms)"] * count + au_rtt
+                            ) / new_count
+                            prev["Sent video bitrate(Mbps)"] = (
+                                prev["Sent video bitrate(Mbps)"] * count + vi_bitrate
+                            ) / new_count
+                            prev["video RTT (ms)"] = (
+                                prev["video RTT (ms)"] * count + vi_rtt
+                            ) / new_count
+
+                            prev["count"] = new_count
+                            prev["last_timestamp"] = current_timestamp
+
+                    # 4. Format the output (rounded to 2 decimals for clean UI)
+                    result[hostname] = {
+                        "Sent Audio Bitrate(Kbps)": round(
+                            self.running_averages[hostname]["Sent Audio bitrate(Kbps)"],
+                            2,
+                        ),
+                        "Audio RTT(ms)": round(
+                            self.running_averages[hostname]["Audio RTT(ms)"], 2
+                        ),
+                        "Sent Video Bitrate(Mbps)": round(
+                            self.running_averages[hostname]["Sent video bitrate(Mbps)"],
+                            2,
+                        ),
+                        "Video RTT (ms)": round(
+                            self.running_averages[hostname]["video RTT (ms)"], 2
+                        ),
+                    }
+
+                    # 5. Attach the robot state
+                    if self.do_robo or self.do_bs:
+                        result[hostname]["robot_state"] = {
+                            "current_coord": self.current_coord,
+                            "current_rotation": self.current_rotation,
+                            "rotations_enabled": self.rotations_enabled,
+                        }
+
+                return jsonify(result), 200
 
         try:
             self.app.run(host='0.0.0.0', port=5005, debug=True, threaded=True, use_reloader=False)

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -722,7 +722,13 @@ class TeamsAutomation(Realm):
 
         if len(self.real_sta_list) == self.participants_joined:
             logging.info("All participants have joined the call. Starting the test.")
-
+        if self.do_bs:
+            self.bs_coord_result = self.robo_obj.get_coordinates_list()
+            if self.bs_coord_result:
+                self.from_coordinate = self.coordinates[0]
+                self.successful_coords.append(self.from_coordinate)
+            else:
+                sys.exit(1)
         self.set_start_time()
         logging.info("TEST WILL BE STARTING")
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -223,12 +223,42 @@ class TeamsAutomation(Realm):
         logging.error("Flask server did not start within 10 seconds. Exiting.")
         sys.exit(1)
 
-    def run(self):
-        flask_thread = threading.Thread(target=self.start_flask_server)
-        flask_thread.daemon = True
-        flask_thread.start()
-        self.wait_for_flask()
+    def change_port_to_ip(self, upstream_port):
+        """
+        Convert a given port name to its corresponding IP address if it's not already an IP.
 
+        This function checks whether the provided `upstream_port` is a valid IPv4 address.
+        If it's not, it attempts to extract the IP address of the port by resolving it
+        via the internal `name_to_eid()` method and then querying the IP using `json_get()`.
+
+        Args:
+            upstream_port (str): The name or IP of the upstream port. This could be a
+                                 LANforge port name like '1.1.eth1' or an IP address.
+
+        Returns:
+            str: The resolved IP address if the port name was converted successfully,
+                otherwise returns the original input if it was already an IP or
+                if resolution fails.
+        """
+        if upstream_port.count(".") != 3:
+            target_port_list = self.name_to_eid(upstream_port)
+            shelf, resource, port, _ = target_port_list
+            try:
+                target_port_ip = self.json_get(
+                    f"/port/{shelf}/{resource}/{port}?fields=ip"
+                )["interface"]["ip"]
+                upstream_port = target_port_ip
+            except Exception as e:
+                logging.warning(
+                    f"The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}. Exception: {e}"
+                )
+            logging.info(f"Upstream port IP {upstream_port}")
+        else:
+            logging.info(f"Upstream port IP {upstream_port}")
+
+        return upstream_port
+
+    def create_host(self):
         if self.generic_endps_profile.create(ports=[self.real_sta_list[0]], real_client_os_types=[self.real_sta_os_types[0]]):
             logging.info('Real client generic endpoint creation completed.')
         else:
@@ -239,9 +269,7 @@ class TeamsAutomation(Realm):
             cmd = f"py teams_host.py --ip {self.upstream_port}"
             self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[0], cmd)
         elif self.real_sta_os_types[0] == 'linux':
-
             cmd = "su -l lanforge ctteams.bash %s %s %s" % (self.wifi_interfaces_list[0], self.upstream_port, "host")
-
             self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[0], cmd)
         elif self.real_sta_os_types[0] == 'macos':
             cmd = "sudo bash ctteams.bash %s %s" % (self.upstream_port, "host")
@@ -249,9 +277,9 @@ class TeamsAutomation(Realm):
         self.generic_endps_profile.start_cx()
         time.sleep(5)
 
+    def wait_for_login(self):
         while not self.login_completed:
             try:
-
                 generic_endpoint = self.json_get(f'/generic/{self.generic_endps_profile.created_endp[0]}')
                 endp_status = generic_endpoint["endpoint"]["status"]
                 if endp_status == "Stopped":
@@ -262,6 +290,15 @@ class TeamsAutomation(Realm):
             except Exception as e:
                 logging.info(f"Error while checking login_completed status: {e}")
                 time.sleep(5)
+
+    def run(self):
+        flask_thread = threading.Thread(target=self.start_flask_server)
+        flask_thread.daemon = True
+        flask_thread.start()
+        self.wait_for_flask()
+
+        self.create_host()
+        self.wait_for_login()
 
         if self.generic_endps_profile.create(ports=self.real_sta_list[1:], real_client_os_types=self.real_sta_os_types[1:]):
             logging.info('Real client generic endpoint creation completed.')

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -82,7 +82,9 @@ class TeamsAutomation(Realm):
                  do_webui=None,
                  test_name=None,
                  report_dir=None,
-                 do_bs=None
+                 do_bs=None,
+                 do_robo=None,
+                 rotations_enabled=False
 
                  ):
         super().__init__(lfclient_host=lanforge_ip)
@@ -119,6 +121,10 @@ class TeamsAutomation(Realm):
         self.audio = audio
         self.video = video
         self.do_bs = do_bs
+        self.do_robo = do_robo
+        self.rotations_enabled = rotations_enabled
+        self.current_coord = None
+        self.current_rotation = "NA"
         self.audio_stats_header = [
             'Sent Audio Bitrate(Kbps)',
             'Sent Audio Packets',
@@ -148,6 +154,10 @@ class TeamsAutomation(Realm):
                 self.header += self.video_stats_header
             else:
                 self.header = ['timestamp'] + self.video_stats_header
+        if self.do_robo or self.do_bs:
+            self.header.append("current_coordinate")
+            if self.rotations_enabled:
+                self.header.append("current_rotation")
         self.data_store = {}
         self.stop_signal = False
         self.path = os.path.join(os.getcwd(), "teams_test_results")
@@ -617,6 +627,22 @@ class TeamsAutomation(Realm):
 
         self.lanforge_os_type = ["Linux"] * len(self.lanforge_port_list)
 
+    def delete_current_csv_files(self):
+        filename_pattern = (
+            f"*_{self.current_coord}_{self.current_rotation}.csv"
+            if self.rotations_enabled
+            else f"*_{self.current_coord}.csv"
+        )
+        csv_files_pattern = os.path.join(self.path, filename_pattern)
+        csv_files = glob.glob(csv_files_pattern)
+
+        for file_path in csv_files:
+            try:
+                os.remove(file_path)
+                logger.info(f"Deleted CSV file: {file_path}")
+            except Exception as e:
+                logger.error(f"Error deleting file {file_path}: {e}")
+
     def get_device_data(self):
         """
         Collect and correlate device, resource, and port information for real stations.
@@ -855,9 +881,21 @@ class TeamsAutomation(Realm):
             data = request.json
 
             for hostname, stats in data.items():
+                if self.do_robo or self.do_bs:
+                    stats["current_coord"] = self.current_coord
+                    stats["current_rotation"] = self.current_rotation
+                    stats["rotations_enabled"] = self.rotations_enabled
+
                 self.data_store[hostname] = stats
 
-                csv_file = os.path.join(self.path, f'{hostname}.csv')
+                if self.do_robo:
+                    csv_file = (
+                        os.path.join(self.path, f"{hostname}_{self.current_coord}_{self.current_rotation}.csv")
+                        if self.rotations_enabled
+                        else os.path.join(self.path, f"{hostname}_{self.current_coord}.csv")
+                    )
+                else:
+                    csv_file = os.path.join(self.path, f'{hostname}.csv')
                 with open(csv_file, mode='a', newline='') as file:
                     writer = csv.writer(file)
 
@@ -915,6 +953,10 @@ class TeamsAutomation(Realm):
                             video.get("vi_sent_codec", "NA"),
                             video.get("vi_processing", "NA"),
                         ]
+                    if self.do_robo or self.do_bs:
+                        row.append(self.current_coord)
+                        if self.rotations_enabled:
+                            row.append(self.current_rotation)
                     writer.writerow(row)
 
             return jsonify({"status": "success"}), 200
@@ -1027,6 +1069,8 @@ def main():
         optional.add_argument('--audio', action='store_true')
         optional.add_argument('--video', action='store_true')
         optional.add_argument('--do_bs', action='store_true', help='specify this flag to enable band-steering timing mode')
+        optional.add_argument('--do_robo', action='store_true', help='specify this flag to enable robo coordinate tracking mode')
+        optional.add_argument('--rotations_enabled', action='store_true', help='specify this flag to enable rotation tracking in robo mode')
         optional.add_argument('--do_webUI', action='store_true', help='useful to specify whether we are running through webui or cli')
         optional.add_argument('--testname', help="report directory while running test through web ui")
         optional.add_argument('--report_dir', help="report directory while running test through web ui")
@@ -1054,7 +1098,9 @@ def main():
             do_webui=args.do_webUI,
             test_name=args.testname,
             report_dir=args.report_dir,
-            do_bs=args.do_bs
+            do_bs=args.do_bs,
+            do_robo=args.do_robo,
+            rotations_enabled=args.rotations_enabled
 
         )
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1515,31 +1515,125 @@ class TeamsAutomation(Realm):
             sys.exit(0)
 
     def create_avg_data(self):
-        output_file = os.path.join(self.path, "teams_call_avg_data.csv")
+        exclude_cols = [
+            "timestamp",
+            "Sent Audio Codec",
+            "Received Audio Codec",
+            "Sent Video Resolution(px)",
+            "Sent Video Codec",
+            "Video Processing",
+            "current_coordinate",
+            "current_rotation",
+            "x",
+            "y",
+            "signal",
+            "channel",
+            "mode",
+            "tx_rate",
+            "rx_rate",
+            "bssid",
+            "from_coordinate",
+            "to_coordinate",
+        ]
+        if self.do_robo:
+            if self.rotations_enabled:
+                output_file = os.path.join(
+                    self.path,
+                    f"teams_call_avg_data_{self.current_coord}_{self.current_rotation}.csv",
+                )
+            else:
+                output_file = os.path.join(
+                    self.path, f"teams_call_avg_data_{self.current_coord}.csv"
+                )
+        else:
+            output_file = os.path.join(self.path, "teams_call_avg_data.csv")
         summary_rows = []
 
-        for csv_path in glob.glob(os.path.join(self.path, "*.csv")):
-            if csv_path.endswith("teams_cred.csv"):
-                continue
-            df = pd.read_csv(csv_path)
+        if self.do_robo:
+            if self.rotations_enabled:
+                logger.info(
+                    f"Creating average data for coordinate {self.current_coord} with rotation {self.current_rotation}"
+                )
+                for csv_path in glob.glob(
+                    os.path.join(
+                        self.path, f"*{self.current_coord}_{self.current_rotation}.csv"
+                    )
+                ):
+                    if csv_path.endswith("teams_cred.csv"):
+                        continue
+                    df = pd.read_csv(csv_path)
 
-            device_name = os.path.splitext(os.path.basename(csv_path))[0]
-            df = df.drop(columns=["timestamp"], errors="ignore")
+                    device_name = os.path.splitext(os.path.basename(csv_path))[0]
+                    df = df.drop(columns=exclude_cols, errors="ignore")
 
-            numeric_cols = df.select_dtypes(include="number").columns
-            averages = df[numeric_cols].mean().round(2)
+                    df = df.apply(pd.to_numeric, errors="coerce")
+                    averages = df.mean().round(2)
 
-            row = averages.to_dict()
-            row["Device Name"] = device_name
-            summary_rows.append(row)
+                    row = averages.to_dict()
+                    row["Device Name"] = device_name
+                    summary_rows.append(row)
+
+            else:
+                logger.info(
+                    f"Creating average data for coordinate {self.current_coord} with no rotation"
+                )
+
+                for csv_path in glob.glob(
+                    os.path.join(self.path, f"*{self.current_coord}.csv")
+                ):
+                    if csv_path.endswith("teams_cred.csv"):
+                        continue
+                    df = pd.read_csv(csv_path)
+
+                    device_name = os.path.splitext(os.path.basename(csv_path))[0]
+                    df = df.drop(columns=exclude_cols, errors="ignore")
+
+                    df = df.apply(pd.to_numeric, errors="coerce")
+                    averages = df.mean().round(2)
+
+                    row = averages.to_dict()
+                    row["Device Name"] = device_name
+                    summary_rows.append(row)
+        else:
+            logger.info(f"Creating average data for all devices")
+
+            for csv_path in glob.glob(os.path.join(self.path, "*.csv")):
+                if csv_path.endswith("teams_cred.csv") or csv_path.endswith(
+                    "teams_call_avg_data.csv"
+                ):
+                    continue
+                df = pd.read_csv(csv_path)
+
+                device_name = os.path.splitext(os.path.basename(csv_path))[0]
+                df = df.drop(columns=exclude_cols, errors="ignore")
+
+                df = df.apply(pd.to_numeric, errors="coerce")
+                averages = df.mean().round(2)
+
+                row = averages.to_dict()
+                row["Device Name"] = device_name
+                summary_rows.append(row)
 
         summary_df = pd.DataFrame(summary_rows)
 
-        cols = ["Device Name"] + [col for col in summary_df.columns if col != "Device Name"]
+        cols = ["Device Name"] + [
+            col for col in summary_df.columns if col != "Device Name"
+        ]
         summary_df = summary_df[cols]
 
         summary_df.to_csv(output_file, index=False)
         logger.info(f"Avg data saved to {output_file}")
+        self.avg_csv_files_list.append(
+            {
+                "file": output_file,
+                "coord": self.current_coord if self.do_robo else None,
+                "rotation": (
+                    self.current_rotation
+                    if self.do_robo and self.rotations_enabled
+                    else None
+                ),
+            }
+        )
 
     def stop_test_in_webui(self):
         try:

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -81,7 +81,8 @@ class TeamsAutomation(Realm):
                  video=None,
                  do_webui=None,
                  test_name=None,
-                 report_dir=None
+                 report_dir=None,
+                 do_bs=None
 
                  ):
         super().__init__(lfclient_host=lanforge_ip)
@@ -97,10 +98,11 @@ class TeamsAutomation(Realm):
         self.real_sta_os_types = []
         self.real_sta_hostname = []
         self.hostname_os_combination = []
-        self.wifi_interfaces = []
+        self.wifi_interfaces_list = []
         self.windows = 0
         self.linux = 0
         self.mac = 0
+        self.android = 0
         self.meet_link = None
         self.participants_joined = 0
         self.start_time = None
@@ -116,6 +118,7 @@ class TeamsAutomation(Realm):
         self.generic_endps_profile.type = "teams"
         self.audio = audio
         self.video = video
+        self.do_bs = do_bs
         self.audio_stats_header = [
             'Sent Audio Bitrate(Kbps)',
             'Sent Audio Packets',
@@ -185,7 +188,7 @@ class TeamsAutomation(Realm):
             obj = {
                 "configured_devices": self.real_sta_hostname,
                 "configuration_status": "configured",
-                "no_of_devices": f' Total({len(self.real_sta_os_types)}) : W({self.windows}),L({self.linux}),M({self.mac})',
+                "no_of_devices": f' Total({len(self.real_sta_os_types)}) : W({self.windows}),L({self.linux}),M({self.mac}),A({self.android})',
                 "device_list": self.hostname_os_combination,
             }
             self.updating_webui_runningjson(obj)
@@ -221,7 +224,7 @@ class TeamsAutomation(Realm):
             self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[0], cmd)
         elif self.real_sta_os_types[0] == 'linux':
 
-            cmd = "su -l lanforge ctteams.bash %s %s %s" % (self.wifi_interfaces[0], self.upstream_port, "host")
+            cmd = "su -l lanforge ctteams.bash %s %s %s" % (self.wifi_interfaces_list[0], self.upstream_port, "host")
 
             self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[0], cmd)
         elif self.real_sta_os_types[0] == 'macos':
@@ -255,7 +258,7 @@ class TeamsAutomation(Realm):
                 cmd = f"py teams_client.py --ip {self.upstream_port}"
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
             elif self.real_sta_os_types[i] == 'linux':
-                cmd = "su -l lanforge ctteams.bash %s %s %s" % (self.wifi_interfaces[i], self.upstream_port, "client")
+                cmd = "su -l lanforge ctteams.bash %s %s %s" % (self.wifi_interfaces_list[i], self.upstream_port, "client")
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
             elif self.real_sta_os_types[i] == 'macos':
                 cmd = "sudo bash ctteams.bash %s %s" % (self.upstream_port, "client")
@@ -319,7 +322,7 @@ class TeamsAutomation(Realm):
 
         test_parameters = pd.DataFrame([{
 
-            'No of Clients': f'W({self.windows}),L({self.linux}),M({self.mac})',
+            'No of Clients': f'W({self.windows}),L({self.linux}),M({self.mac}),A({self.android})',
             'Test Duration(min)': self.duration,
             "HOST": self.real_sta_list[0],
             "TEST TYPE": testtype
@@ -469,8 +472,12 @@ class TeamsAutomation(Realm):
             return False
 
     def set_start_time(self):
-        self.start_time = datetime.now(self.tz) + timedelta(seconds=30)
-        self.end_time = self.start_time + timedelta(minutes=self.duration)
+        if self.do_bs:
+            self.start_time = datetime.now(self.tz) + timedelta(seconds=30)
+            self.end_time = self.start_time + timedelta(days=24)
+        else:
+            self.start_time = datetime.now(self.tz) + timedelta(seconds=30)
+            self.end_time = self.start_time + timedelta(minutes=self.duration)
         return [self.start_time, self.end_time]
 
     def filter_ios_devices(self, device_list):
@@ -618,7 +625,7 @@ class TeamsAutomation(Realm):
             f"{hostname} ({os_type})"
             for hostname, os_type in zip(self.real_sta_hostname, self.real_sta_os_types)
         ]
-        self.wifi_interfaces = [item.split('.')[2] for item in self.real_sta_list]
+        self.wifi_interfaces_list = [item.split('.')[2] for item in self.real_sta_list]
 
         # Count OS types
         for os_type in self.real_sta_os_types:
@@ -628,6 +635,8 @@ class TeamsAutomation(Realm):
                 self.linux += 1
             elif os_type == 'macos':
                 self.mac += 1
+            elif os_type == 'android':
+                self.android += 1
         logger.info(f"Selected Real Devices: {self.real_sta_list}")
 
         return self.real_sta_list
@@ -907,6 +916,7 @@ def main():
         optional.add_argument('--lf_logger_config_json', help='lf_logger config json')
         optional.add_argument('--audio', action='store_true')
         optional.add_argument('--video', action='store_true')
+        optional.add_argument('--do_bs', action='store_true', help='specify this flag to enable band-steering timing mode')
         optional.add_argument('--do_webUI', action='store_true', help='useful to specify whether we are running through webui or cli')
         optional.add_argument('--testname', help="report directory while running test through web ui")
         optional.add_argument('--report_dir', help="report directory while running test through web ui")
@@ -933,7 +943,8 @@ def main():
             video=args.video,
             do_webui=args.do_webUI,
             test_name=args.testname,
-            report_dir=args.report_dir
+            report_dir=args.report_dir,
+            do_bs=args.do_bs
 
         )
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -648,11 +648,6 @@ class TeamsAutomation(Realm):
         self.wait_for_flask()
 
     def run(self):
-        flask_thread = threading.Thread(target=self.start_flask_server)
-        flask_thread.daemon = True
-        flask_thread.start()
-        self.wait_for_flask()
-
         self.create_host()
         self.wait_for_login()
         self.create_participants()
@@ -671,6 +666,45 @@ class TeamsAutomation(Realm):
                     f"Completed one cycle of test for coordinate {self.current_coord}"
                 )
             self.reset_variables_for_next_run()
+
+    def run_robo_test(self):
+        for coord in self.coordinates:
+            self.robo_obj.wait_for_battery()
+            matched, aborted = self.robo_obj.move_to_coordinate(coord=coord)
+            if matched:
+                self.current_coord = coord
+                self.successful_coords.append(coord)
+            else:
+                self.failed_coords.append(coord)
+
+            if aborted:
+                logger.error(f"Failed to Reach the coordinate {self.current_coord}")
+                self.failed_coords.append(coord)
+                sys.exit()
+
+            if self.rotations_enabled:
+                for rotation in self.rotations:
+                    self.robo_obj.wait_for_battery()
+                    rotated = self.robo_obj.rotate_angle(angle_degree=rotation)
+                    if rotated:
+                        self.current_rotation = rotation
+                    else:
+                        logger.error(
+                            f"Failed to Rotate the Angle {self.current_rotation}"
+                        )
+                        sys.exit()
+                    logger.info(
+                        f"Running Robo test for coordinate {coord} with rotation {rotation}"
+                    )
+                    self.run()
+                    self.create_avg_data()
+            else:
+                self.current_rotation = None  # Explicitly clear rotation state
+                logger.info(
+                    f"Running Robo test for coordinate {coord} with no rotation"
+                )
+                self.run()
+                self.create_avg_data()
 
     def wait_for_test_start(self):
         check_count = 0

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -267,19 +267,33 @@ class TeamsAutomation(Realm):
 
         self.generic_endps_profile.start_cx()
 
-        while not self.test_start:
-
-            logging.info("WAITING FOR THE TEST TO BE STARTED")
-            time.sleep(5)
-
-        self.set_start_time()
-        logging.info("TEST WILL BE STARTING")
+        self.wait_for_test_start()
 
         while datetime.now(self.tz) < self.end_time or not self.check_gen_cx():
             if self.stop_signal:
                 break
 
             time.sleep(5)
+
+    def wait_for_test_start(self):
+        check_count = 0
+        while len(self.real_sta_list) != self.participants_joined:
+            logging.info(
+                f"Waiting for all participants to join the call. Joined: {self.participants_joined}, Expected: {len(self.real_sta_list)}"
+            )
+            time.sleep(5)
+            check_count += 1
+            if check_count > 24:
+                logging.warning(
+                    f"Waited for 2 minutes but not all participants joined. Proceeding with the test with the participants that have joined. Joined: {self.participants_joined}, Expected: {len(self.real_sta_list)}"
+                )
+                break
+
+        if len(self.real_sta_list) == self.participants_joined:
+            logging.info("All participants have joined the call. Starting the test.")
+
+        self.set_start_time()
+        logging.info("TEST WILL BE STARTING")
 
     def generate_report(self):
         report = lf_report(_output_pdf='teams_call_report.pdf',
@@ -690,11 +704,10 @@ class TeamsAutomation(Realm):
         def get_participants_joined():
             return jsonify({"participants": self.participants_joined})
 
-        @self.app.route('/set_participants_joined', methods=['POST'])
+        @self.app.route('/set_participants_joined', methods=['GET'])
         def set_participants_joined():
-            data = request.json
-            self.participants_joined = data.get('participants_joined', None)
-            return jsonify({"message": f"Updated participants jopind status to {self.participants_joined}"})
+            self.participants_joined += 1
+            return jsonify({"message": f"Updated participants joined status to {self.participants_joined}"})
 
         @self.app.route('/get_participants_req', methods=['GET'])
         def get_participants_req():

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -732,6 +732,212 @@ class TeamsAutomation(Realm):
         self.set_start_time()
         logging.info("TEST WILL BE STARTING")
 
+    def add_bandsteering_report_section(self):
+        try:
+
+            """
+            Bandsteering reporting (Robo-style):
+            Reads all zoom stats CSVs from report directory (self.path) and builds:
+            - BSSID change count graph per device
+            - Table of BSSID change events
+            """
+
+            report_dir = self.path
+
+            if not report_dir or not os.path.isdir(report_dir):
+                logger.error(f"Bandsteering report: invalid report dir: {report_dir}")
+                return
+
+            logging.info(f"Bandsteering report dir: {report_dir}")
+
+            # Search for CSV files in self.path
+            csv_files = []
+            for hostname in self.real_sta_hostname:
+                csv_pattern = os.path.join(report_dir, f"*{hostname}*.csv")
+                csv_files.extend(glob.glob(csv_pattern))
+            logging.info(f"Bandsteering CSV files found: {csv_files}")
+
+            if not csv_files:
+                logging.warning("No CSVs found in report dir for bandsteering")
+                return
+
+            self.report.set_obj_html(
+                _obj_title="Band Steering Statistics",
+                _obj="This section summarizes BSSID changes observed while the robot moved between coordinates.",
+            )
+            self.report.build_objective()
+
+            allowed_bssids = set(self.bssids) if self.bssids else set()
+
+            for csv_file_path in csv_files:
+                try:
+                    df = pd.read_csv(csv_file_path)
+                except Exception as e:
+                    logging.error(
+                        f"Unable to read CSV {csv_file_path}: {e}", exc_info=True
+                    )
+                    continue
+
+                # Rename columns to match the specific capitalization expected by this logic
+                df.rename(
+                    columns={
+                        "timestamp": "TimeStamp",
+                        "bssid": "BSSID",
+                        "channel": "Channel",
+                        "from_coordinate": "From_Coord",
+                        "to_coordinate": "To_Coord",
+                    },
+                    inplace=True,
+                )
+
+                required_cols = {
+                    "TimeStamp",
+                    "BSSID",
+                    "From_Coord",
+                    "To_Coord",
+                    "Channel",
+                }
+
+                # Check if this CSV actually contains bandsteering data (skip summary/other CSVs)
+                if not required_cols.issubset(df.columns):
+                    continue
+
+                device_name = os.path.basename(csv_file_path).replace(".csv", "")
+
+                # Clean columns
+                df["BSSID"] = df["BSSID"].fillna("NA").astype(str)
+                df["TimeStamp"] = df["TimeStamp"].fillna("NA").astype(str)
+                df["From_Coord"] = df["From_Coord"].fillna("NA").astype(str)
+                df["To_Coord"] = df["To_Coord"].fillna("NA").astype(str)
+                df["Channel"] = df["Channel"].fillna("NA").astype(str)
+
+                # Filter only configured BSSIDs (if provided)
+                if allowed_bssids:
+                    df = df[df["BSSID"].isin(allowed_bssids)]
+
+                if df.empty:
+                    logging.info(f"No matching BSSID rows for {device_name}")
+
+                # Detect change points
+                df["prev_bssid"] = df["BSSID"].shift()
+
+                mask = (
+                    (df["BSSID"] != df["prev_bssid"])
+                    & (df["BSSID"] != "NA")
+                    & (df["prev_bssid"] != "NA")
+                    & (df["prev_bssid"].notnull())
+                )
+
+                bssid_list = df.loc[mask, "BSSID"].tolist()
+                timestamp_list = df.loc[mask, "TimeStamp"].tolist()
+                from_coordinate_list = df.loc[mask, "From_Coord"].tolist()
+                to_coordinate_list = df.loc[mask, "To_Coord"].tolist()
+                channel_list = df.loc[mask, "Channel"].tolist()
+
+                skip_table = not mask.any()
+
+                # Count BSSID switches
+                if skip_table:
+                    # Ensure all expected BSSIDs show zero
+                    bssid_counts = {bssid: 0 for bssid in self.bssids}
+                else:
+                    bssid_counts = Counter(bssid_list)
+
+                # Ensure consistent graph ordering
+                if self.bssids:
+                    final_bssid_counts = {
+                        bssid: bssid_counts.get(bssid, 0) for bssid in self.bssids
+                    }
+                else:
+                    final_bssid_counts = bssid_counts
+
+                x_axis = list(final_bssid_counts.keys())
+                y_axis = [[float(v)] for v in final_bssid_counts.values()]
+
+                self.report.set_obj_html(
+                    _obj_title=f"BSSID Change Count Of The Client {device_name}",
+                    _obj=" ",
+                )
+                self.report.build_objective()
+
+                graph = lf_bar_graph(
+                    _data_set=y_axis,
+                    _xaxis_name="BSSID",
+                    _yaxis_name="Number of Changes",
+                    _xaxis_categories=[""],
+                    _xaxis_label=x_axis,
+                    _graph_image_name=f"teams_bssid_change_count_{device_name}",
+                    _label=x_axis,
+                    _xaxis_step=1,
+                    _graph_title=f"Teams Bandsteering: BSSID change count for device : {device_name}",
+                    _title_size=16,
+                    _bar_width=0.15,
+                    _figsize=(18, 6),
+                    _dpi=96,
+                    _show_bar_value=True,
+                )
+
+                graph_png = graph.build_bar_graph()
+                self.report.set_graph_image(graph_png)
+                self.report.move_graph_image()
+                self.report.build_graph()
+
+                if skip_table:
+                    self.report.set_obj_html(
+                        _obj_title=f"Teams Band Steering Results for {device_name}",
+                        _obj="No band steering events observed for the configured BSSID list.",
+                    )
+                    self.report.build_objective()
+                    continue
+
+                self.report.set_obj_html(
+                    _obj_title=f"Teams Band Steering Results for {device_name}",
+                    _obj=" ",
+                )
+                self.report.build_objective()
+
+                table_df = pd.DataFrame(
+                    {
+                        "TimeStamp": timestamp_list,
+                        "BSSID": bssid_list,
+                        "Channel": channel_list,
+                        "From Coordinate": from_coordinate_list,
+                        "To Coordinate": to_coordinate_list,
+                    }
+                )
+
+                self.report.set_table_dataframe(table_df)
+                self.report.build_table()
+
+            # Handle Charging Timestamps (Check if robo_obj exists first)
+            if (
+                hasattr(self, "robo_obj")
+                and hasattr(self.robo_obj, "charging_timestamps")
+                and len(self.robo_obj.charging_timestamps) != 0
+            ):
+                self.report.set_obj_html(_obj_title="Charging Timestamps", _obj="")
+                self.report.build_objective()
+                df = pd.DataFrame(
+                    self.robo_obj.charging_timestamps,
+                    columns=[
+                        "charge_dock_arrival_timestamp",
+                        "charging_completion_timestamp",
+                    ],
+                )
+                # Add S.No column
+                df.insert(0, "S.No", range(1, len(df) + 1))
+                self.report.set_table_dataframe(df)
+                self.report.build_table()
+            else:
+                self.report.set_obj_html(
+                    _obj_title="Charging Timestamps",
+                    _obj="Robot did not go to charge during this test",
+                )
+                self.report.build_objective()
+        except Exception as e:
+            logger.error(f"Exeception Occured {e}")
+            logger.error("Error Occured ", exc_info=True)
+
     def generate_report(self):
         report = lf_report(_output_pdf='teams_call_report.pdf',
                            _output_html='teams_call_report.html',

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -156,6 +156,12 @@ class TeamsAutomation(Realm):
         self.do_webui = do_webui
         self.test_name = test_name
         self.report_dir = report_dir
+        self.lanforge_port_list = []
+        self.serial_list = []
+        self.lanforge_os_type = []
+        self.device_names = []
+        self.user_list = []
+        self.hostname_to_station_map = {}
 
     def updating_webui_runningjson(self, obj):
         data = {}
@@ -554,6 +560,103 @@ class TeamsAutomation(Realm):
         self.device_list = filtered_list
         return filtered_list
 
+    def get_android_device_data(self):
+        """
+        Fetch and process Android device information from the ADB interop API.
+
+        This method queries the '/adb' endpoint to retrieve connected Android
+        device details, matches devices against the configured user list,
+        and extracts relevant metadata for test execution.
+
+        Behavior:
+        - Supports both dictionary and list response formats from the API
+        - Filters devices based on matching 'user-name' entries
+        - Extracts device serial numbers and LANforge resource IDs
+        - Builds LANforge port identifiers in the format: 1.<resource>.eth0
+        - Populates internal lists used for endpoint and test setup
+
+        Side Effects:
+        - Updates self.serial_list with Android device serial numbers
+        - Updates self.lanforge_port_list with LANforge port identifiers
+        - Sets self.lanforge_os_type to 'Linux' for all discovered devices
+
+        Returns:
+            None
+        """
+        interop_data = self.json_get('/adb')
+        interop_mobile_data = interop_data.get('devices', {})
+
+        if isinstance(interop_mobile_data, dict):
+            for user in self.user_list:
+                if user != '':
+                    if interop_mobile_data.get('user-name') == user:
+                        serial = interop_mobile_data.get('name', '')
+                        resource = serial.split('.')[1]
+                        serial_no = serial.split('.')[2]
+                        self.serial_list.append(serial_no)
+                        lanforge_port = f"1.{resource}.eth0"
+                        self.lanforge_port_list.append(lanforge_port)
+                else:
+                    self.serial_list.append("")
+                    self.lanforge_port_list.append("")
+        else:
+            for user in self.user_list:
+                if user != '':
+                    for mobile_device in interop_mobile_data:
+                        for serial, device_data in mobile_device.items():
+                            if device_data.get('user-name') == user:
+                                resource = serial.split('.')[1]
+                                serial_no = serial.split('.')[2]
+                                self.serial_list.append(serial_no)
+                                lanforge_port = f"1.{resource}.eth0"
+                                self.lanforge_port_list.append(lanforge_port)
+                                break
+                else:
+                    self.serial_list.append("")
+                    self.lanforge_port_list.append("")
+
+        self.lanforge_os_type = ["Linux"] * len(self.lanforge_port_list)
+
+    def get_device_data(self):
+        """
+        Collect and correlate device, resource, and port information for real stations.
+
+        This method gathers metadata for devices listed in `self.real_sta_list` by:
+        1. Extracting user-specified resource identifiers from real station entries.
+        2. Querying the '/resource/all' API to map resources to device names,
+           controller IPs, EIDs, and associated users.
+        3. Querying the '/port/all' API to locate ports belonging to the matched
+           resources, preserving the order defined by the real station list.
+        4. Extracting wireless-specific attributes for ports associated with
+           the 'wiphy0' parent device.
+
+        Side Effects:
+        - Populates self.device_names with matched device hostnames
+        - Populates self.user_list with users associated with each resource
+
+        Returns:
+            None
+        """
+        ports_list = []
+        user_resources = [".".join(item.split(".")[:2]) for item in self.real_sta_list]
+
+        response = self.json_get("/resource/all")
+        resource_data_list = response.get("resources", [])
+
+        for user_resource in user_resources:
+            for element in resource_data_list:
+                if user_resource in element:
+                    resource_values = element[user_resource]
+                    self.device_names.append(resource_values["hostname"])
+                    self.user_list.append(resource_values["user"])
+                    ports_list.append(
+                        {
+                            "eid": resource_values["eid"],
+                            "ctrl-ip": resource_values["ctrl-ip"],
+                        }
+                    )
+                    break
+
     def select_real_devices(self, real_sta_list=None):
         """
         Selects real devices for testing.
@@ -627,6 +730,10 @@ class TeamsAutomation(Realm):
         ]
         self.wifi_interfaces_list = [item.split('.')[2] for item in self.real_sta_list]
 
+        self.hostname_to_station_map = dict(
+            zip(self.real_sta_hostname, self.real_sta_list)
+        )
+
         # Count OS types
         for os_type in self.real_sta_os_types:
             if os_type == 'windows':
@@ -638,6 +745,9 @@ class TeamsAutomation(Realm):
             elif os_type == 'android':
                 self.android += 1
         logger.info(f"Selected Real Devices: {self.real_sta_list}")
+
+        self.get_device_data()
+        self.get_android_device_data()
 
         return self.real_sta_list
 

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1,23 +1,30 @@
 #!/usr/bin/env python3
 """
-    NAME: lf_interop_teams.py
+NAME: lf_interop_teams.py
 
-    PURPOSE: lf_interop_teams.py provides the available devices and allows the user to start Microsoft Teams call conference meeting for the user-specified duration
+PURPOSE: lf_interop_teams.py provides the available devices and allows the user to start Microsoft Teams call conference meeting for the user-specified duration
 
-    EXAMPLE-1:
-    Command Line Interface to run Teams:
-    python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --participants 3 --duration 1 --audio --video
+EXAMPLE-1:
+Command Line Interface to run Teams:
+python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --duration 1 --audio --video
 
-    EXAMPLE-2:
-    Command Line Interface to run Teams on Specified Resources:
-    python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --participants 3 --duration 1 --audio --video --resources 1.95,1.400,1.300
+EXAMPLE-2:
+Command Line Interface to run Teams on Specified Resources:
+python3 lf_interop_teams.py --mgr 192.168.204.75 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300
 
+EXAMPLE-3:
+Command Line Interface to run Teams on Specified Resources with Robo Functionality:
+python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5
 
-    NOTES:
-    1. Use 'python3 lf_interop_teams.py --help' to see command line usage and options.
-    2. Always specify the duration in minutes (for example: --duration 3 indicates a duration of 3 minutes).
-    3. If --resources are not given after passing the CLI, a list of available devices will be displayed on the terminal.
-    4. Enter the resource numbers separated by commas (,) in the resource argument Eg: (1.95,1.200).
+EXAMPLE-4:
+Command Line Interface to run Teams on Specified Resources with Robo Functionality and Rotations Enabled:
+python3 lf_interop_teams.py --mgr 192.168.207.78 --upstream_port 1.1.eth1 --duration 1 --audio --video --resources 1.95,1.400,1.300 --do_robo --robo_ip 192.168.200.186 --coordinates 3,4,5 --rotations 30,40
+
+NOTES:
+1. Use 'python3 lf_interop_teams.py --help' to see command line usage and options.
+2. Always specify the duration in minutes (for example: --duration 3 indicates a duration of 3 minutes).
+3. If --resources are not given after passing the CLI, a list of available devices will be displayed on the terminal.
+4. Enter the resource numbers separated by commas (,) in the resource argument Eg: (1.95,1.200).
 
 """
 import os
@@ -37,6 +44,7 @@ import json
 import sys
 import traceback
 import glob
+from collections import Counter
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
@@ -60,15 +68,34 @@ lf_horizontal_stacked_graph = lf_graph.lf_horizontal_stacked_graph
 DeviceConfig = importlib.import_module("py-scripts.DeviceConfig")
 lf_base_interop_profile = importlib.import_module("py-scripts.lf_base_interop_profile")
 RealDevice = lf_base_interop_profile.RealDevice
+
+# robo_base_class = importlib.import_module("py-scripts.lf_robo_base_class")
 robo_base_class = importlib.import_module("py-scripts.lf_base_robo")
 
 # Set up logging
-logger = logging.getLogger(__name__)
-log = logging.getLogger('werkzeug')
+log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)
 
 # Import LF logger configuration module
 lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
+
+os.makedirs("test_logs", exist_ok=True)
+
+# 1. Configure the logging system
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler(
+            f"test_logs/lf_interop_teams_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.log",
+            mode="w",
+        ),  # Writes to file
+        logging.StreamHandler(sys.stdout),  # Writes to terminal
+    ],
+)
+
+# 2. Create the logger instance
+logger = logging.getLogger(__name__)
 
 
 class TeamsAutomation(Realm):

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -105,7 +105,6 @@ class TeamsAutomation(Realm):
         self.meet_link = None
         self.participants_joined = 0
         self.participants_req = participants_req
-        self.test_start = False
         self.start_time = None
         self.end_time = None
         self.audio = None
@@ -156,7 +155,6 @@ class TeamsAutomation(Realm):
         self.do_webui = do_webui
         self.test_name = test_name
         self.report_dir = report_dir
-        self.execute_finally = False
 
     def updating_webui_runningjson(self, obj):
         data = {}
@@ -470,6 +468,7 @@ class TeamsAutomation(Realm):
         except Exception as e:
             logging.error(f"Error in check_gen_cx function {e}", exc_info=True)
             logging.info(f"generic endpoint data {generic_endpoint}")
+            return False
 
     def set_start_time(self):
         self.start_time = datetime.now(self.tz) + timedelta(seconds=30)
@@ -713,15 +712,6 @@ class TeamsAutomation(Realm):
         def get_participants_req():
             return jsonify({"participants": self.participants_req})
 
-        @self.app.route('/test_started', methods=['GET', 'POST'])
-        def test_started():
-            if request.method == 'GET':
-                return jsonify({"test_started": self.test_start})
-            elif request.method == 'POST':
-                data = request.json
-                self.test_start = data.get('test_started', False)
-                return jsonify({"message": f"Updated test_start status to {self.test_start}"})
-
         @self.app.route('/get_start_end_time', methods=['GET'])
         def get_start_end_time():
             return jsonify({
@@ -878,6 +868,8 @@ class TeamsAutomation(Realm):
 
 
 def main():
+    args = None
+    teams = None
     try:
 
         parser = argparse.ArgumentParser(
@@ -977,15 +969,14 @@ def main():
         teams.run()
         time.sleep(10)
         teams.create_avg_data()
-        teams.execute_finally = True
 
     except Exception as e:
         logging.error(f"AN ERROR OCCURED WHILE RUNNING TEST {e}")
         traceback.print_exc()
 
     finally:
-        if not ('--help' in sys.argv or '-h' in sys.argv):
-            if teams.execute_finally:
+        if args is not None and not ('--help' in sys.argv or '-h' in sys.argv):
+            if teams is not None:
                 teams.stop_signal = True
                 teams.generate_report()
                 teams.move_csv_files()

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -588,6 +588,65 @@ class TeamsAutomation(Realm):
         self.generic_endps_profile.created_cx = []
         self.generic_endps_profile.created_endp = []
 
+    def get_signal_and_channel_data(self):
+        """
+        Returns a dictionary of LANforge stats keyed by station name.
+        Example: {'sta001': {'signal': -55, 'channel': 36, ...}}
+        """
+
+        lf_stats_map = {}
+        interfaces_dict = dict()
+
+        try:
+            # Get raw data from LANforge API
+            port_data = self.json_get("/ports/all/")["interfaces"]
+            for port in port_data:
+                interfaces_dict.update(port)
+        except Exception as e:
+            print(f"Error fetching port data: {e}")
+            return {}
+
+        # Loop through your managed stations (e.g., sta001, sta002)
+        for sta in self.real_sta_list:
+            # Default values if station is missing
+            lf_stats_map[sta] = {
+                "signal": "-",
+                "channel": "-",
+                "mode": "-",
+                "tx_rate": "-",
+                "rx_rate": "-",
+                "bssid": "-",
+            }
+
+            if sta in interfaces_dict:
+                data = interfaces_dict[sta]
+
+                # --- Signal Parsing ---
+                sig = data.get("signal", "-")
+                if "dBm" in str(sig):
+                    lf_stats_map[sta]["signal"] = sig.split(" ")[0]
+                else:
+                    lf_stats_map[sta]["signal"] = sig
+
+                # --- Other Fields ---
+                lf_stats_map[sta]["channel"] = data.get("channel", "-")
+                lf_stats_map[sta]["mode"] = data.get("mode", "-")
+                lf_stats_map[sta]["tx_rate"] = data.get("tx-rate", "-")
+                lf_stats_map[sta]["rx_rate"] = data.get("rx-rate", "-")
+                lf_stats_map[sta]["bssid"] = data.get(
+                    "ap", "-"
+                )  # 'ap' is usually BSSID
+
+        print(lf_stats_map)
+
+        return lf_stats_map
+
+    def handle_flask_server(self):
+        flask_thread = threading.Thread(target=self.start_flask_server)
+        flask_thread.daemon = True
+        flask_thread.start()
+        self.wait_for_flask()
+
     def run(self):
         flask_thread = threading.Thread(target=self.start_flask_server)
         flask_thread.daemon = True

--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -939,160 +939,236 @@ class TeamsAutomation(Realm):
             logger.error("Error Occured ", exc_info=True)
 
     def generate_report(self):
-        report = lf_report(_output_pdf='teams_call_report.pdf',
-                           _output_html='teams_call_report.html',
-                           _results_dir_name="teams_call_report",
-                           _path=self.path)
-        self.report_path_date_time = report.get_path_date_time()
+        try:
 
-        report.set_title("Teams Call Automated Report")
-        report.build_banner()
-
-        report.set_table_title("Objective:")
-        report.build_table_title()
-        report.set_text("The objective is to conduct automated Teams call tests across multiple laptops to gather statistics on sent audio, video, and received audio, video performance." +
-                        "The test will collect these statistics and store them in a CSV file. Additionally, automated graphs will be generated using the collected data.")
-        report.build_text_simple()
-
-        report.set_table_title("Test Parameters:")
-        report.build_table_title()
-        testtype = ""
-        if self.audio and self.video:
-            testtype = "AUDIO & VIDEO"
-        elif self.audio:
-            testtype = "AUDIO"
-        elif self.video:
-            testtype = "VIDEO"
-
-        test_parameters = pd.DataFrame([{
-
-            'No of Clients': f'W({self.windows}),L({self.linux}),M({self.mac}),A({self.android})',
-            'Test Duration(min)': self.duration,
-            "HOST": self.real_sta_list[0],
-            "TEST TYPE": testtype
-
-        }])
-        report.set_table_dataframe(test_parameters)
-        report.build_table()
-
-        # Read per-device average metrics
-        df = pd.read_csv(os.path.join(self.path, "teams_call_avg_data.csv"))
-        df.columns = df.columns.str.strip()
-
-        report.set_table_title("Test Devices:")
-        report.build_table_title()
-
-        device_details = pd.DataFrame({
-            'Hostname': self.real_sta_hostname,
-            'OS Type': self.real_sta_os_types,
-        })
-        report.set_table_dataframe(device_details)
-        report.build_table()
-
-        if self.audio:
-            metrics = [
-                ("Audio RTT(ms)", "Audio RTT (ms)"),
-                ("Received Audio Jitter(ms)", "Received Audio Jitter (ms)"),
-                ("Sent Audio Bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
-            ]
-
-        if self.video:
-            # Create bar graphs for each metric
-            metrics = [
-                ("Sent Video Bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
-                ("Received Video Bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
-                ("Sent Video Packets", "Sent Video Packets"),
-            ]
-        if self.audio and self.video:
-            # Create bar graphs for each metric
-            metrics = [
-                ("Audio RTT(ms)", "Audio RTT (ms)"),
-                ("Received Audio Jitter(ms)", "Received Audio Jitter (ms)"),
-                ("Sent Audio Bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
-                ("Sent Video Bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
-                ("Received Video Bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
-                ("Sent Video Packets", "Sent Video Packets"),
-            ]
-
-        for column, title in metrics:
-            report.set_graph_title(f"Average {title}")
-            report.build_graph_title()
-
-            bar_graph_horizontal = lf_bar_graph_horizontal(
-                _data_set=[df[column].tolist()],
-                _xaxis_name=f"AVG {title}",
-                _yaxis_name="Devices",
-                _yaxis_label=df["Device Name"].tolist(),
-                _yaxis_categories=df["Device Name"].tolist(),
-                _yaxis_step=1,
-                _yticks_font=8,
-                _bar_height=.25,
-                _color_name=["orange"],
-                _show_bar_value=True,
-                _figsize=(16, len(df) * 1 + 4),
-                _graph_title=f"AVG {title} Per Device",
-                _graph_image_name=title.replace(" ", "_"),
-                _label=[title]
+            self.report = lf_report(
+                _output_pdf="teams_call_report.pdf",
+                _output_html="teams_call_report.html",
+                _results_dir_name="teams_call_report",
+                _path=self.path,
             )
-            graph_image = bar_graph_horizontal.build_bar_graph_horizontal()
-            report.set_graph_image(graph_image)
-            report.move_graph_image()
-            report.build_graph()
+            self.report_path_date_time = self.report.get_path_date_time()
 
-        if self.audio:
-            selected_columns = [
-                "Device Name",
-                "Sent Audio Bitrate(Kbps)",
-                "Sent Audio Packets",
-                "Audio RTT(ms)",
-                "Received Audio Jitter(ms)",
-                "Received Audio Packet Loss(%)",
-            ]
+            self.report.set_title("Teams Call Automated Report")
+            self.report.build_banner()
 
-            column_headings = {
-                "Device Name": "Device Name",
-                "Sent Audio Bitrate(Kbps)": "AVG Sent Audio Bitrate (Kbps)",
-                "Sent Audio Packets": "AVG Sent Audio Packets",
-                "Audio RTT(ms)": "AVG Audio RTT (ms)",
-                "Received Audio Jitter(ms)": "AVG Received Audio Jitter (ms)",
-                "Received Audio Packet Loss(%)": "AVG Received Audio Packet Loss (%)",
-            }
+            self.report.set_table_title("Objective:")
+            self.report.build_table_title()
+            self.report.set_text(
+                "The objective is to conduct automated Teams call tests across multiple laptops to gather statistics on sent audio, video, and received audio, video performance."
+                + "The test will collect these statistics and store them in a CSV file. Additionally, automated graphs will be generated using the collected data."
+            )
+            self.report.build_text_simple()
 
-            filtered_df = df[selected_columns].rename(columns=column_headings)
+            self.report.set_table_title("Test Parameters:")
+            self.report.build_table_title()
+            testtype = ""
+            if self.audio and self.video:
+                testtype = "AUDIO & VIDEO"
+            elif self.audio:
+                testtype = "AUDIO"
+            elif self.video:
+                testtype = "VIDEO"
 
-            report.set_table_title("Test Audio Results Table")
-            report.build_table_title()
-            report.set_table_dataframe(filtered_df)
-            report.build_table()
+            test_parameters = pd.DataFrame(
+                [
+                    {
+                        "No of Clients": f"W({self.windows}),L({self.linux}),M({self.mac}),A({self.android})",
+                        "Test Duration(min)": self.duration,
+                        "HOST": self.real_sta_list[0],
+                        "TEST TYPE": testtype,
+                    }
+                ]
+            )
+            self.report.set_table_dataframe(test_parameters)
+            self.report.build_table()
 
-        if self.video:
-            selected_columns = [
-                "Device Name",
-                "Sent Video Bitrate(Mbps)",
-                "Received Video Bitrate(Mbps)",
-                "Sent Video Frame Rate(fps)",
-                "Video RTT (ms)",
-                "Sent Video Packets",
-            ]
+            self.report.set_table_title("Test Devices:")
+            self.report.build_table_title()
 
-            column_headings = {
-                "Device Name": "Device Name",
-                "Sent Video Bitrate(Mbps)": "AVG Sent Video Bitrate (Mbps)",
-                "Received Video Bitrate(Mbps)": "AVG Received Video Bitrate (Mbps)",
-                "Sent Video Frame Rate(fps)": "AVG Sent Video Frame Rate (fps)",
-                "Video RTT (ms)": "AVG Video RTT (ms)",
-                "Sent Video Packets": "AVG Sent Video Packets",
-            }
+            device_details = pd.DataFrame(
+                {
+                    "Hostname": self.real_sta_hostname,
+                    "OS Type": self.real_sta_os_types,
+                }
+            )
+            self.report.set_table_dataframe(device_details)
+            self.report.build_table()
 
-            filtered_df = df[selected_columns].rename(columns=column_headings)
+            if self.audio:
+                metrics = [
+                    ("Audio RTT(ms)", "Audio RTT (ms)"),
+                    ("Received Audio Jitter(ms)", "Received Audio Jitter (ms)"),
+                    ("Sent Audio Bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
+                ]
 
-            report.set_table_title("Test Video Results Table")
-            report.build_table_title()
-            report.set_table_dataframe(filtered_df)
-            report.build_table()
+            if self.video:
+                # Create bar graphs for each metric
+                metrics = [
+                    ("Sent Video Bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
+                    ("Received Video Bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
+                    ("Sent Video Packets", "Sent Video Packets"),
+                ]
+            if self.audio and self.video:
+                # Create bar graphs for each metric
+                metrics = [
+                    ("Audio RTT(ms)", "Audio RTT (ms)"),
+                    ("Received Audio Jitter(ms)", "Received Audio Jitter (ms)"),
+                    ("Sent Audio Bitrate(Kbps)", "Sent Audio Bitrate (Kbps)"),
+                    ("Sent Video Bitrate(Mbps)", "Sent Video Bitrate (Mbps)"),
+                    ("Received Video Bitrate(Mbps)", "Received Video Bitrate (Mbps)"),
+                    ("Sent Video Packets", "Sent Video Packets"),
+                ]
 
-        report.write_html()
-        report.write_pdf()
+            # Read per-device average metrics
+            self.generate_graphs_and_tables(metrics)
+            if self.do_robo and self.do_webui:
+                self.add_live_view_images_to_report()
+            if self.do_bs:
+                self.add_bandsteering_report_section()
+            self.report.write_html()
+            self.report.write_pdf()
+        except Exception as e:
+            logging.error(f"Error in generate_report function: {e}", exc_info=True)
+        finally:
+            self.move_csv_files()
+
+    def generate_graphs_and_tables(self, metrics):
+        """
+        Generate graphs and tables for the report based on the collected metrics.
+
+        This method reads the average metrics from the generated CSV files, creates
+        visualizations (bar graphs) for each specified metric, and compiles a summary
+        table of average values for all devices. The generated graphs and tables are
+        then added to the report.
+
+        Args:
+            metrics (list of tuples): A list of tuples where each tuple contains the metric name and its corresponding data.
+
+        """
+        for item in self.avg_csv_files_list:
+            csv_file = item.get("file")
+            coord = item.get("coord")
+            rotation = item.get("rotation")
+            df = pd.read_csv(csv_file)
+            df.columns = df.columns.str.strip()
+
+            logger.info(
+                f"checking metrics {metrics} in dataframe columns {df.columns.tolist()}"
+            )
+            logger.info(f"checking metrics dict {metrics}")
+
+            for column, title in metrics:
+                image_name = title.replace(" ", "_")
+                if self.do_robo:
+                    if self.rotations_enabled:
+                        self.report.set_graph_title(
+                            f"Average {title} for Coordinate {coord} with rotation {rotation}"
+                        )
+                        image_name = f"{image_name}_{coord}_{rotation}"
+                    else:
+                        self.report.set_graph_title(
+                            f"Average {title} for Coordinate {coord}"
+                        )
+                        image_name = f"{image_name}_{coord}"
+                else:
+                    self.report.set_graph_title(f"Average {title}")
+                self.report.build_graph_title()
+
+                bar_graph_horizontal = lf_bar_graph_horizontal(
+                    _data_set=[df[column].tolist()],
+                    _xaxis_name=f"AVG {title}",
+                    _yaxis_name="Devices",
+                    _yaxis_label=df["Device Name"].tolist(),
+                    _yaxis_categories=df["Device Name"].tolist(),
+                    _yaxis_step=1,
+                    _yticks_font=8,
+                    _bar_height=0.25,
+                    _color_name=["orange"],
+                    _show_bar_value=True,
+                    _figsize=(16, len(df) * 1 + 4),
+                    _graph_title=f"AVG {title} Per Device",
+                    _graph_image_name=image_name,
+                    _label=[title],
+                )
+                graph_image = bar_graph_horizontal.build_bar_graph_horizontal()
+                self.report.set_graph_image(graph_image)
+                self.report.move_graph_image()
+                self.report.build_graph()
+
+            if self.audio:
+                selected_columns = [
+                    "Device Name",
+                    "Sent Audio Bitrate(Kbps)",
+                    "Sent Audio Packets",
+                    "Audio RTT(ms)",
+                    "Received Audio Jitter(ms)",
+                    "Received Audio Packet Loss(%)",
+                ]
+
+                column_headings = {
+                    "Device Name": "Device Name",
+                    "Sent Audio Bitrate(Kbps)": "AVG Sent Audio Bitrate (Kbps)",
+                    "Sent Audio Packets": "AVG Sent Audio Packets",
+                    "Audio RTT(ms)": "AVG Audio RTT (ms)",
+                    "Received Audio Jitter(ms)": "AVG Received Audio Jitter (ms)",
+                    "Received Audio Packet Loss(%)": "AVG Received Audio Packet Loss (%)",
+                }
+
+                filtered_df = df[selected_columns].rename(columns=column_headings)
+
+                if self.do_robo:
+                    if self.rotations_enabled:
+                        self.report.set_table_title(
+                            f"Average Audio Metrics for {coord} with rotation {rotation}"
+                        )
+                    else:
+                        self.report.set_table_title(
+                            f"Average Audio Metrics for {coord}"
+                        )
+                else:
+                    self.report.set_table_title("Test Audio Results Table")
+
+                self.report.build_table_title()
+                self.report.set_table_dataframe(filtered_df)
+                self.report.build_table()
+
+            if self.video:
+                selected_columns = [
+                    "Device Name",
+                    "Sent Video Bitrate(Mbps)",
+                    "Received Video Bitrate(Mbps)",
+                    "Sent Video Frame Rate(fps)",
+                    "Video RTT (ms)",
+                    "Sent Video Packets",
+                ]
+
+                column_headings = {
+                    "Device Name": "Device Name",
+                    "Sent Video Bitrate(Mbps)": "AVG Sent Video Bitrate (Mbps)",
+                    "Received Video Bitrate(Mbps)": "AVG Received Video Bitrate (Mbps)",
+                    "Sent Video Frame Rate(fps)": "AVG Sent Video Frame Rate (fps)",
+                    "Video RTT (ms)": "AVG Video RTT (ms)",
+                    "Sent Video Packets": "AVG Sent Video Packets",
+                }
+
+                filtered_df = df[selected_columns].rename(columns=column_headings)
+
+                if self.do_robo:
+                    if self.rotations_enabled:
+                        self.report.set_table_title(
+                            f"Average Video Metrics for Coordinate {coord} with rotation {rotation}"
+                        )
+                    else:
+                        self.report.set_table_title(
+                            f"Average Video Metrics for Coordinate {coord}"
+                        )
+                else:
+                    self.report.set_table_title("Test Video Results Table")
+
+                self.report.build_table_title()
+                self.report.set_table_dataframe(filtered_df)
+                self.report.build_table()
 
     def check_gen_cx(self):
         try:

--- a/py-scripts/real_application_tests/teams_automation/teams_android.py
+++ b/py-scripts/real_application_tests/teams_automation/teams_android.py
@@ -1,0 +1,824 @@
+import uiautomator2 as u2
+import time
+from ppadb.client import Client as AdbClient
+import xml.etree.ElementTree as ET
+from datetime import datetime
+import argparse
+import pytz
+import requests
+import logging
+import os
+import sys
+
+
+class TeamsAndroid:
+    def __init__(
+        self,
+        host="127.0.0.1",
+        port=5037,
+        upstream_port=None,
+        meet_link=None,
+        participant_name=None,
+    ):
+        self.host = host
+        self.port = port
+        self.client = AdbClient(host=self.host, port=self.port)
+        self.serial = None
+        self.d = None
+        self.upstream_port = upstream_port
+        self.stop_signal = False
+        self.audio = True
+        self.video = True
+        self.meet_link = meet_link
+        self.start_time = None
+        self.end_time = None
+        self.tz = pytz.timezone("Asia/Kolkata")
+        self.base_url = f"http://{self.upstream_port}:5005"
+        self.participant_name = participant_name
+
+        os.makedirs(f"{os.getcwd()}/ms_teams_mobile_logs", exist_ok=True)
+
+        # Configure the logging system
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[
+                logging.FileHandler(
+                    f"{os.getcwd()}/ms_teams_mobile_logs/{self.participant_name}.log",
+                    mode="w",
+                ),  # Writes to file
+                logging.StreamHandler(sys.stdout),  # Writes to terminal
+            ],
+        )
+
+        # Create the logger instance
+        self.logger = logging.getLogger(__name__)
+
+    def get_devices(self):
+        """Return list of connected ADB serials"""
+        devices = self.client.devices()
+        return [d.serial for d in devices]
+
+    def connect(self, serial):
+        try:
+            self.d = u2.connect(serial)
+            self.serial = serial
+            self.logger.info(f"[{serial}] Connected")
+            return True
+        except Exception as e:
+            self.logger.error(f"[{serial}] Failed to connect: {e}")
+            return False
+
+    def open_chrome_incognito(self, d):
+        self.logger.info(f"[{d.serial}] open_chrome_incognito: START")
+        self.close_meeting(d)
+        time.sleep(10)
+
+        # Launch Chrome directly in incognito with Teams URL
+        d.app_start("com.android.chrome")
+
+        # Build selector, then wait for it
+        btn = d(resourceId="com.android.chrome:id/menu_button")
+
+        if btn.wait(timeout=10):  # <-- actively waits up to 5s
+            btn.click()
+        else:
+            raise RuntimeError("Menu button not found")
+
+        # Click "New Incognito tab"
+        incog_row = d(resourceId="com.android.chrome:id/new_incognito_tab_menu_id")
+        if incog_row.wait(timeout=10):
+            incog_row.click()
+        else:
+            raise RuntimeError("Incognito row not found")
+
+        count = 0
+        while "com.android.chrome:id/url_bar" not in d.dump_hierarchy():
+            time.sleep(1)
+            self.logger.info(f"Waiting for URL bar to appear for device {d.serial}...")
+            count += 1
+            if count > 60:
+                raise RuntimeError("URL bar not found in time in open_chrome_incognito")
+
+        url_bar = d(resourceId="com.android.chrome:id/url_bar")
+        if url_bar.wait(timeout=10):
+            url_bar.click()
+            url_bar.set_text("https://www.google.com")
+            d.press("enter")
+        else:
+            raise RuntimeError("URL bar not found in open_chrome_incognito")
+
+        time.sleep(10)
+        self.logger.info(f"[{d.serial}] open_chrome_incognito: PASS")
+
+    def get_credentials(self):
+        try:
+            response = requests.get(f"{self.base_url}/get_credentials", timeout=5)
+            if response.status_code == 200:
+                data = response.json()
+                email = data["email"].strip()
+                passwd = data["password"].strip()
+            else:
+                self.logger.error(
+                    f"Failed to get credentials: {response.json().get('log')}"
+                )
+                email = None
+                passwd = None
+        except requests.exceptions.RequestException as e:
+            self.logger.error(f"Error during credential request: {e}")
+            email = None
+            passwd = None
+
+        return email, passwd
+
+    def login_teams(self, d, email, passwd):
+        try:
+            self.logger.info(f"[{d.serial}] login_teams: START")
+            # Wait for the URL bar and type the Teams URL
+            count = 0
+            while "com.android.chrome:id/url_bar" not in d.dump_hierarchy():
+                time.sleep(1)
+                self.logger.info(
+                    f"Waiting for URL bar to appear for device {d.serial}..."
+                )
+                count += 1
+                if count > 60:
+                    raise RuntimeError("URL bar not found in time in login_teams")
+            url_bar = d(resourceId="com.android.chrome:id/url_bar")
+            if url_bar.wait(timeout=10):
+                url_bar.click()
+                url_bar.set_text("https://teams.microsoft.com/v2")
+                d.press("enter")
+            else:
+                raise RuntimeError("URL bar not found in login_teams")
+
+            if not email or not passwd:
+                raise RuntimeError("Email or password is None")
+            count = 0
+            while 'resource-id="i0116"' not in d.dump_hierarchy():
+                self.logger.info(
+                    f"Waiting for email input field to appear... for device {d.serial}"
+                )
+                time.sleep(2)
+                count += 1
+                if count > 60:
+                    raise RuntimeError("Email input field not found in time")
+
+            email_input = d.xpath('//*[@resource-id="i0116"]')
+            if email_input.wait(timeout=30):
+                email_input.set_text(email)
+                d.press("enter")
+            else:
+                self.logger.error(f"Email input not found for device {d.serial}")
+                raise RuntimeError("Email input not found")
+
+            time.sleep(10)
+            d.send_keys(passwd)
+
+            d.press("enter")
+            time.sleep(5)
+            d.press("enter")
+            time.sleep(20)
+            self.logger.info(f"[{d.serial}] login_teams: PASS")
+        except Exception as e:
+            self.logger.exception(f"[{d.serial}] login_teams: FAILED | {e}")
+            d.app_stop("com.android.chrome")
+            raise
+
+    def enter_meeting(self, d):
+        try:
+            self.logger.info(f"[{d.serial}] enter_meeting: START")
+            count = 0
+            while "com.android.chrome:id/url_bar" not in d.dump_hierarchy():
+                time.sleep(1)
+                self.logger.info(
+                    f"Waiting for URL bar to appear for device {d.serial}..."
+                )
+                count += 1
+                if count > 60:
+                    raise RuntimeError("URL bar not found in time in enter_meeting")
+
+            url_bar = d(resourceId="com.android.chrome:id/url_bar")
+            if url_bar.wait(timeout=10):
+                url_bar.click()
+                url_bar.set_text(
+                    self.meet_link,
+                )
+                d.press("enter")
+            else:
+                raise RuntimeError("URL bar not found in enter_meeting")
+
+            d.dump_hierarchy()
+            time.sleep(10)
+
+            # Wait for the "Allow while visiting the site" button to appear
+            count = 0
+            while "Allow while visiting the site" not in d.dump_hierarchy():
+                self.logger.info(
+                    f"⏳ Waiting for 'Allow while visiting the site' button to appear... for device {d.serial}"
+                )
+                time.sleep(2)
+                count += 1
+                if count > 120:
+                    raise RuntimeError(
+                        "'Allow while visiting the site' not found in time"
+                    )
+
+            allow_btn = d(text="Allow while visiting the site")
+
+            if allow_btn.wait(timeout=10):
+                self.logger.info(
+                    f"✅ 'Allow while visiting the site' button is present for device {d.serial}"
+                )
+                info = allow_btn.info
+
+                if info.get("enabled") and info.get("clickable"):
+                    allow_btn.click()
+                    self.logger.info(
+                        f"👉 Clicked 'Allow while visiting the site' button successfully for device {d.serial}"
+                    )
+                else:
+                    self.logger.warning(
+                        f"⚠️ Button found but not clickable yet for device {d.serial}"
+                    )
+
+            else:
+                raise RuntimeError("'Allow while visiting the site' button not found")
+
+            d.dump_hierarchy()
+            time.sleep(5)
+
+            count = 0
+            while "Turn camera on (Ctrl+Shift+O)" not in d.dump_hierarchy():
+                self.logger.info(
+                    f"⏳ Waiting for camera toggle button to appear... for device {d.serial}"
+                )
+                time.sleep(2)
+                count += 1
+                if count > 60:
+                    raise RuntimeError("Camera toggle button not found in time")
+
+            camera_toggle_btn = d(text="Turn camera on (Ctrl+Shift+O)")
+            if camera_toggle_btn.wait(timeout=120):
+                camera_toggle_btn.click()
+            else:
+                raise RuntimeError("Camera toggle button not found")
+
+            join_btn = d(resourceId="prejoin-join-button")
+            if join_btn.wait(timeout=60):
+                join_btn.click()
+            else:
+                raise RuntimeError("Join button not found")
+            time.sleep(10)
+            self.logger.info(f"[{d.serial}] enter_meeting: PASS")
+        except Exception as e:
+            self.logger.exception(f"[{d.serial}] enter_meeting: FAILED | {e}")
+            d.app_stop("com.android.chrome")
+            raise
+
+    def update_participation(self):
+
+        endpoint_url = f"{self.base_url}/set_participants_joined"
+        try:
+            response = requests.get(endpoint_url, timeout=5)
+            if response.status_code == 200:
+                self.logger.info("Device participation status updated successfully.")
+            else:
+                self.logger.error(
+                    f"Failed to update device participation status. Status code: {response.status_code}"
+                )
+        except requests.RequestException as e:
+            self.logger.error(f"Request error: {e}")
+
+    def enable_stats(self, d):
+        self.logger.info(f"[{d.serial}] enable_stats: START")
+        self.update_participation()
+        time.sleep(10)
+        count = 0
+        while "callingButtons-showMoreBtn" not in d.dump_hierarchy():
+            self.logger.info(
+                f"[{d.serial}] Waiting for More button to appear in call controls..."
+            )
+            time.sleep(1)
+            count += 1
+            if count > 180:
+                raise RuntimeError(
+                    "More button did not appear in call controls within 180 seconds"
+                )
+        more_btn = d(resourceId="callingButtons-showMoreBtn")
+        if more_btn.wait(timeout=180):
+            more_btn.click()
+        else:
+            raise RuntimeError("More button not found after UI indicated presence")
+        settings_btn = d(resourceId="SettingsMenuControl-id")
+        if settings_btn.wait(timeout=60):
+            settings_btn.click()
+        else:
+            raise RuntimeError("Settings button not found")
+        call_health_btn = d(resourceId="call-health-button")
+        if call_health_btn.wait(timeout=60):
+            call_health_btn.click()
+        else:
+            raise RuntimeError("Call health button not found")
+
+        count = 0
+        while self.start_time is None or self.end_time is None:
+            self.get_start_and_end_time()
+            count += 1
+            if count > 60:
+                self.logger.error(
+                    "Failed to receive start_time and end_time within 2 minutes. Exiting script."
+                )
+                sys.exit(1)
+            time.sleep(2)
+
+        try:
+            start_dt = datetime.fromisoformat(self.start_time.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(self.end_time.replace("Z", "+00:00"))
+            if start_dt.tzinfo is None:
+                start_dt = self.tz.localize(start_dt)
+            if end_dt.tzinfo is None:
+                end_dt = self.tz.localize(end_dt)
+        except Exception as e:
+            self.logger.error(
+                f"Invalid start_time or end_time format: start_time={self.start_time}, end_time={self.end_time}, error={e}"
+            )
+            sys.exit(1)
+
+        while start_dt > datetime.now(self.tz):
+            time.sleep(2)
+            self.logger.info("waiting for the start time")
+
+        while end_dt > datetime.now(self.tz):
+            audio_stats = {}
+            video_stats = {}
+            try:
+                if self.audio:
+                    audio_stats = self.collect_audio_stats(d)
+                if self.video:
+                    video_stats = self.collect_video_stats(d)
+                self.send_stats_to_server(d.serial, audio_stats, video_stats)
+            except Exception as e:
+                self.logger.error(f"[{d.serial}] Error collecting/uploading stats: {e}")
+            self.check_stop_signal()
+            if self.stop_signal:
+                self.logger.info("Stop signal received, exiting stats collection loop.")
+                break
+
+        self.close_meeting(d)
+        self.logger.info(f"[{d.serial}] enable_stats: PASS")
+
+    def check_stop_signal(self):
+        """Check the stop signal from the Flask server."""
+        try:
+            endpoint_url = f"{self.base_url}/check_stop"
+
+            response = requests.get(
+                endpoint_url, timeout=5
+            )  # Replace with your Flask server URL
+            if response.status_code == 200:
+
+                stop_signal_from_server = response.json().get("stop", False)
+
+                # Only update if the server's stop signal is True
+                if stop_signal_from_server:
+                    self.stop_signal = True
+                    self.logger.info(
+                        "Stop signal received from the server. Exiting the loop."
+                    )
+                else:
+
+                    self.logger.info(
+                        "No stop signal received from the server. Continuing."
+                    )
+            return self.stop_signal
+        except Exception as e:
+            self.logger.error(f"Error checking stop signal: {e}")
+            return False
+
+    def get_start_and_end_time(self):
+        endpoint_url = f"{self.base_url}/get_start_end_time"
+        try:
+            response = requests.get(endpoint_url, timeout=5)
+            if response.status_code == 200:
+                data = response.json()
+                self.start_time = data.get("start_time")
+                self.end_time = data.get("end_time")
+            else:
+                self.logger.error(
+                    f"Failed to fetch start/end time. Status code: {response.status_code}"
+                )
+        except requests.RequestException as e:
+            self.logger.error(f"Request error: {e}")
+        return None
+
+    def close_meeting(self, d):
+        d.app_stop("com.android.chrome")
+        self.logger.info(f"Closed Chrome on device {d.serial}")
+
+    def open_interop_app(self, d):
+        d.app_start("com.candela.wecan")
+        count = 0
+        while "com.candela.wecan:id/enter_button" not in d.dump_hierarchy():
+            time.sleep(1)
+            self.logger.info(f"Waiting for Interop app to load on device {d.serial}...")
+            count += 1
+            if count > 60:
+                raise RuntimeError(
+                    f"Interop app did not load in time for device {d.serial}"
+                )
+        enter_test_room = d(resourceId="com.candela.wecan:id/enter_button")
+        if enter_test_room.wait(timeout=10):
+            enter_test_room.click()
+        else:
+            raise RuntimeError(
+                f"Enter button not found in Interop app for device {d.serial}"
+            )
+        self.logger.info(f"Opened Interop app on device {d.serial}")
+
+    def collect_audio_stats(self, d):
+        self.logger.info(f"[{d.serial}] collect_audio_stats: START")
+        # Wait until "View more audio data" button appears
+        count = 0
+        while "View more audio data" not in d.dump_hierarchy():
+            time.sleep(1)
+            self.logger.info(
+                f"[{d.serial}] Waiting for 'View more audio data' button..."
+            )
+            count += 1
+            if count > 60:
+                raise RuntimeError(
+                    f"Timeout waiting for 'View more audio data' button on {d.serial}"
+                )
+
+        # Open panel
+        if d(text="View more audio data").wait(timeout=10):
+            try:
+                d(text="View more audio data").click()
+                self.logger.info(f"[{d.serial}] Clicked 'View more audio data' button")
+            except Exception as e:
+                self.logger.warning(
+                    f"[{d.serial}] Retrying click due to stale element: {e}"
+                )
+                time.sleep(5)
+                d(text="View more audio data").click()
+        else:
+            raise RuntimeError(
+                f"Audio panel not found or clickable for device {d.serial}"
+            )
+
+        # Wait for all resource-ids 0–7 to appear
+        expected_ids = [str(i) for i in range(8)]
+        count = 0
+
+        while True:
+            xml = d.dump_hierarchy()
+            tree = ET.fromstring(xml)
+            present_ids = {
+                node.attrib.get("resource-id")
+                for node in tree.findall(".//node")
+                if node.attrib.get("resource-id")
+            }
+
+            missing = set(expected_ids) - present_ids
+            if not missing:
+                self.logger.info(f"[{d.serial}] ✅ All Audio resource-ids found")
+                break
+
+            count += 1
+            if count > 30:
+                raise RuntimeError(
+                    f"Timeout waiting for Audio resource-ids {missing} on {d.serial}"
+                )
+
+            time.sleep(1)
+
+        # Now safe to grab
+        def grab(resource_id, default="NA", strip=""):
+            try:
+                parent = tree.find(f'.//*[@resource-id="{resource_id}"]')
+                if parent is not None:
+                    node = parent.find('node[@index="2"]')
+                    if node is not None:
+                        val = node.attrib.get("text", "")
+                        if val:
+                            return val.replace(strip, "").strip()
+            except Exception as e:
+                self.logger.error(
+                    f"[{d.serial}] XML parse failed for {resource_id}: {e}"
+                )
+            return default
+
+        audio_stats_data = {
+            "au_sent_bitrate": grab("0", "0", "Kbps"),
+            "au_sent_pkts": grab("1", "0", "packets"),
+            "au_rtt": grab("2", "0", "ms"),
+            "au_sent_codec": grab("3", "NA"),
+            "au_recv_jitter": grab("4", "0", "ms"),
+            "au_recv_pkt_loss": grab("5", "0", "%"),
+            "au_recv_pkts": grab("6", "0", "packets"),
+            "au_recv_codec": grab("7", "NA"),
+        }
+
+        count = 0
+        while True:
+            xml = d.dump_hierarchy()
+            if "Go back to call health root panel" in xml:
+                break
+            time.sleep(1)
+            self.logger.info(
+                f"[{d.serial}] Waiting for go back to call health panel..."
+            )
+            count += 1
+            if count > 60:
+                raise RuntimeError(
+                    f"Timeout waiting for 'Go back to call health root panel' on {d.serial}"
+                )
+
+        if d(text="Go back to call health root panel").wait(timeout=10):
+            try:
+                d(text="Go back to call health root panel").click()
+                self.logger.info(
+                    f"[{d.serial}] Clicked 'Go back to call health root panel'"
+                )
+            except Exception as e:
+                self.logger.warning(
+                    f"[{d.serial}] Retrying click due to stale element: {e}"
+                )
+                time.sleep(5)
+                d(text="Go back to call health root panel").click()
+        else:
+            raise RuntimeError(
+                f"'Go back to call health root panel' button not clickable on {d.serial}"
+            )
+
+        self.logger.info(f"[{d.serial}] collect_audio_stats: PASS")
+        return audio_stats_data
+
+    def collect_video_stats(self, d):
+        self.logger.info(f"[{d.serial}] collect_video_stats: START")
+        # Wait until "View more video data" button appears
+        count = 0
+        while "View more video data" not in d.dump_hierarchy():
+            time.sleep(1)
+            self.logger.info(
+                f"[{d.serial}] Waiting for 'View more video data' button..."
+            )
+            count += 1
+            if count > 60:
+                raise RuntimeError(
+                    f"Timeout waiting for 'View more video data' button on {d.serial}"
+                )
+
+        if d(text="View more video data").wait(timeout=10):
+            try:
+                d(text="View more video data").click()
+                self.logger.info(f"[{d.serial}] Clicked 'View more video data' button")
+            except Exception as e:
+                self.logger.warning(
+                    f"[{d.serial}] Retrying click due to stale element: {e}"
+                )
+                time.sleep(5)
+                d(text="View more video data").click()
+        else:
+            raise RuntimeError(
+                f"'View more video data' panel not found or clickable for device {d.serial}"
+            )
+
+        # Wait for all 8 resource-ids (0–7) to appear
+        expected_ids = [str(i) for i in range(8)]
+        count = 0
+
+        while True:
+            xml = d.dump_hierarchy()
+            tree = ET.fromstring(xml)
+
+            present_ids = {
+                node.attrib.get("resource-id")
+                for node in tree.findall(".//node")
+                if node.attrib.get("resource-id")
+            }
+
+            missing = set(expected_ids) - present_ids
+            if not missing:
+                self.logger.info(f"[{d.serial}] ✅ All video resource-ids found")
+                break
+
+            count += 1
+            if count > 30:
+                raise RuntimeError(
+                    f"Timeout waiting for video resource-ids {missing} on {d.serial}"
+                )
+
+            time.sleep(1)
+
+        # Grab helper
+        def grab(resource_id, default="NA", strip=""):
+            try:
+                parent = tree.find(f'.//*[@resource-id="{resource_id}"]')
+                if parent is not None:
+                    node = parent.find('node[@index="2"]')
+                    if node is not None:
+                        val = node.attrib.get("text", "")
+                        if val:
+                            return val.replace(strip, "").strip()
+            except Exception as e:
+                self.logger.error(
+                    f"[{d.serial}] XML parse failed for {resource_id}: {e}"
+                )
+            return default
+
+        # Collect video stats
+        video_stats_data = {
+            "vi_sent_bitrate": grab("0", "0", "Mbps"),
+            "vi_recv_bitrate": grab("1", "0", "Mbps"),
+            "vi_sent_frame_rate": grab("2", "0", "fps"),
+            "vi_sent_res": grab("3", "NA", "px"),
+            "vi_rtt": grab("4", "0", "ms"),
+            "vi_sent_pkts": grab("5", "0", "packets"),
+            "vi_sent_codec": grab("6", "NA"),
+            "vi_processing": grab("7", "NA"),
+        }
+
+        count = 0
+        while True:
+            xml = d.dump_hierarchy()
+            if "Go back to call health root panel" in xml:
+                break
+            time.sleep(1)
+            self.logger.info(
+                f"[{d.serial}] Waiting for go back to call health panel..."
+            )
+            count += 1
+            if count > 60:
+                raise RuntimeError(
+                    f"Timeout waiting for 'Go back to call health root panel' on {d.serial}"
+                )
+
+        if d(text="Go back to call health root panel").wait(timeout=10):
+            try:
+                d(text="Go back to call health root panel").click()
+                self.logger.info(
+                    f"[{d.serial}] Clicked 'Go back to call health root panel'"
+                )
+            except Exception as e:
+                self.logger.warning(
+                    f"[{d.serial}] Retrying click due to stale element: {e}"
+                )
+                time.sleep(5)
+                d(text="Go back to call health root panel").click()
+        else:
+            raise RuntimeError(
+                f"'Go back to call health root panel' button not clickable on {d.serial}"
+            )
+
+        self.logger.info(f"[{d.serial}] collect_video_stats: PASS")
+        return video_stats_data
+
+    def send_stats_to_server(self, serial, audio_stats, video_stats):
+        stats_data = {"timestamp": datetime.now().isoformat()}
+        if self.audio:
+            stats_data["audio_stats"] = audio_stats
+        if self.video:
+            stats_data["video_stats"] = video_stats
+        payload = {self.participant_name: stats_data}
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/upload_stats", json=payload, timeout=5
+            )
+            if response.status_code == 200:
+                self.logger.info(f"Stats uploaded for {self.participant_name}")
+            else:
+                self.logger.warning(
+                    f"Failed to upload stats for {self.participant_name}: {response.status_code} - {response.text}"
+                )
+        except Exception as e:
+            self.logger.error(
+                f"Exception during upload for {self.participant_name}: {e}"
+            )
+
+    def dump_xml(self, d):
+        xml = d.dump_hierarchy()
+        with open(f"dump_{d.serial}.xml", "w", encoding="utf-8") as f:
+            f.write(xml)
+
+
+if __name__ == "__main__":
+
+    teams_android = None
+
+    try:
+
+        parser = argparse.ArgumentParser(description="Teams Android Automation")
+        parser.add_argument(
+            "--devices",
+            type=str,
+            default="",
+            help="Comma-separated list of device serials to use. If empty, all connected devices are used.",
+        )
+        parser.add_argument(
+            "--meet_link",
+            type=str,
+            help="Teams meeting link to join.",
+            required=True,
+        )
+        parser.add_argument(
+            "--upstream_port",
+            type=str,
+            default=None,
+            help="Upstream port for LANforge connection.",
+            required=True,
+        )
+        parser.add_argument(
+            "--audio",
+            action="store_true",
+            help="Enable audio stats collection.",
+        )
+        parser.add_argument(
+            "--video",
+            action="store_true",
+            help="Enable video stats collection.",
+        )
+        parser.add_argument(
+            "--participant_name",
+            type=str,
+            default="Test Participant",
+            help="Name to use for the meeting participant.",
+            required=True,
+        )
+        args = parser.parse_args()
+
+        teams_android = TeamsAndroid(
+            upstream_port=args.upstream_port,
+            meet_link=args.meet_link,
+            participant_name=args.participant_name,
+        )
+        teams_android.audio = args.audio
+        teams_android.video = args.video
+        if not teams_android.audio and not teams_android.video:
+            teams_android.logger.error(
+                "At least one of --audio or --video must be enabled."
+            )
+            sys.exit(1)
+
+        if args.devices:
+            # Although the arg might say comma-separated, we only use the first one
+            serial = args.devices.split(",")[0]
+            teams_android.logger.info(f"Using specified device: {serial}")
+        else:
+            devices = teams_android.get_devices()
+            if not devices:
+                teams_android.logger.error("No devices connected, exiting.")
+                sys.exit(1)
+            serial = devices[0]
+            teams_android.logger.info(
+                f"No specific device provided, using first connected device: {serial}"
+            )
+
+        if not teams_android.connect(serial):
+            teams_android.logger.error("Failed to connect to device, exiting.")
+            sys.exit(1)
+
+        teams_android.logger.info(f"[{teams_android.serial}] Starting automation flow")
+
+        try:
+            teams_android.open_chrome_incognito(teams_android.d)
+            email, passwd = teams_android.get_credentials()
+            teams_android.login_teams(teams_android.d, email, passwd)
+            teams_android.enter_meeting(teams_android.d)
+            teams_android.enable_stats(teams_android.d)
+            teams_android.logger.info(
+                f"[{teams_android.serial}] Automation flow completed"
+            )
+        except RuntimeError as rt_err:
+            teams_android.logger.error(
+                f"[{teams_android.serial}] Flow aborted: {rt_err}"
+            )
+            sys.exit(1)
+
+    except Exception as e:
+        if teams_android is not None:
+            teams_android.logger.error(f"Exception in main: {e}")
+        else:
+            logging.error(f"Exception in main before TeamsAndroid init: {e}")
+        sys.exit(1)
+
+    finally:
+        if teams_android is not None and teams_android.d is not None:
+            try:
+                teams_android.close_meeting(teams_android.d)
+            except Exception as e:
+                teams_android.logger.error(
+                    f"Error closing meeting for {teams_android.serial}: {e}"
+                )
+
+            try:
+                teams_android.open_interop_app(teams_android.d)
+                teams_android.logger.info(
+                    f"open_interop_app completed for {teams_android.serial}"
+                )
+            except Exception as e:
+                teams_android.logger.error(
+                    f"Error running open_interop_app for {teams_android.serial}: {e}"
+                )

--- a/py-scripts/real_application_tests/teams_automation/teams_android_app.py
+++ b/py-scripts/real_application_tests/teams_automation/teams_android_app.py
@@ -1,0 +1,436 @@
+import uiautomator2 as u2
+import time
+from ppadb.client import Client as AdbClient
+from datetime import datetime
+import argparse
+import pytz
+import requests
+import logging
+import os
+import sys
+import traceback
+import subprocess
+
+
+class TeamsAndroidApp:
+    def __init__(
+        self,
+        host="127.0.0.1",
+        port=5037,
+        upstream_port=None,
+        meet_link=None,
+        participant_name=None,
+        serial=None,
+        audio=True,
+        video=True,
+    ):
+        self.host = host
+        self.client = AdbClient(host=self.host, port=port)
+        self.serial = serial
+        self.d = None
+        self.upstream_port = upstream_port
+        self.stop_signal = False
+        self.audio = audio
+        self.video = video
+        self.meet_link = meet_link
+        self.start_time = None
+        self.end_time = None
+        self.tz = pytz.timezone("Asia/Kolkata")
+        self.base_url = f"http://{self.upstream_port}:5005"
+        self.participant_name = participant_name
+
+        os.makedirs(f"{os.getcwd()}/ms_teams_mobile_logs", exist_ok=True)
+
+        # Configure the logging system
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[
+                logging.FileHandler(
+                    f"{os.getcwd()}/ms_teams_mobile_logs/{self.participant_name}.log",
+                    mode="w",
+                ),  # Writes to file
+                logging.StreamHandler(sys.stdout),  # Writes to terminal
+            ],
+        )
+
+        # Create the logger instance
+        self.logger = logging.getLogger(__name__)
+
+    def get_devices(self):
+        """Return list of connected ADB serials"""
+        devices = self.client.devices()
+        return [d.serial for d in devices]
+
+    def connect(self):
+        self.d = u2.connect(self.serial)
+        self.logger.info(f"[{self.participant_name} ({self.serial})] Connected")
+
+    def is_app_installed(self, package_name):
+        """Check if an app is installed on the device."""
+        result = subprocess.run(
+            ["adb", "-s", self.serial, "shell", "pm", "list", "packages", package_name],
+            capture_output=True, text=True
+        )
+        installed = f"package:{package_name}" in result.stdout
+        if not installed:
+            self.logger.error(
+                f"[{self.participant_name} ({self.serial})] App '{package_name}' is not installed on the device."
+            )
+        return installed
+
+    def update_participation(self):
+
+        endpoint_url = f"{self.base_url}/set_participants_joined"
+        try:
+            response = requests.get(endpoint_url, timeout=5)
+            if response.status_code == 200:
+                self.logger.info(
+                    f"[{self.participant_name} ({self.serial})] Device participation status updated successfully."
+                )
+            else:
+                self.logger.error(
+                    f"[{self.participant_name} ({self.serial})] Failed to update device participation status. Status code: {response.status_code}"
+                )
+        except requests.RequestException as e:
+            self.logger.error(
+                f"[{self.participant_name} ({self.serial})] Request error: {e}"
+            )
+
+    def check_stop_signal(self):
+        """Check the stop signal from the Flask server."""
+        try:
+            endpoint_url = f"{self.base_url}/check_stop"
+
+            response = requests.get(
+                endpoint_url, timeout=5
+            )
+            if response.status_code == 200:
+
+                stop_signal_from_server = response.json().get("stop", False)
+
+                # Only update if the server's stop signal is True
+                if stop_signal_from_server:
+                    self.stop_signal = True
+                    self.logger.info(
+                        "Stop signal received from the server. Exiting the loop."
+                    )
+                else:
+
+                    self.logger.info(
+                        "No stop signal received from the server. Continuing."
+                    )
+            return self.stop_signal
+        except Exception as e:
+            self.logger.error(
+                f"[{self.participant_name} ({self.serial})] Error checking stop signal: {e}"
+            )
+            return self.stop_signal
+
+    def close_meeting(self):
+        if self.d is not None:
+            self.d.app_stop("com.microsoft.teams")
+            self.logger.info(
+                f"Closed Teams App on device {self.participant_name} ({self.serial})"
+            )
+
+    def open_interop_app(self):
+        if self.d is None:
+            return
+        self.d.app_start("com.candela.wecan")
+        count = 0
+        while "com.candela.wecan:id/enter_button" not in self.d.dump_hierarchy():
+            time.sleep(1)
+            self.logger.info(
+                f"Waiting for Interop app to load on device {self.participant_name} ({self.serial})..."
+            )
+            count += 1
+            if count > 60:
+                raise Exception(
+                    f"Interop app did not load in time for device {self.participant_name} ({self.serial})"
+                )
+        enter_test_room = self.d(resourceId="com.candela.wecan:id/enter_button")
+        if enter_test_room.wait(timeout=10):
+            enter_test_room.click()
+        else:
+            raise Exception(
+                f"Enter button not found in Interop app for device {self.participant_name} ({self.serial})"
+            )
+        self.logger.info(
+            f"Opened Interop app on device {self.participant_name} ({self.serial})"
+        )
+
+    def get_start_and_end_time(self):
+        endpoint_url = f"{self.base_url}/get_start_end_time"
+        try:
+            response = requests.get(endpoint_url, timeout=5)
+            if response.status_code == 200:
+                data = response.json()
+                self.start_time = data.get("start_time")
+                self.end_time = data.get("end_time")
+            else:
+                self.logger.error(
+                    f"[{self.participant_name} ({self.serial})] Failed to fetch Start Time and End Time of the Test. Status code: {response.status_code}"
+                )
+        except requests.RequestException as e:
+            self.logger.error(
+                f"[{self.participant_name} ({self.serial})] Request error: {e}"
+            )
+
+    def dump_xml(self):
+        xml = self.d.dump_hierarchy()
+        with open(f"dump_{self.d.serial}.xml", "w", encoding="utf-8") as f:
+            f.write(xml)
+
+    def enable_audio(self):
+        wait_count = 0
+        while (
+            "Mic muted" not in self.d.dump_hierarchy()
+            and "Mic unmuted" not in self.d.dump_hierarchy()
+        ):
+            time.sleep(1)
+            self.logger.info(
+                f"Waiting for Mute/Unmute button to be available for device {self.participant_name} ({self.serial})..."
+            )
+            wait_count += 1
+            if wait_count > 60:
+                self.logger.error(
+                    f"Mute/Unmute button not found in time for device {self.participant_name} ({self.serial})"
+                )
+                return
+        if "Mic unmuted" in self.d.dump_hierarchy():
+            self.logger.info(
+                f"Audio is already unmuted for device {self.participant_name} ({self.serial})"
+            )
+            return
+        else:
+            unmute_btn = self.d(description="Mic muted")
+            if unmute_btn.wait(timeout=20):
+                unmute_btn.click()
+                self.logger.info(
+                    f"[{self.participant_name} ({self.serial})] Un Mute button clicked to unmute audio."
+                )
+            else:
+                self.logger.error(
+                    f"[{self.participant_name} ({self.serial})] Un Mute button not found to click."
+                )
+
+    def enable_video(self):
+        count = 0
+        while (
+            "Video is off" not in self.d.dump_hierarchy()
+            and "Video is on" not in self.d.dump_hierarchy()
+        ):
+            time.sleep(1)
+            self.logger.info(
+                f"Waiting for Video Turn on button {self.participant_name} ({self.serial})..."
+            )
+            count += 1
+            if count > 60:
+                self.logger.error(
+                    f"Unable to find Video Turn on Button or Video Turn off Button {self.participant_name} ({self.serial})"
+                )
+                return
+        if "Video is on" in self.d.dump_hierarchy():
+            self.logger.info(
+                f"Video is already on for Device {self.participant_name} - {self.serial}"
+            )
+            return
+        else:
+            video_btn = self.d(description="Video is off")
+            if video_btn.wait(timeout=20):
+                video_btn.click()
+                self.logger.info(
+                    f"[{self.participant_name} ({self.serial})] Video Turn on button clicked to enable video."
+                )
+            else:
+                self.logger.error(
+                    f"[{self.participant_name} ({self.serial})] Video Turn on button not found to click."
+                )
+
+    def join_meeting(self):
+        subprocess.run(
+            [
+                "adb",
+                "-s",
+                self.serial,
+                "shell",
+                "am",
+                "start",
+                "-a",
+                "android.intent.action.VIEW",
+                "-d",
+                self.meet_link,
+                "com.microsoft.teams",
+            ]
+        )
+
+        if self.video:
+            self.enable_video()
+        if self.audio:
+            self.enable_audio()
+
+        self.enter_participant_name()
+
+        wait_count = 0
+        while "Join now" not in self.d.dump_hierarchy():
+            time.sleep(1)
+            wait_count += 1
+            self.logger.info(
+                f"Waiting for meeting join screen to load on device {self.participant_name} ({self.serial})..."
+            )
+            if wait_count > 60:
+                self.logger.error(
+                    f"Meeting join screen did not load in time for device {self.participant_name} ({self.serial})"
+                )
+                sys.exit(1)
+
+        join_btn = self.d.xpath('//*[@text="Join now"]')
+
+        if join_btn.wait(timeout=20):
+            join_btn.click()
+            self.logger.info(
+                f"[{self.participant_name} ({self.serial})] Join now button clicked."
+            )
+        else:
+            self.logger.error(
+                f"[{self.participant_name} ({self.serial})] Join now button not found to click."
+            )
+            sys.exit(1)
+
+    def enter_participant_name(self):
+        wait_count = 0
+        while "Enter name" not in self.d.dump_hierarchy():
+            time.sleep(1)
+            wait_count += 1
+            self.logger.info(
+                f"Waiting for participant name input field to be available for device {self.participant_name} ({self.serial})..."
+            )
+            if wait_count > 60:
+                self.logger.error(
+                    f"Participant name input field did not appear in time for device {self.participant_name} ({self.serial})"
+                )
+                sys.exit(1)
+        name_input = self.d.xpath('//*[@text="Enter name"]')
+        if name_input.wait(timeout=20):
+            name_input.set_text(self.participant_name)
+            self.logger.info(
+                f"[{self.participant_name} ({self.serial})] Participant name entered."
+            )
+            time.sleep(2)
+        else:
+            self.logger.error(
+                f"[{self.participant_name} ({self.serial})] Participant name input field not found to enter name."
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    teams_android_app = None
+    try:
+
+        parser = argparse.ArgumentParser(description="Teams Android App Automation")
+        parser.add_argument("--upstream_port", type=str, help="Upstream server port")
+        parser.add_argument("--meet_link", type=str, help="Teams meeting link")
+        parser.add_argument("--participant_name", type=str, help="Participant name")
+        parser.add_argument(
+            "--audio",
+            action="store_true",
+            help="Enable audio stats collection.",
+        )
+        parser.add_argument(
+            "--video",
+            action="store_true",
+            help="Enable video stats collection.",
+        )
+        parser.add_argument(
+            "--device",
+            type=str,
+            default="",
+            help="Comma-separated list of device serials to use. If empty, all connected devices are used.",
+            required=True,
+        )
+        args = parser.parse_args()
+
+        teams_android_app = TeamsAndroidApp(
+            upstream_port=args.upstream_port,
+            meet_link=args.meet_link,
+            participant_name=args.participant_name,
+            serial=args.device.strip(),
+            audio=args.audio,
+            video=args.video,
+        )
+
+        test_device_serial = args.device.strip()
+
+        total_devices = teams_android_app.get_devices()
+        if test_device_serial not in total_devices:
+            logging.error(
+                f"Specified device serial '{test_device_serial}' not found among connected devices: {total_devices}"
+            )
+            sys.exit(1)
+
+        teams_android_app.connect()
+
+        if not teams_android_app.is_app_installed("com.microsoft.teams"):
+            sys.exit(1)
+        if not teams_android_app.is_app_installed("com.candela.wecan"):
+            sys.exit(1)
+
+        teams_android_app.join_meeting()
+        teams_android_app.update_participation()
+        count = 0
+        while (
+            teams_android_app.start_time is None
+            or teams_android_app.end_time is None
+        ):
+            teams_android_app.get_start_and_end_time()
+            count += 1
+            if count > 60:
+                teams_android_app.logger.error(
+                    "Failed to receive start_time and end_time within 2 minutes. Exiting script."
+                )
+                sys.exit(1)
+            time.sleep(2)
+
+        try:
+            start_dt = datetime.fromisoformat(
+                teams_android_app.start_time.replace("Z", "+00:00")
+            )
+            end_dt = datetime.fromisoformat(
+                teams_android_app.end_time.replace("Z", "+00:00")
+            )
+            if start_dt.tzinfo is None:
+                start_dt = teams_android_app.tz.localize(start_dt)
+            if end_dt.tzinfo is None:
+                end_dt = teams_android_app.tz.localize(end_dt)
+        except Exception as e:
+            teams_android_app.logger.error(
+                f"Invalid start_time or end_time format: start_time={teams_android_app.start_time}, end_time={teams_android_app.end_time}, error={e}"
+            )
+            sys.exit(1)
+
+        while start_dt > datetime.now(teams_android_app.tz):
+            time.sleep(2)
+            teams_android_app.logger.info("waiting for the start time")
+
+        while end_dt > datetime.now(teams_android_app.tz):
+            teams_android_app.check_stop_signal()
+            time.sleep(5)
+            if teams_android_app.stop_signal:
+                teams_android_app.logger.info(
+                    "Stop signal received, exiting stats collection loop."
+                )
+                break
+        # teams_android_app.dump_xml()
+
+    except Exception as e:
+        logging.error(f"An error occurred: {e}")
+        traceback.print_exc()
+    finally:
+        if teams_android_app:
+            teams_android_app.close_meeting()
+            try:
+                teams_android_app.open_interop_app()
+            except Exception as e:
+                logging.error(f"Failed to open interop app: {e}")


### PR DESCRIPTION
## Summary

Add robot-assisted robo and bandsteering test support to the Teams interop automation framework, introduce two new Android device automation scripts, and refactor the core orchestration flow into modular helpers.

## Changes

### Robo & Bandsteering Support
- Initialize `RobotClass` with coordinate, rotation, and cycle configuration under `do_robo`/`do_bs` flags
- Add `run_robo_test()` to loop through coordinates with optional rotations, battery checks, and per-coordinate avg data
- Add `monitor_test()` with robo battery-pause/reinitialize logic and bandsteering coordinate traversal
- Add `wait_for_test_start()` with bandsteering coordinate list initialization via `get_coordinates_list()`
- Add `get_signal_and_channel_data()` for querying per-station signal, channel, mode, tx/rx rate, and BSSID from LANforge API
- Enrich `/upload_stats` POST with bandsteering telemetry (x, y, signal, channel, bssid, from/to coordinate) and add GET handler for running averages

### Reporting
- Add `add_bandsteering_report_section()` for BSSID change detection, bar graphs, event tables, and charging timestamps
- Add `add_live_view_images_to_report()` for injecting video/audio heatmap PNGs into the HTML report
- Refactor `generate_report()` with try/except/finally and extract `generate_graphs_and_tables()` for multi-coordinate support
- Update `create_avg_data()` with per-coordinate output files and column exclusion for non-numeric/BS fields

### Android Automation (New Files)
- **teams_android.py**: Automates Teams meeting join via Chrome incognito using uiautomator2, collects real-time audio/video call health stats from in-call UI panels, and uploads to the Flask server
- **teams_android_app.py**: Automates Teams meeting join via the native Android app using ADB intents and uiautomator2, with participant name entry, audio/video toggling, and test lifecycle synchronization

### Orchestration Refactor
- Decompose monolithic `run()` into `create_host()`, `wait_for_login()`, `create_participants()`, and `handle_flask_server()`
- Add `change_port_to_ip()` for resolving LANforge port names to IP addresses
- Add `reset_variables_for_next_run()` and `delete_current_csv_files()` for robo re-run state management
- Remove obsolete `participants_req`, `test_start` state, and `/test_started` endpoint
- Update `shutdown()` and `stop_test_in_webui()` with proper cleanup sequencing

### CLI & Misc
- Add robo argument group (`--robo_ip`, `--coordinates`, `--rotations`, `--do_robo`, `--do_bs`, `--cycles`, `--bssids`)
- Move `--duration` from required to optional; add `--enable_mobile_stats`
- Rename endpoint prefix/type from Zoom to Teams; normalize stats header names
- Add dual file+console logging with timestamped log files under `test_logs/`
- Add `gen_cxprofile.py` change to support teams test type in command parsing
