### PR TITLE
lf_interop_ping.py : Fix endpoint key handling in get_results function for multi-device response

### DIFF
--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -364,10 +364,13 @@ class Ping(Realm):
         logging.debug(self.generic_endps_profile.created_endp)
         results = self.json_get(
             "/generic/{}".format(','.join(self.generic_endps_profile.created_endp)))
-        if (len(self.generic_endps_profile.created_endp) > 1):
+        if (len(self.generic_endps_profile.created_endp) > 1) and 'endpoints' in results.keys():
             results = results['endpoints']
         else:
-            results = results['endpoint']
+            try:
+                results = results['endpoint']
+            except Exception as e:
+                logger.error(f"Endpoint not found {e}")
         return (results)
 
     def generate_remarks(self, station_ping_data):


### PR DESCRIPTION
- Add check for 'endpoints' key when multiple devices are present
- fallback to 'endpoint' using try/except to avoid key errors 
VERIFIED CLI : python3 lf_interop_ping.py --mgr 192.168.207.75 --real --target 192.168.204.72 --ping_interval 1 
--ping_duration 1  --use_default_config