### PR TITLE
update_dependencies.py : Add flask,pytz,python-dotenv modules.

### DIFF
--- a/py-scripts/update_dependencies.py
+++ b/py-scripts/update_dependencies.py
@@ -34,6 +34,9 @@ pip_packages: list = [
     'xlsxwriter',
     'pytesseract',
     'opencv-python',
+    'flask',
+    'pytz',
+    'python-dotenv',
 ]
 
 


### PR DESCRIPTION
Hi @smileyrekiere ,
These modules are required for the upcoming PR (`lf_multi_traffic.py` — new file). In this file, classes are externally imported from the `py-scripts/real_application_tests/` directory, and those scripts depend on modules such as `flask`, `pytz`, and `python-dotenv`.

When I pushed the commits for `lf_multi_traffic.py` in our forked scripts repo for the purpose of PR, the CI HELPER linter (part of the GitHub Actions workflow) failed. Therefore, these modules need to be added to `update_dependencies.py` to ensure the GitHub Action (HELPER CHECK) passes successfully.

Previously, these dependencies were not flagged when pushing `real_application_tests` because the CI linter (`lf_help_check.py`) only runs for scripts strictly present under `py-scripts/`. As a result, scripts inside `py-scripts/real_application_tests` were not being checked.

It would also be good to include the dependencies required by the real application tests in the same `update_dependencies.py` file for consistency and to avoid similar issues in the future.

Please let me know if there are any concerns.

++ @a-gavin  @goyalsaurabh06 