### PR TITLE
add FTM_WAIT and NO-CX to valid idle endpoint statuses

### DIFF
--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -1001,7 +1001,7 @@ class RealBrowserTest(Realm):
                 return False  # Handle case where endpoint data is not available
             endp_status = generic_endpoint["endpoint"].get("status", "")
             # If the endpoint status is not 'Stopped' or 'WAITING', return False
-            if endp_status not in ["Stopped", "WAITING"]:
+            if endp_status not in ["Stopped", "WAITING", "FTM_WAIT", "NO-CX"]:
                 return False
         # If all endpoints are in 'Stopped' or 'WAITING', return True
         return True

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -719,7 +719,7 @@ class ZoomAutomation(Realm):
 
                 endp_status = generic_endpoint["endpoint"].get("status", "")
 
-                if endp_status not in ["Stopped", "WAITING", "NO-CX"]:
+                if endp_status not in ["Stopped", "WAITING", "NO-CX", "FTM_WAIT"]:
                     return False
 
             return True


### PR DESCRIPTION
lf_interop_real_browser.py: add FTM_WAIT and NO-CX to valid idle endpoint statuses
lf_interop_zoom.py: add FTM_WAIT to valid idle endpoint statuses