### PR TITLE
Harmonize CLI parameters for RAG readiness

### DIFF
--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -708,10 +708,11 @@ class LFCliBase:
             parser = argparse.ArgumentParser()
         optional = parser.add_argument_group('arguments with PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in /lanforge-scripts/py-json/LANforge/lfcli_base.py')
         required = parser.add_argument_group('arguments with NO PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in  /lanforge-scripts/py-json/LANforge/lfcli_base.py')
-        optional.add_argument('--mgr',
+        optional.add_argument('--mgr', "--m", "lanforge_ip", dest="mgr",
                               default='localhost',
                               help='hostname for where LANforge GUI is running')
-        optional.add_argument('--mgr_port',
+        optional.add_argument('--mgr_port', '--port', '--o', '--lanforge_port',
+                              dest='port',
                               default=8080,
                               help='port LANforge GUI HTTP service is running on')
         optional.add_argument('--debug',
@@ -757,14 +758,22 @@ class LFCliBase:
         # Optional Args
         optional.add_argument('--mgr',
                               '--lfmgr',
+                              '--m',
+                              '--lanforge_ip',
+                                dest='mgr',
                               default='localhost',
                               help='Hostname or IP address of the LANforge GUI machine (localhost is default)')
         optional.add_argument('--mgr_port',
                               '--port',
+                              '--o',
+                              '--lanforge_port',
+                              dest='port',
                               default=8080,
                               help='IP Port the LANforge GUI is listening on (8080 is default)')
         optional.add_argument('-u',
                               '--upstream_port',
+                              '--upstream',
+                              dest='upstream',
                               default='1.eth1',
                               help='non-station port that generates traffic: <resource>.<port>, e.g: 1.eth1')
         optional.add_argument('--num_stations',
@@ -774,14 +783,15 @@ class LFCliBase:
         optional.add_argument('--test_id',
                               default="webconsole",
                               help='Test ID (intended to use for ws events)')
-        optional.add_argument('-d',
-                              '--debug',
+        optional.add_argument('--debug',
                               action="store_true",
                               help='Enable debugging')
         optional.add_argument('--log_level',
+                              dest="log_level",
                               default=None,
                               help='Set logging level: debug | info | warning | error | critical')
         optional.add_argument('--lf_logger_config_json',
+                              dest="lf_logger_config_json",
                               help="--lf_logger_config_json <json file> , json configuration of logger")
         optional.add_argument('--proxy',
                               nargs='?',
@@ -816,17 +826,19 @@ class LFCliBase:
                     optional.add_argument(argument['name'], help=argument['help'])
 
         # Required Args
-        required.add_argument('--radio',
-                              help='radio EID, e.g: 1.wiphy2')
+        required.add_argument('--radio', default='wiphy0',
+                              help='create stations in lanforge at this radio (by default: wiphy0)')
         # Silently support capitalized security types
         required.add_argument('--security',
                               default="open",
                               help='WiFi Security protocol: < open | wep | wpa | wpa2 | wpa3 >')
         required.add_argument('--ssid',
                               help='WiFi SSID for script objects to associate to')
-        required.add_argument('--passwd',
+        required.add_argument('--paswd',
+                              '--passwd',
                               '--password',
                               '--key',
+                              dest='paswd',
                               default="[BLANK]",
                               help='WiFi passphrase/password/key')
         # please override this password argument using set_defaults(passwd='NA')

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -33,12 +33,12 @@ def cv_base_adjust_parser(args):
 
 def cv_add_base_parser(parser):
     """Update provided argparse argument parser with Chamber View-specific arguments."""
-    parser.add_argument("-m", "--mgr",
+    parser.add_argument("-m", "--mgr", "--lfmgr", "--lanforge_ip",
                         dest="mgr",
                         type=str,
                         default="localhost",
                         help="Hostname or IP address of the LANforge GUI machine (localhost is default)")
-    parser.add_argument("-o", "--port",
+    parser.add_argument("-o", "--port", "--mgr_port", "--lanforge_port",
                         dest="port",
                         type=int,
                         default=8080,

--- a/py-scripts/create_station.py
+++ b/py-scripts/create_station.py
@@ -1076,7 +1076,7 @@ def main():
     create_station = CreateStation(**vars(args),
                                    sta_list=station_list,
                                    up=(not args.create_admin_down),
-                                   password=args.passwd,
+                                   password=args.paswd,
                                    set_txo_data=None)
 
     if not args.no_pre_cleanup:

--- a/py-scripts/lf_dataplane_test.py
+++ b/py-scripts/lf_dataplane_test.py
@@ -22,7 +22,7 @@ NOTES:      To best understand the Dataplane test, please review manual configur
 EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated theoretical rate for one minute
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations           1.1.wlan0 \
                 --duration          1m \
                 --traffic_type      UDP \
                 --traffic_direction DUT-TX \
@@ -31,7 +31,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT receive test. Configure TCP traffic at 1 Gbps
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations           1.1.wlan0 \
                 --traffic_type      TCP \
                 --traffic_direction DUT-RX \
                 --rate              1Gbps
@@ -39,7 +39,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT transmit and receive test with multiple 250Mbps traffic configurations
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations           1.1.wlan0 \
                 --traffic_type      UDP,TCP \
                 --traffic_direction DUT-TX,DUT-RX \
                 --rate              250Mbps
@@ -48,7 +48,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Note that radio must support specified parameters. Recommended to first configure manually
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      UDP \
                 --rate              100Mbps \
                 --nss               1,2,3,4 \
@@ -58,7 +58,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # The values specified are *parsed as dB*
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --rate              100Mbps \
                 --attenuator1       "1.1.3273" \
                 --atten1_min        10 \
@@ -70,7 +70,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Ensure attenuation values are separated by two periods, otherwise test will not parse properly
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --rate              100Mbps \
                 --attenuator1       "1.1.3273" \
                 --attenuations1     "0..+100..955" \
@@ -82,7 +82,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
 
             {
                 "upstream": "1.1.eth1",
-                "station": "1.1.wlan0",
+                "stations": "1.1.wlan0",
                 "rate": "1Gbps"
             }
 
@@ -240,7 +240,7 @@ class DataplaneTest(cv_test):
         self.test_name = "Dataplane"
 
         self.upstream = upstream
-        self.station = station
+        self.stations = station
         self.dut = dut
         self.opposite_speed = opposite_speed
         self.speed = speed
@@ -370,8 +370,8 @@ class DataplaneTest(cv_test):
         # General test configuration
         if self.upstream != "":
             cfg_options.append("upstream_port: " + self.upstream)
-        if self.station != "":
-            cfg_options.append("traffic_port: " + self.station)
+        if self.stations != "":
+            cfg_options.append("traffic_port: " + self.stations)
         if self.duration != "":
             cfg_options.append("duration: " + self.duration)
 
@@ -470,7 +470,7 @@ NOTES:      To best understand the Dataplane test, please review manual configur
 EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated theoretical rate for one minute
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --duration          1m \
                 --traffic_type      UDP \
                 --traffic_direction DUT-TX \
@@ -479,7 +479,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT receive test. Configure TCP traffic at 1 Gbps
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      TCP \
                 --traffic_direction DUT-RX \
                 --rate              1Gbps
@@ -487,7 +487,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT transmit and receive test with multiple 250Mbps traffic configurations
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      UDP,TCP \
                 --traffic_direction DUT-TX,DUT-RX \
                 --rate              250Mbps
@@ -496,7 +496,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Note that radio must support specified parameters. Recommended to first configure manually
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      UDP \
                 --rate              100Mbps \
                 --nss               1,2,3,4 \
@@ -506,7 +506,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Ensure attenuation values are separated by two periods, otherwise test will not parse properly
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --rate              100Mbps \
                 --attenuator1       "1.1.3273" \
                 --attenuations1     "0..+100..955" \
@@ -518,7 +518,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
 
             {
                 "upstream": "1.1.eth1",
-                "station": "1.1.wlan0",
+                "stations": "1.1.wlan0",
                 "rate": "1Gbps"
             }
 
@@ -544,12 +544,13 @@ INCLUDE_IN_README:
                         help="Path to JSON configuration file for test. When specified, JSON takes precedence over command line args.",
                         default="")
 
-    parser.add_argument("-u", "--upstream",
+    parser.add_argument("-u", "--upstream", "--upstream_port",
                         dest="upstream",
                         type=str,
                         default="",
                         help="Upstream port used in test. Example: '1.1.eth2'")
-    parser.add_argument("--station",
+    parser.add_argument("--s", "--station", "--stations",
+                        dest="stations",
                         type=str,
                         default="",
                         help="Station used in test. Example: '1.1.sta01500'")
@@ -597,7 +598,8 @@ INCLUDE_IN_README:
                         type=str,
                         help="Direction(s) of generated traffic, relative to DUT. Bi-directional traffic may be "
                              "achieved by setting the opposite.")
-    parser.add_argument("--type",
+    parser.add_argument("--protocol",
+                        "--type",
                         "--types",
                         "--traffic_type",
                         "--traffic_types",
@@ -610,17 +612,15 @@ INCLUDE_IN_README:
                         "--download_speed",
                         "--download_rate",
                         dest="speed",
-                        default="",
-                        help="Requested traffic rate used in test for selected traffic direction(s). "
-                             "Percentage of theoretical is also supported. Default: 85%%.")
+                        default="1Gbps",
+                        help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
     parser.add_argument("--opposite_speed",
                         "--opposite_rate",
                         "--upload_speed",
                         "--upload_rate",
                         dest="opposite_speed",
-                        default="",
-                        help="Requested opposite traffic rate used in test for selected traffic direction(s). "
-                             "Percentage of theoretical is also supported. Default: 0")
+                        default="10Mbps",
+                        help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
 
     parser.add_argument("--duration",
                         default="",
@@ -706,7 +706,7 @@ INCLUDE_IN_README:
                             must also have --pull_report also set to pull reports""")
     # Logging configuration
     parser.add_argument("--lf_logger_config_json",
-                        help="Path to logger JSON configuration")
+                        help="--lf_logger_config_json <json file> : Path to logger JSON configuration of logger")
     parser.add_argument('--logger_no_file',
                         default=None,
                         action="store_true",
@@ -842,7 +842,7 @@ def apply_json_configuration(args):
     if "duration" in json_data:
         args.duration = json_data["duration"]
     if "station" in json_data:
-        args.station = json_data["station"]
+        args.stations = json_data["station"]
 
     # Traffic configuration
     for key in ["speed", "rate", "download_speed", "download_rate"]:

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -25,6 +25,7 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
             # pre-existing and pre-configured stations 'sta0000' and 'sta0001'
             # together
                 ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.207.75 \
                     --pull_report   \
                     --upstream      1.1.eth1 \
                     --stations      1.1.sta0000,1.1.sta0001 \
@@ -38,6 +39,55 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
                     --config_name   existing_wct_config
+
+            # Run test with creating stations in lanforge starting from given index with specified ssid and security type
+            # with 10 stations and 1.1.eth1 as upstream port
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.158.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --create_stations \
+                    --radio         wiphy0 \
+                    --start_id      1000 \                          # starting index of station to be created
+                    --num_stations  10 \                            # create this number of stations starting from start_id
+                    --stations      1.1.sta1010,1.1.sta2020         # or create stations with these names if specified
+                    --ssid          test_ssid \
+                    --security      WPA2 \
+                    --paswd         test_password \
+
+            # Run test on multiple stations and obtain individual station upload and download rates
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --per_station_upload_rate \
+                    --per_station_download_rate \
+
+
+            # Run test on multiple stations seperating into batches
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001,1.1.sta0002,1.1.sta0003,1.1.sta0004,1.1.sta0005
+                    --batch_size    2 \
+
+            # Run test and save the reports in a specific directory on the executing system
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --local_lf_report_dir /home/user/lf_reports \
+            #Run test with custom download / upload rates for each station
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta000
+                    --download_rate 100Mbps \
+                    --upload_rate   1Mbps \
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -139,7 +189,7 @@ class WiFiCapacityTest(cv_test):
         self.test_name = "WiFi Capacity"
         self.batch_size = batch_size
         self.loop_iter = loop_iter
-        self.protocol = protocol
+        self.traffic_types = protocol
         self.duration = duration
         self.upload_rate = upload_rate
         self.download_rate = download_rate
@@ -223,8 +273,8 @@ class WiFiCapacityTest(cv_test):
             cfg_options.append("batch_size: " + self.batch_size)
         if self.loop_iter != "":
             cfg_options.append("loop_iter: " + self.loop_iter)
-        if self.protocol != "":
-            cfg_options.append("protocol: " + str(self.protocol))
+        if self.traffic_types != "":
+            cfg_options.append("traffic_types: " + str(self.traffic_types))
         if self.duration != "":
             cfg_options.append("duration: " + self.duration)
         if self.upload_rate != "":
@@ -308,6 +358,7 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
             # pre-existing and pre-configured stations 'sta0000' and 'sta0001'
             # together
                 ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.207.75 \
                     --pull_report   \
                     --upstream      1.1.eth1 \
                     --stations      1.1.sta0000,1.1.sta0001 \
@@ -321,6 +372,56 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
                     --config_name   existing_wct_config
+
+            # Run test with creating stations in lanforge starting from given index with specified ssid and security type
+            # with 10 stations and 1.1.eth1 as upstream port
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.158.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --create_stations \
+                    --radio         wiphy0 \
+                    --start_id      1000 \                          # starting index of station to be created
+                    --num_stations  10 \                            # create this number of stations starting from start_id
+                    --stations      1.1.sta1010,1.1.sta2020         # or create stations with these names if specified
+                    --ssid          test_ssid \
+                    --security      WPA2 \
+                    --paswd         test_password \
+
+            # Run test on multiple stations and obtain individual station upload and download rates
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --per_station_upload_rate \
+                    --per_station_download_rate \
+
+
+            # Run test on multiple stations seperating into batches
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001,1.1.sta0002,1.1.sta0003,1.1.sta0004,1.1.sta0005
+                    --batch_size    2 \
+
+            # Run test and save the reports in a specific directory on the executing system
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --local_lf_report_dir /home/user/lf_reports \
+            
+            #Run test with custom download / upload rates for each station
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta000
+                    --download_rate 100Mbps \
+                    --upload_rate   1Mbps \
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -339,41 +440,45 @@ INCLUDE_IN_README:
 
     cv_add_base_parser(parser)  # see cv_test_manager.py
 
-    parser.add_argument("-u", "--upstream", type=str, default="",
-                        help="Upstream port for wifi capacity test ex. 1.1.eth1")
+    parser.add_argument("-u", "--upstream", "--upstream_port", dest="upstream", type=str, default="",
+                        help="Upstream port used in test. Example: '1.1.eth2")
     parser.add_argument("-b", "--batch_size", type=str, default="",
-                        help="station increment ex. 1,2,3")
+                        help="Select number of stations to add per iteration.  Default is 1")
     parser.add_argument("-l", "--loop_iter", type=str, default="",
                         help="Loop iteration ex. 1")
-    parser.add_argument("-p", "--protocol", type=str, default="",
+    parser.add_argument("-p", "--protocol", "--type", "--types", "--traffic_type", "--traffic_types", type=str, dest="traffic_types", default="",
                         help="Protocol ex.TCP-IPv4")
     parser.add_argument("-d", "--duration", type=str, default="",
-                        help="duration in ms. ex. 5000")
-    parser.add_argument("--verbosity", default="5", help="Specify verbosity of the report values 1 - 11 default 5")
-    parser.add_argument("--download_rate", type=str, default="1Gbps",
+                        help="Duration of each traffic run")
+    parser.add_argument("--verbosity", default="5", help="Verbosity of the report specified as single value in 1 - 11 range (whole numbers).\n"
+                             "The larger the number, the more verbose. Default: 5")
+    parser.add_argument("--speed", "--rate", "--download_speed", "--download_rate", type=str, default="1Gbps",
                         help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
-    parser.add_argument("--upload_rate", type=str, default="10Mbps",
+    parser.add_argument("--opposite_speed", "--opposite_rate", "--upload_speed", "--upload_rate", type=str, default="10Mbps",
                         help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
     parser.add_argument("--sort", type=str, default="interleave",
                         help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.")
-    parser.add_argument("-s", "--stations", type=str, default="",
+    parser.add_argument("-s", "--station", "--stations", dest="stations", type=str, default="",
                         help="If specified, these stations will be used.  If not specified, all available stations will be selected.  Example: 1.1.sta001,1.1.wlan0,...")
     parser.add_argument("-cs", "--create_stations", default=False, action='store_true',
-                        help="create stations in lanforge (by default: False)")
+                        help="""create stations in lanforge (by default: False)
+                        If specifed, either mention --num_stations or --stations to create stations in lanforge. If both are specified, --stations will be used to create stations
+                        Also mention --radio, --ssid, --security and --password to create stations with these parameters""")
     parser.add_argument("-radio", "--radio", default="wiphy0",
                         help="create stations in lanforge at this radio (by default: wiphy0)")
     parser.add_argument("-ssid", "--ssid", default="",
                         help="ssid name")
     parser.add_argument("-security", "--security", default="open",
-                        help="ssid Security type")
-    parser.add_argument("-paswd", "--paswd", "-passwd", "--passwd", default="[BLANK]",
-                        help="ssid Password")
+                        help="ssid Security type. If not open, then mention --password to create stations with this security type and password")
+    parser.add_argument("-paswd", "--paswd", "-passwd", "--passwd", "--password", "--key", dest="paswd", default="[BLANK]",
+                        help="WiFi passphrase/password/key. Leave empty for open security type.")
     parser.add_argument("--report_dir", default="")
     parser.add_argument("--scenario", default="")
-    parser.add_argument("--graph_groups", help="File to save graph groups to", default=None)
-    parser.add_argument("--local_lf_report_dir", help="--local_lf_report_dir <where to pull reports to>  default '' put where dataplane script run from", default="")
-    parser.add_argument("--lf_logger_config_json", help="--lf_logger_config_json <json file> , json configuration of logger")
-    parser.add_argument("--num_stations", help="Specify the number of stations need to be create.", type=int,
+    parser.add_argument("--graph_groups", help="Path to file to save graph_groups to on local system", default=None)
+    parser.add_argument("--local_lf_report_dir", help="""--local_lf_report_dir <where to pull reports to>  default ''  means put in current working directory,
+                         must also have --pull_report also set to pull reports.""", default="")
+    parser.add_argument("--lf_logger_config_json", dest="lf_logger_config_json", help="--lf_logger_config_json <json file> : Path to logger JSON configuration of logger")
+    parser.add_argument("--num_stations", help="Specify the number of stations need to be create. Could use --start_id to specify the starting ID of the stations being used.", type=int,
                         default=None)
     parser.add_argument('--start_id', help='Specify the station starting id \n e.g: --start_id <value> default 0',
                         default=0)


### PR DESCRIPTION
Changes made:

- added aliases for common params amongst the 3 scripts
- modified 'dest' so similar params are accessed by same var name in code
- updated 'help' of params with best amongst the scripts
- for wifi_capacity, added examples for various scenarios
- for dependency params, updated help to describe about required params
- fixed example in wifi capcity test