### PR TITLE
lf_interop_ping_plotter.py: add detailed logging around API calls

### DIFF
--- a/py-scripts/lf_interop_ping_plotter.py
+++ b/py-scripts/lf_interop_ping_plotter.py
@@ -253,14 +253,21 @@ class Ping(Realm):
             # checking if target is eth1 or 1.1.eth1
             target_port_list = self.name_to_eid(self.target)
             shelf, resource, port, _ = target_port_list
+            endp = '/port/{}/{}/{}?fields=ip'.format(shelf, resource, port)
+            logger.debug(f"GET {endp}")
+            result = self.json_get(endp)
+            if result is None:
+                logger.error(f"GET {endp} returned no response while resolving ping target '{self.target}'. Aborting the test.")
+                exit(1)
             try:
-                target_port_ip = self.json_get('/port/{}/{}/{}?fields=ip'.format(shelf, resource, port))['interface']['ip']
-                self.target = target_port_ip
+                self.target = result['interface']['ip']
             except Exception:
-                logging.warning('The target is not an ethernet port. Proceeding with the given target {}.'.format(self.target))
-            logging.info(self.target)
+                logger.error(f"GET {endp} response does not contain 'interface'/'ip', or the data is not in the expected format. Aborting the test.")
+                logger.error(json.dumps(result, indent=2))
+                exit(1)
+            logger.info(f"Ping target resolved to: {self.target}")
         else:
-            logging.info(self.target)
+            logger.info(f"Ping target: {self.target}")
         return self.target
 
     def api_get(self, endp: str):
@@ -276,7 +283,15 @@ class Ping(Realm):
         """
         if endp[0] != '/':
             endp = '/' + endp
-        response = requests.get(url=self.api_url + endp)
+        url = self.api_url + endp
+        logger.debug(f"GET {url}")
+        try:
+            response = requests.get(url=url)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"GET {url} failed: {e}", exc_info=True)
+            raise
+        if not response.ok:
+            logger.error(f"GET {url} returned HTTP {response.status_code}: {response.text}")
         data = response.json()
         return response, data
 
@@ -400,8 +415,10 @@ class Ping(Realm):
             logger.info("Please re-check the configuration applied")
 
     def check_tab_exists(self):
+        logger.debug("GET /generic")
         response = self.json_get("generic")
         if response is None:
+            logger.error("GET /generic returned no response; Generic tab may not be available on the LANforge manager.")
             return False
         else:
             return True
@@ -440,19 +457,35 @@ class Ping(Realm):
         self.stop_time = datetime.now()
 
     def get_results(self):
-        # logging.info(self.generic_endps_profile.created_endp)
-        results = self.json_get(
-            "/generic/{}".format(','.join(self.generic_endps_profile.created_endp)))
-        overallres = self.json_get("/generic/all")
-        if len(self.generic_endps_profile.created_endp) > 1 and 'endpoints' in results.keys():
+        endp = "/generic/{}".format(','.join(self.generic_endps_profile.created_endp))
+        logger.debug(f"GET {endp}")
+        results = self.json_get(endp)
+
+        if results is None:
+            logger.error(f"GET {endp} returned no response for created endpoints: {self.generic_endps_profile.created_endp}")
+
+        multiple_endpoints_requested = len(self.generic_endps_profile.created_endp) > 1
+
+        if multiple_endpoints_requested and 'endpoints' in results.keys():
             results = results['endpoints']
-        else:
             try:
-                results = results['endpoint']
-            except Exception as e:
-                logger.info(overallres)
-                logger.error(f"Endpoint not found {e}")
-        return (results)
+                returned_names = [list(d.keys())[0] for d in results]
+                missing = [name for name in self.generic_endps_profile.created_endp if name not in returned_names]
+                if missing:
+                    logger.error(f"GET {endp} response is missing results for endpoints: {missing}")
+            except Exception:
+                logger.error(f"GET {endp} 'endpoints' list is not in the expected format.")
+            return results
+
+        try:
+            results = results['endpoint']
+        except Exception:
+            logger.error(f"GET {endp} response does not contain the 'endpoint' or 'endpoints' key, or the data is not in the expected format.")
+            overallres = self.json_get("/generic/all")
+            logger.error("GET /generic/all response:")
+            logger.error(json.dumps(overallres, indent=2))
+
+        return results
 
     def generate_remarks(self, station_ping_data):
         remarks = []

--- a/py-scripts/lf_interop_ping_plotter.py
+++ b/py-scripts/lf_interop_ping_plotter.py
@@ -874,7 +874,11 @@ class Ping(Realm):
                 if client.split(' ')[1] != 'Android':
                     res_list.append(client.split(' ')[2])
                 else:
-                    interop_tab_data = self.json_get('/adb/')["devices"]
+                    logger.debug("GET /adb/")
+                    adb_response = self.json_get('/adb/')
+                    if adb_response is None:
+                        logger.error("GET /adb/ returned no response while building the pass/fail device list.")
+                    interop_tab_data = adb_response["devices"]
                     for dev in interop_tab_data:
                         for item in dev.values():
                             # Extract the username from the client string (e.g., 'samsungmob' from "1.15 android samsungmob")
@@ -1018,8 +1022,16 @@ class Ping(Realm):
             for resource in self.real_sta_list:
                 shelf, r_id, _ = resource.split('.')
                 url = 'http://{}:{}/resource/{}/{}?fields=hw version'.format(self.host, self.port, shelf, r_id)
-                hw_version = requests.get(url)
-                hw_version = hw_version.json()
+                logger.debug(f"GET {url}")
+                try:
+                    hw_version_response = requests.get(url)
+                except requests.exceptions.RequestException as e:
+                    logger.error(f"GET {url} failed for resource {shelf}.{r_id}: {e}", exc_info=True)
+                    continue
+                if not hw_version_response.ok:
+                    logger.error(f"GET {url} returned HTTP {hw_version_response.status_code}: {hw_version_response.text}")
+                    continue
+                hw_version = hw_version_response.json()
                 if 'resource' in hw_version.keys():
                     hw_version = hw_version['resource']
                     if 'hw version' in hw_version.keys():
@@ -1034,9 +1046,9 @@ class Ping(Realm):
                         else:
                             self.android += 1
                     else:
-                        logging.warning('Malformed response for hw version query on resource manager.')
+                        logger.warning(f"Malformed response for hw version query on resource {shelf}.{r_id}: {hw_version}")
                 else:
-                    logging.warning('Malformed response for hw version query on resource manager.')
+                    logger.warning(f"Malformed response for hw version query on resource {shelf}.{r_id}: {hw_version}")
         # Test setup information table for devices in device list
         if config_devices == '':
             test_setup_info = {
@@ -1345,7 +1357,11 @@ class Ping(Realm):
         input_test_list = []
         dev_avg = []
         statuslist = []
-        interop_tab_data = self.json_get('/adb/')["devices"]
+        logger.debug("GET /adb/")
+        adb_response = self.json_get('/adb/')
+        if adb_response is None:
+            logger.error("GET /adb/ returned no response while building the device report list.")
+        interop_tab_data = adb_response["devices"]
         for i in range(len(report_names)):
             for j in groupdevlist:
                 # For a string like "1.360 Lin test3":
@@ -2112,8 +2128,16 @@ class Ping(Realm):
             for resource in self.real_sta_list:
                 shelf, r_id, _ = resource.split('.')
                 url = 'http://{}:{}/resource/{}/{}?fields=hw version'.format(self.host, self.port, shelf, r_id)
-                hw_version = requests.get(url)
-                hw_version = hw_version.json()
+                logger.debug(f"GET {url}")
+                try:
+                    hw_version_response = requests.get(url)
+                except requests.exceptions.RequestException as e:
+                    logger.error(f"GET {url} failed for resource {shelf}.{r_id}: {e}", exc_info=True)
+                    continue
+                if not hw_version_response.ok:
+                    logger.error(f"GET {url} returned HTTP {hw_version_response.status_code}: {hw_version_response.text}")
+                    continue
+                hw_version = hw_version_response.json()
                 if 'resource' in hw_version.keys():
                     hw_version = hw_version['resource']
                     if 'hw version' in hw_version.keys():
@@ -2128,9 +2152,9 @@ class Ping(Realm):
                         else:
                             self.android += 1
                     else:
-                        logging.warning('Malformed response for hw version query on resource manager.')
+                        logger.warning(f"Malformed response for hw version query on resource {shelf}.{r_id}: {hw_version}")
                 else:
-                    logging.warning('Malformed response for hw version query on resource manager.')
+                    logger.warning(f"Malformed response for hw version query on resource {shelf}.{r_id}: {hw_version}")
         # Test setup information table for devices in device list
         if config_devices == '':
             test_setup_info = {

--- a/py-scripts/lf_interop_ping_plotter.py
+++ b/py-scripts/lf_interop_ping_plotter.py
@@ -289,7 +289,7 @@ class Ping(Realm):
             response = requests.get(url=url)
         except requests.exceptions.RequestException as e:
             logger.error(f"GET {url} failed: {e}", exc_info=True)
-            raise
+            return None, None
         if not response.ok:
             logger.error(f"GET {url} returned HTTP {response.status_code}: {response.text}")
         data = response.json()
@@ -308,6 +308,9 @@ class Ping(Realm):
             elif device.count('.') == 0:
                 shelf, resource = 1, device
             response_code, device_data = self.api_get('/resource/{}/{}'.format(shelf, resource))
+            if device_data is None:
+                logger.error(f"GET /resource/{shelf}/{resource} returned no response for device {device}.")
+                continue
             if 'status' in device_data and device_data['status'] == 'NOT_FOUND':
                 logger.info('Device {} is not found.'.format(device))
                 continue

--- a/py-scripts/lf_interop_ping_plotter.py
+++ b/py-scripts/lf_interop_ping_plotter.py
@@ -1950,7 +1950,11 @@ class Ping(Realm):
             self.coordinates_completed.append(coord)
             self.currentcoordinate = coord
 
-            ports_data_dict = self.json_get('/ports/all/')['interfaces']
+            logger.debug("GET /ports/all/")
+            ports_response = self.json_get('/ports/all/')
+            if ports_response is None:
+                logger.error(f"GET /ports/all/ returned no response while updating port data at coordinate {coord}.")
+            ports_data_dict = ports_response['interfaces']
             ports_data = {}
             for ports in ports_data_dict:
                 port, port_data = list(ports.keys())[0], list(ports.values())[0]
@@ -3223,7 +3227,11 @@ connectivity problems.
 
     # start generate endpoint
     ping.start_generic()
-    ports_data_dict = ping.json_get('/ports/all/')['interfaces']
+    logger.debug("GET /ports/all/")
+    ports_response = ping.json_get('/ports/all/')
+    if ports_response is None:
+        logger.error("GET /ports/all/ returned no response while fetching initial port data.")
+    ports_data_dict = ports_response['interfaces']
     ports_data = {}
     for ports in ports_data_dict:
         port, port_data = list(ports.keys())[0], list(ports.values())[0]
@@ -3259,9 +3267,12 @@ connectivity problems.
             logger.info(result_data)
             logger.error(e)
             exit(0)
-        # logging.info(result_data)
         if args.virtual:
-            ports_data_dict = ping.json_get('/ports/all/')['interfaces']
+            logger.debug("GET /ports/all/")
+            ports_response = ping.json_get('/ports/all/')
+            if ports_response is None:
+                logger.error("GET /ports/all/ returned no response while polling virtual station port data.")
+            ports_data_dict = ports_response['interfaces']
             ports_data = {}
             for ports in ports_data_dict:
                 port, port_data = list(ports.keys())[0], list(ports.values())[0]


### PR DESCRIPTION
## Summary
- Adds request/response logging around every LANforge API call in the
  script (json_get, api_get, raw requests.get) so failures show the
  endpoint, context, and response body instead of surfacing as unlogged
  crashes or silent no-ops.
- change_target_to_ip now aborts the test with a clear error when the
  ping target can't be resolved to an IP; get_results detects and logs
  When a multi-endpoint response is missing data for some of the
  Requested endpoints.
- hw version and /ports/all/ lookups (in report generation and the
  polling loop) Now log failures with the resource/coordinate they
  occurred at and skip to the next item instead of crashing partway
  through.
- api_get() now returns (None, None) instead of raising when the
  request fails, and filter_iOS_devices() handles that case gracefully
  (logs and continues) Instead of crashing on `'status' in None`.

## Test plan
- [x] Verified CLI: `python3 lf_interop_ping_plotter.py --mgr 192.168.207.75 --real --ping_interval 1 --ping_duration 1m --target www.google.com --use_default_config`