### PR TITLE
Add API retries, endpoint status monitoring, and minor fixes to Real Browser & YouTube interop tests

### DIFF
--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -2228,7 +2228,7 @@ class RealBrowserTest(Realm):
                 self.upstream_port = target_port_ip
             except KeyError as e:
                 logger.error(f"Missing expected key {e} in LANforge /port/{shelf}/{resource}/{port} response. Aborting test.")
-                logger.info("LANforge response received:\n%s", json.dumps(port_resp, indent=2, default=str))
+                logger.info("LANforge response received:\n%s", json.dumps(response, indent=2, default=str))
                 exit(1)
             except Exception:
                 logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {self.upstream_port}.')
@@ -2382,7 +2382,7 @@ class RealBrowserTest(Realm):
                 interop_tab_data = response["devices"]
             except KeyError as e:
                 logger.error(f"Missing expected key {e} in LANforge /adb/ response. Aborting test.")
-                logger.info("LANforge /adb/ response received:\n%s", json.dumps(interop_resp, indent=2, default=str))
+                logger.info("LANforge /adb/ response received:\n%s", json.dumps(response, indent=2, default=str))
                 exit(1)
             user_to_serial_map = {}
             for dev in interop_tab_data:

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -263,6 +263,7 @@ class RealBrowserTest(Realm):
         self.generic_endps_profile = self.new_generic_endp_profile()
         self.generic_endps_profile.type = 'real_browser'
         self.generic_endps_profile.name_prefix = "rb"
+        self.endpoint_last_status = {}
         self.file_name = file_name
         self.group_name = group_name
         self.profile_name = profile_name
@@ -1042,6 +1043,68 @@ class RealBrowserTest(Realm):
 
         return response
 
+    def monitor_endpoint_status_changes(self, wait_time=40, poll_interval=5):
+        """
+        Checks the current status of every generic endpoint and, only the
+        first time an endpoint's status changes, logs a message and appends
+        a row (timestamp, endpoint_name, status) to
+        endpoint_status_changes.csv. Repeated polls of an unchanged status
+        are not logged or written again.
+        """
+        csv_file = "endpoint_status_changes.csv"
+        if csv_file not in self.csv_file_names:
+            self.csv_file_names.append(csv_file)
+        created_endp = self.generic_endps_profile.created_endp
+
+        start_time = time.time()
+        endpoint_data = {}
+        while True:
+            for gen_endp in created_endp:
+                generic_endpoint = self.json_get(f"/generic/{gen_endp}")
+                if generic_endpoint and "endpoint" in generic_endpoint:
+                    endpoint_data[gen_endp] = generic_endpoint
+
+            if endpoint_data or (time.time() - start_time) >= wait_time:
+                break
+
+            logger.warning(
+                "No data received for any of the created endpoints; retrying..."
+            )
+            time.sleep(poll_interval)
+
+        if not endpoint_data:
+            logger.error(
+                f"No data received for any of the created endpoints after waiting "
+                f"{wait_time} seconds. Aborting test."
+            )
+            exit(1)
+
+        for gen_endp, generic_endpoint in endpoint_data.items():
+            current_status = generic_endpoint["endpoint"].get("status", "")
+            previous_status = self.endpoint_last_status.get(gen_endp)
+
+            if current_status == previous_status:
+                continue
+
+            logger.info(
+                f"Endpoint {gen_endp} status changed to: {current_status}"
+            )
+
+            file_exists = os.path.isfile(csv_file) and os.path.getsize(csv_file) > 0
+            with open(csv_file, mode="a", newline="") as f:
+                writer = csv.writer(f)
+                if not file_exists:
+                    writer.writerow(["timestamp", "endpoint_name", "status"])
+                writer.writerow(
+                    [
+                        datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        gen_endp,
+                        current_status,
+                    ]
+                )
+
+            self.endpoint_last_status[gen_endp] = current_status
+
     def update_webui_json(self):
         """
         Update web GUI status based on available devices.
@@ -1569,6 +1632,7 @@ class RealBrowserTest(Realm):
 
                     # CSV FOR WEBUI GRAPHS
                     self.write_live_webui_csv(rows)
+                    self.monitor_endpoint_status_changes()
 
                     time.sleep(1)
                     return True
@@ -2089,6 +2153,7 @@ class RealBrowserTest(Realm):
                                     }
                                     writer.writerow(row)
                                     last_data.append(row)
+                    self.monitor_endpoint_status_changes()
                     time.sleep(1)
                 except Exception as e:
                     logging.exception(f"Error in get_stats function {e}", exc_info=True)
@@ -2711,6 +2776,8 @@ class RealBrowserTest(Realm):
 
                 if 'real_time_data.csv' not in self.csv_file_names:
                     self.csv_file_names.append('real_time_data.csv')
+                if 'endpoint_status_changes.csv' not in self.csv_file_names:
+                    self.csv_file_names.append('endpoint_status_changes.csv')
 
                 for filename in self.csv_file_names:
                     source_path = os.path.join(source_dir, filename)
@@ -3017,6 +3084,7 @@ class RealBrowserTest(Realm):
                                         }
                                     writer.writerow(row)
                                     last_data.append(row)
+                    self.monitor_endpoint_status_changes()
                     time.sleep(1)
                 except Exception as e:
                     logging.exception(f"Error in get_stats function {e}", exc_info=True)
@@ -3107,6 +3175,8 @@ class RealBrowserTest(Realm):
             if not self.dowebgui:
                 source_dir = "."
                 destination_dir = self.report_path_date_time
+                if 'endpoint_status_changes.csv' not in self.robo_csv_files:
+                    self.robo_csv_files.append('endpoint_status_changes.csv')
                 for filename in self.robo_csv_files:
                     source_path = os.path.join(source_dir, filename)
                     destination_path = os.path.join(destination_dir, filename)

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -9,18 +9,18 @@ Pre-requisites: Real clients should be connected to the LANforge MGR and Interop
 
             Example-1 :
             Command Line Interface to run url in the Browser with specified URL and duration:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --debug --upstream_port 1.1.eth1
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "https://google.com" --duration 10m --debug --upstream_port 1.1.eth1
 
                 CASE-1:
-                If not specified it takes the default url (default url is www.google.com)
+                If not specified it takes the default url (default url is https://google.com)
 
             Example-2:
             Command Line Interface to run url in the Browser with specified Resources:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --debug --upstream_port 1.1.eth1
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "https://google.com" --duration 10m --device_list 1.10,1.12 --debug --upstream_port 1.1.eth1
 
             Example-3:
             Command Line Interface to run url in the Browser with specified urls_per_tennm (specify the number of url you want to test in the given duration):
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug --upstream_port 1.1.eth1
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "https://google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug --upstream_port 1.1.eth1
 
                 CASE-1:
                 If not specified it takes the default count value (default count is 1)
@@ -66,7 +66,7 @@ Pre-requisites: Real clients should be connected to the LANforge MGR and Interop
                 2. Always specify the duration in minutes (for example: --duration 3 indicates a duration of 3 minutes).
                 3. If --device_list are not given after passing the CLI, a list of available devices will be displayed on the terminal.
                 4. Enter the resource numbers separated by commas (,) in the resource argument and also enclose in double quotes (e.g. : 1.10,1.12).
-                5. For --url, you can specify the URL (e.g., www.google.com).
+                5. For --url, you can specify the URL (e.g., https://google.com).
                 6. To run the test by specifying the incremental capacity, enable the --incremental flag.
 
             STATUS: BETA RELEASE
@@ -3469,22 +3469,22 @@ def main():
 
             Pre-requisites: Real devices should be connected to the LANforge MGR and Interop app should be open on the real clients which are connected to Lanforge
 
-            Example: (python3 or ./)lf_interop_real_browser_test.py --mgr 192.168.214.219 --duration 1 --url "www.google.com"
+            Example: (python3 or ./)lf_interop_real_browser_test.py --mgr 192.168.214.219 --duration 1 --url "https://google.com"
 
             Example-1 :
             Command Line Interface to run url in the Browser with specified URL and duration:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --debug --upstream_port 1.1.eth1
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "https://google.com" --duration 10m --debug --upstream_port 1.1.eth1
 
                 CASE-1:
-                If not specified it takes the default url (default url is www.google.com)
+                If not specified it takes the default url (default url is https://google.com)
 
             Example-2:
             Command Line Interface to run url in the Browser with specified Resources:
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --debug --upstream_port 1.1.eth1
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "https://google.com" --duration 10m --device_list 1.10,1.12 --debug --upstream_port 1.1.eth1
 
             Example-3:
             Command Line Interface to run url in the Browser with specified urls_per_tennm (specify the number of url you want to test in the given duration):
-            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "www.google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug --upstream_port 1.1.eth1
+            python3 lf_interop_real_browser_test.py --mgr 192.168.214.219 --url "https://google.com" --duration 10m --device_list 1.10,1.12 --count 10 --debug --upstream_port 1.1.eth1
 
                 CASE-1:
                 If not specified it takes the default count value (default count is 1)
@@ -3515,7 +3515,7 @@ def main():
                 2. Always specify the duration in minutes (for example: --duration 3 indicates a duration of 3 minutes).
                 3. If --device_list are not given after passing the CLI, a list of available devices will be displayed on the terminal.
                 4. Enter the resource numbers separated by commas (,) in the resource argument and also enclose in double quotes (e.g. : 1.10,1.12).
-                5. For --url, you can specify the URL (e.g., www.google.com).
+                5. For --url, you can specify the URL (e.g., https://google.com).
                 6. To run the test by specifying the incremental capacity, enable the --incremental flag.
 
             STATUS: BETA RELEASE

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -826,7 +826,16 @@ class RealBrowserTest(Realm):
         webui_mac = 0
 
         # Retrieve data from LANforge port Manager tab including alias, MAC address, mode, parent device, RX rate, TX rate, SSID, and signal strength
-        eid_data = self.json_get("ports?fields=alias,mac,mode,Parent Dev,ssid,signal,phantom,down,ip")
+        eid_data = self.json_get_with_retry("ports?fields=alias,mac,mode,Parent Dev,ssid,signal,phantom,down,ip")
+        if eid_data is None:
+            logger.error("GET ports?fields=alias,mac,mode,Parent Dev,ssid,signal,phantom,down,ip returned no response from LANforge. Aborting test.")
+            exit(1)
+        try:
+            interfaces = eid_data["interfaces"]
+        except KeyError as e:
+            logger.error(f"Missing expected key {e} in LANforge /ports response. Aborting test.")
+            logger.info("LANforge /ports response received:\n%s", json.dumps(eid_data, indent=2, default=str))
+            exit(1)
         resource_ids = []
         if self.resource_ids:
 
@@ -835,14 +844,14 @@ class RealBrowserTest(Realm):
         for item in resource_ids:
             item = str(item)
 
-            for alias in eid_data["interfaces"]:
+            for alias in interfaces:
                 for i in alias:
 
                     resource_id = i.split('.')[1]
                     if resource_id == item:
 
                         resource_id_list.append(i.split(".")[1])
-                        resource_hw_data = self.json_get("/resource/" + i.split(".")[0] + "/" + i.split(".")[1])
+                        resource_hw_data = self.json_get_with_retry("/resource/" + i.split(".")[0] + "/" + i.split(".")[1])
                         hw_version = resource_hw_data['resource']['hw version']
                         # Check if the hardware version does not start with ('Win', 'Linux', 'Apple') and the resource ID is in resource_ids
                         if not hw_version.startswith(('Win', 'Linux', 'Apple')) and alias[i]["parent dev"] == 'wiphy0' and not alias[i]["down"] and alias[i]['ip'] != '0.0.0.0':
@@ -898,8 +907,13 @@ class RealBrowserTest(Realm):
             elif os_type == "Android":
                 self.android = self.android + 1
 
-        interop_data = self.json_get('/adb')
-        interop_mobile_data = interop_data.get('devices', {})
+        interop_data = self.json_get_with_retry('/adb')
+        try:
+            interop_mobile_data = interop_data.get('devices', {})
+        except Exception as e:
+            logger.error(f"Error extracting devices from /adb response: {e}. Aborting test.")
+            logger.info("LANforge /adb response received:\n%s", json.dumps(interop_data, indent=2, default=str))
+            exit(1)
 
         for user in user_name:
             if user == '':
@@ -1005,6 +1019,28 @@ class RealBrowserTest(Realm):
                 return False
         # If all endpoints are in 'Stopped' or 'WAITING', return True
         return True
+
+    def json_get_with_retry(self, url, wait_time=40, poll_interval=5):
+        """
+        Calls self.json_get(url), retrying every poll_interval seconds for up
+        to wait_time seconds if LANforge returns no response. Aborts the test
+        if it still hasn't responded once wait_time has elapsed.
+        """
+        start_time = time.time()
+        response = self.json_get(url)
+        while response is None and (time.time() - start_time) < wait_time:
+            logger.warning(f"GET {url} returned no response from LANforge; retrying...")
+            time.sleep(poll_interval)
+            response = self.json_get(url)
+
+        if response is None:
+            logger.error(
+                f"GET {url} returned no response from LANforge after waiting "
+                f"{wait_time} seconds. Aborting test."
+            )
+            exit(1)
+
+        return response
 
     def update_webui_json(self):
         """
@@ -2121,9 +2157,14 @@ class RealBrowserTest(Realm):
         if self.upstream_port.count('.') != 3:
             target_port_list = self.name_to_eid(self.upstream_port)
             shelf, resource, port, _ = target_port_list
+            response = self.json_get_with_retry(f'/port/{shelf}/{resource}/{port}?fields=ip')
             try:
-                target_port_ip = self.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
+                target_port_ip = response['interface']['ip']
                 self.upstream_port = target_port_ip
+            except KeyError as e:
+                logger.error(f"Missing expected key {e} in LANforge /port/{shelf}/{resource}/{port} response. Aborting test.")
+                logger.info("LANforge response received:\n%s", json.dumps(port_resp, indent=2, default=str))
+                exit(1)
             except Exception:
                 logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {self.upstream_port}.')
             logging.info(f"Upstream port IP {self.upstream_port}")
@@ -2181,7 +2222,7 @@ class RealBrowserTest(Realm):
                     logger.warning("Invalid device format: %s", device)
                     continue
 
-                device_data_resp = self.json_get(f'/resource/{shelf}/{resource}')
+                device_data_resp = self.json_get_with_retry(f'/resource/{shelf}/{resource}')
                 if not device_data_resp or 'resource' not in device_data_resp:
                     logger.warning("Device data not found for %s", device)
                     continue
@@ -2271,7 +2312,13 @@ class RealBrowserTest(Realm):
         test_input_list = []
 
         if not self.expected_passfail_value:
-            interop_tab_data = self.json_get('/adb/')["devices"]
+            response = self.json_get_with_retry('/adb/')
+            try:
+                interop_tab_data = response["devices"]
+            except KeyError as e:
+                logger.error(f"Missing expected key {e} in LANforge /adb/ response. Aborting test.")
+                logger.info("LANforge /adb/ response received:\n%s", json.dumps(interop_resp, indent=2, default=str))
+                exit(1)
             user_to_serial_map = {}
             for dev in interop_tab_data:
                 for item in dev.values():

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -828,9 +828,6 @@ class RealBrowserTest(Realm):
 
         # Retrieve data from LANforge port Manager tab including alias, MAC address, mode, parent device, RX rate, TX rate, SSID, and signal strength
         eid_data = self.json_get_with_retry("ports?fields=alias,mac,mode,Parent Dev,ssid,signal,phantom,down,ip")
-        if eid_data is None:
-            logger.error("GET ports?fields=alias,mac,mode,Parent Dev,ssid,signal,phantom,down,ip returned no response from LANforge. Aborting test.")
-            exit(1)
         try:
             interfaces = eid_data["interfaces"]
         except KeyError as e:

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -126,7 +126,6 @@ from datetime import datetime, timedelta
 from flask import Flask, request, jsonify
 from threading import Thread
 import traceback
-import threading
 from collections import Counter
 import re
 logger = logging.getLogger(__name__)
@@ -140,9 +139,6 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.
 
 
 # Import LANforge-related modules
-
-# Set up logging
-logger = logging.getLogger(__name__)
 
 # Import LF logger configuration module
 lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
@@ -251,8 +247,7 @@ class Youtube(Realm):
         self.generic_endps_profile.name_prefix = "yt"
         self.endpoint_last_status = {}
         self.Devices = None
-        self.start_time = ""
-        self.stop_time = ""
+        self.stop_time = None
         self.do_webUI = do_webUI
         self.ui_report_dir = ui_report_dir
         self.devices = base_RealDevice(manager_ip=self.host, selected_bands=[])
@@ -264,8 +259,8 @@ class Youtube(Realm):
         self.ssid = ssid
         self.security = security
         self.band = band
-        self.start_time = None,
-        self.est_end_time = None,
+        self.start_time = None
+        self.est_end_time = None
         self.all_stop = False
         self.keys = []
         self.hostname_os_combination = None
@@ -926,7 +921,7 @@ class Youtube(Realm):
             response.status_code = 200
 
             # Start shutdown in a separate thread
-            shutdown_thread = threading.Thread(target=self.shutdown)
+            shutdown_thread = Thread(target=self.shutdown)
             shutdown_thread.start()
 
             return response
@@ -2077,14 +2072,14 @@ class Youtube(Realm):
                         self.wifi_interface_list.append(port_name.split('.')[2])
         except KeyError as e:
             logger.error(
-                f"/resource/all response is not in the expected format, missing key {e}. "
+                f"/port/all response is not in the expected format, missing key {e}. "
                 "Data received:\n%s",
                 json.dumps(response, indent=2, default=str),
             )
             exit(1)
         except Exception as e:
             logger.error(
-                f"Unexpected error while parsing /resource/all response: {e}",
+                f"Unexpected error while parsing /port/all response: {e}",
                 exc_info=True,
             )
             exit(1)

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -1801,6 +1801,17 @@ class Youtube(Realm):
             try:
                 target_port_ip = response['interface']['ip']
                 upstream_port = target_port_ip
+            except KeyError as e:
+                logger.error(
+                    "/port/%s/%s/%s/?fields=ip response is not in the expected format, missing key %s. "
+                    "Data received:\n%s",
+                    shelf,
+                    resource,
+                    port,
+                    e,
+                    json.dumps(response, indent=2, default=str),
+                )
+                exit(1)
             except Exception as e:
                 logging.warning(f'Could not resolve IP for port {upstream_port}: {e}. Proceeding with the given upstream_port {upstream_port}.')
                 logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
@@ -1910,9 +1921,9 @@ class Youtube(Realm):
         Returns:
             None
         """
-        interop_data = self.json_get_with_retry('/adb')
+        response = self.json_get_with_retry('/adb')
         try:
-            interop_mobile_data = interop_data.get('devices', {})
+            interop_mobile_data = response.get('devices', {})
 
             if isinstance(interop_mobile_data, dict):
                 for user in self.user_list:
@@ -1947,7 +1958,7 @@ class Youtube(Realm):
                 "/adb response is not in the expected format, missing key %s. "
                 "Data received:\n%s",
                 e,
-                json.dumps(interop_data, indent=2, default=str),
+                json.dumps(response, indent=2, default=str),
             )
             exit(1)
         except Exception as e:

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -514,7 +514,7 @@ class Youtube(Realm):
         if real_sta_list is None:
             self.real_sta_list, _, _ = real_devices.query_user()
         else:
-            interface_data = self.json_get("/port/all")
+            interface_data = self.json_get_with_retry("/port/all")
             interfaces = interface_data["interfaces"]
             final_device_list = []  # Initialize the list
 
@@ -1666,6 +1666,28 @@ class Youtube(Realm):
         self.report.write_html()
         self.report.write_pdf()
 
+    def json_get_with_retry(self, url, wait_time=40, poll_interval=5):
+        """
+        Calls self.json_get(url), retrying every poll_interval seconds for up
+        to wait_time seconds if LANforge returns no response. Aborts the test
+        if it still hasn't responded once wait_time has elapsed.
+        """
+        start_time = time.time()
+        response = self.json_get(url)
+        while response is None and (time.time() - start_time) < wait_time:
+            logger.warning(f"GET {url} returned no response from LANforge; retrying...")
+            time.sleep(poll_interval)
+            response = self.json_get(url)
+
+        if response is None:
+            logger.error(
+                f"GET {url} returned no response from LANforge after waiting "
+                f"{wait_time} seconds. Aborting test."
+            )
+            exit(1)
+
+        return response
+
     def check_gen_cx(self):
         try:
 
@@ -1711,8 +1733,9 @@ class Youtube(Realm):
         if upstream_port.count('.') != 3:
             target_port_list = self.name_to_eid(upstream_port)
             shelf, resource, port, _ = target_port_list
+            response = self.json_get_with_retry(f'/port/{shelf}/{resource}/{port}?fields=ip')
             try:
-                target_port_ip = self.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
+                target_port_ip = response['interface']['ip']
                 upstream_port = target_port_ip
             except Exception as e:
                 logging.warning(f'Could not resolve IP for port {upstream_port}: {e}. Proceeding with the given upstream_port {upstream_port}.')
@@ -1823,37 +1846,52 @@ class Youtube(Realm):
         Returns:
             None
         """
-        interop_data = self.json_get('/adb')
-        interop_mobile_data = interop_data.get('devices', {})
+        interop_data = self.json_get_with_retry('/adb')
+        try:
+            interop_mobile_data = interop_data.get('devices', {})
 
-        if isinstance(interop_mobile_data, dict):
-            for user in self.user_list:
-                if user != '':
-                    if interop_mobile_data.get('user-name') == user:
+            if isinstance(interop_mobile_data, dict):
+                for user in self.user_list:
+                    if user != '':
+                        if interop_mobile_data.get('user-name') == user:
 
-                        serial = interop_mobile_data.get('name', '')
-                        resource = serial.split('.')[1]
-                        serial_no = serial.split('.')[2]
-                        self.serial_list.append(serial_no)
-                        lanforge_port = f"1.{resource}.eth0"
-                        self.lanforge_port_list.add(lanforge_port)
+                            serial = interop_mobile_data.get('name', '')
+                            resource = serial.split('.')[1]
+                            serial_no = serial.split('.')[2]
+                            self.serial_list.append(serial_no)
+                            lanforge_port = f"1.{resource}.eth0"
+                            self.lanforge_port_list.add(lanforge_port)
 
-        else:
-            for user in self.user_list:
-                if user != '':
-                    for mobile_device in interop_mobile_data:
-                        for serial, device_data in mobile_device.items():
-                            if device_data.get('user-name') == user:
-                                resource = serial.split('.')[1]
-                                serial_no = serial.split('.')[2]
-                                self.serial_list.append(serial_no)
-                                lanforge_port = f"1.{resource}.eth0"
-                                self.lanforge_port_list.add(lanforge_port)
-                                break
+            else:
+                for user in self.user_list:
+                    if user != '':
+                        for mobile_device in interop_mobile_data:
+                            for serial, device_data in mobile_device.items():
+                                if device_data.get('user-name') == user:
+                                    resource = serial.split('.')[1]
+                                    serial_no = serial.split('.')[2]
+                                    self.serial_list.append(serial_no)
+                                    lanforge_port = f"1.{resource}.eth0"
+                                    self.lanforge_port_list.add(lanforge_port)
+                                    break
 
-        self.lanforge_port_list = list(self.lanforge_port_list)
-        self.lanforge_os_type = ["Linux"] * len(self.lanforge_port_list)
-        self.serial_list_str = ','.join(self.serial_list)
+            self.lanforge_port_list = list(self.lanforge_port_list)
+            self.lanforge_os_type = ["Linux"] * len(self.lanforge_port_list)
+            self.serial_list_str = ','.join(self.serial_list)
+        except KeyError as e:
+            logger.error(
+                "/adb response is not in the expected format, missing key %s. "
+                "Data received:\n%s",
+                e,
+                json.dumps(interop_data, indent=2, default=str),
+            )
+            exit(1)
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while parsing /adb response: {e}",
+                exc_info=True,
+            )
+            exit(1)
 
     def get_device_data(self):
         """
@@ -1898,24 +1936,47 @@ class Youtube(Realm):
         self.user_list = []
 
         # Step 1: Retrieve information about all resources
-        response = self.json_get("/resource/all")
-        resource_data_list = response.get("resources", [])
+        response = self.json_get_with_retry("/resource/all")
+        try:
+            resource_data_list = response.get("resources", [])
 
-        # Step 2: Match user-specified resources with available resources in order.
-        for user_resource in user_resources:
-            for resource_entry in resource_data_list:
-                for resource_key, resource_values in resource_entry.items():
-                    if resource_key == user_resource:
-                        self.device_names.append(resource_values['hostname'])
-                        ports_list.append({
-                            'eid': resource_values['eid'],
-                            'ctrl-ip': resource_values['ctrl-ip']
-                        })
-                        self.user_list.append(resource_values['user'])
-                        break
+            # Step 2: Match user-specified resources with available resources in order.
+            for user_resource in user_resources:
+                for resource_entry in resource_data_list:
+                    for resource_key, resource_values in resource_entry.items():
+                        if resource_key == user_resource:
+                            self.device_names.append(resource_values['hostname'])
+                            ports_list.append({
+                                'eid': resource_values['eid'],
+                                'ctrl-ip': resource_values['ctrl-ip']
+                            })
+                            self.user_list.append(resource_values['user'])
+                            break
+                    else:
+                        continue
+                    break
                 else:
-                    continue
-                break
+                    logger.error(
+                        f"Resource {user_resource} not found in LANforge response. Aborting test."
+                    )
+                    logger.info(
+                        "LANforge resources fetched from /resource/all:\n%s",
+                        json.dumps(resource_data_list, indent=2, default=str),
+                    )
+                    exit(1)
+        except KeyError as e:
+            logger.error(
+                f"/resource/all response is not in the expected format, missing key {e}. "
+                "Data received:\n%s",
+                json.dumps(response, indent=2, default=str),
+            )
+            exit(1)
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while parsing /resource/all response: {e}",
+                exc_info=True,
+            )
+            exit(1)
 
         self.mac_list = []
         self.rssi_list = []
@@ -1924,26 +1985,40 @@ class Youtube(Realm):
         self.wifi_interface_list = []
 
         # Step 3: Retrieve port information
-        response_port = self.json_get("/port/all")
-        interfaces_list = response_port.get('interfaces', [])
+        response_port = self.json_get_with_retry("/port/all")
+        try:
+            interfaces_list = response_port.get('interfaces', [])
 
-        # Step 4: Match ports associated with retrieved resources in the order of ports_list
-        for port_entry in ports_list:
-            expected_eid = port_entry['eid']
-            matched_ports = []
+            # Step 4: Match ports associated with retrieved resources in the order of ports_list
+            for port_entry in ports_list:
+                expected_eid = port_entry['eid']
+                matched_ports = []
 
-            for interface in interfaces_list:
-                for port, port_data in interface.items():
-                    if '.'.join(port.split('.')[:2]) == expected_eid:
-                        matched_ports.append((port, port_data))
+                for interface in interfaces_list:
+                    for port, port_data in interface.items():
+                        if '.'.join(port.split('.')[:2]) == expected_eid:
+                            matched_ports.append((port, port_data))
 
-            for port_name, port_data in matched_ports:
-                if port_data.get("parent dev") == 'wiphy0' and not port_data.get('down') and port_data.get('ip') != '0.0.0.0':
-                    self.mac_list.append(port_data.get("mac"))
-                    self.rssi_list.append(port_data.get("signal"))
-                    self.link_rate_list.append(port_data.get("rx-rate"))
-                    self.ssid_list.append(port_data.get("ssid"))
-                    self.wifi_interface_list.append(port_name.split('.')[2])
+                for port_name, port_data in matched_ports:
+                    if port_data.get("parent dev") == 'wiphy0' and not port_data.get('down') and port_data.get('ip') != '0.0.0.0':
+                        self.mac_list.append(port_data.get("mac"))
+                        self.rssi_list.append(port_data.get("signal"))
+                        self.link_rate_list.append(port_data.get("rx-rate"))
+                        self.ssid_list.append(port_data.get("ssid"))
+                        self.wifi_interface_list.append(port_name.split('.')[2])
+        except KeyError as e:
+            logger.error(
+                f"/resource/all response is not in the expected format, missing key {e}. "
+                "Data received:\n%s",
+                json.dumps(response, indent=2, default=str),
+            )
+            exit(1)
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while parsing /resource/all response: {e}",
+                exc_info=True,
+            )
+            exit(1)
 
     def perform_robo_test(self):
         if self.do_webUI:

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -249,6 +249,7 @@ class Youtube(Realm):
         self.generic_endps_profile = self.new_generic_endp_profile()
         self.generic_endps_profile.type = 'youtube'
         self.generic_endps_profile.name_prefix = "yt"
+        self.endpoint_last_status = {}
         self.Devices = None
         self.start_time = ""
         self.stop_time = ""
@@ -1688,6 +1689,74 @@ class Youtube(Realm):
 
         return response
 
+    def monitor_endpoint_status_changes(self, wait_time=40, poll_interval=5):
+        """
+        Checks the current status of every generic endpoint and, only the
+        first time an endpoint's status changes, logs a message and appends
+        a row (timestamp, endpoint_name, status) to
+        endpoint_status_changes.csv. Repeated polls of an unchanged status
+        are not logged or written again.
+
+        If every created endpoint is missing from the response, retries
+        every poll_interval seconds for up to wait_time seconds. Aborts the
+        test if still none of the created endpoints have responded once
+        wait_time has elapsed.
+        """
+        current_path = self.ui_report_dir if self.do_webUI else os.path.dirname(os.path.abspath(__file__))
+        csv_file = os.path.join(current_path, "endpoint_status_changes.csv")
+        if csv_file not in self.devices_list:
+            self.devices_list.append(csv_file)
+        created_endp = self.generic_endps_profile.created_endp
+
+        start_time = time.time()
+        endpoint_data = {}
+        while True:
+            for gen_endp in created_endp:
+                generic_endpoint = self.json_get(f"/generic/{gen_endp}")
+                if generic_endpoint and "endpoint" in generic_endpoint:
+                    endpoint_data[gen_endp] = generic_endpoint
+
+            if endpoint_data or (time.time() - start_time) >= wait_time:
+                break
+
+            logger.warning(
+                "No data received for any of the created endpoints; retrying..."
+            )
+            time.sleep(poll_interval)
+
+        if not endpoint_data:
+            logger.error(
+                f"No data received for any of the created endpoints after waiting "
+                f"{wait_time} seconds. Aborting test."
+            )
+            exit(1)
+
+        for gen_endp, generic_endpoint in endpoint_data.items():
+            current_status = generic_endpoint["endpoint"].get("status", "")
+            previous_status = self.endpoint_last_status.get(gen_endp)
+
+            if current_status == previous_status:
+                continue
+
+            logger.info(
+                f"Endpoint {gen_endp} status changed to: {current_status}"
+            )
+
+            file_exists = os.path.isfile(csv_file) and os.path.getsize(csv_file) > 0
+            with open(csv_file, mode="a", newline="") as f:
+                writer = csv.writer(f)
+                if not file_exists:
+                    writer.writerow(["timestamp", "endpoint_name", "status"])
+                writer.writerow(
+                    [
+                        datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        gen_endp,
+                        current_status,
+                    ]
+                )
+
+            self.endpoint_last_status[gen_endp] = current_status
+
     def check_gen_cx(self):
         try:
 
@@ -2048,6 +2117,7 @@ class Youtube(Realm):
                             self.start_generic()
                             end_time = datetime.now() + timedelta(minutes=self.duration)
 
+                        self.monitor_endpoint_status_changes()
                         time.sleep(5)
 
                     self.generic_endps_profile.stop_cx()
@@ -2066,6 +2136,7 @@ class Youtube(Realm):
                         self.start_generic()
                         end_time = datetime.now() + timedelta(minutes=self.duration)
 
+                    self.monitor_endpoint_status_changes()
                     time.sleep(5)
 
                 self.generic_endps_profile.stop_cx()
@@ -2961,6 +3032,7 @@ NOTES:
                 end_time = datetime.now() + timedelta(minutes=duration)
 
                 while datetime.now() < end_time or not youtube.check_gen_cx():
+                    youtube.monitor_endpoint_status_changes()
                     time.sleep(1)
 
                 youtube.generic_endps_profile.stop_cx()


### PR DESCRIPTION
  Overview
    This PR makes the Real Browser and YouTube tests more reliable, fixes a few bugs, and adds a new feature to track what happens to endpoints during a test.

   What's New
1. Smarter Retries for API Calls:** Previously, if the LANforge manager took too long to respond, the test would instantly fail. Now, the scripts will automatically wait and retry the request for up to 40 seconds. This prevents tests from failing just because of a small delay.
2. Tracking Status Changes:** Added a new feature that keeps an eye on endpoints while the test is running. If an endpoint's status changes, it gets logged and saved to a new file called `endpoint_status_changes.csv`. 
3. Clearer Error Logs:** If the script receives bad or missing data from the manager, it now prints out the exact data it received before safely stopping the test. This makes it much easier to figure out what went wrong.

 Bug Fixes & Cleanup

1. Fixed a crash during logging:** Fixed a bug where the script would crash when trying to print an message (it was using the wrong variable name).
2. Removed unnecessary code:** Deleted some old checks that are no longer needed because the retry feature handles failures automatically.
3. Fixed example commands:** Updated the help text in the scripts to use correct `https://` web instead of `www.`.
4. Cleaned up the code:** Removed duplicate code imports and fixed some minor formatting issues.