### PR TITLE
lf_interop_youtube.py: Added platform specific path for youtube automation.

### DIFF
--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -171,6 +171,10 @@ RealDevice = lf_base_interop_profile.RealDevice
 
 from IOT.iot_helper import start_iot_thread, with_iot_params_in_table, add_iot_report_section  # noqa: E402
 
+WINDOWS_REAL_APP_DIR = r"C:\Program Files (x86)\LANforge-Server\local\real_application_test\youtube"
+LINUX_REAL_APP_DIR = "/home/lanforge/local/real_application_test/youtube"
+MACOS_REAL_APP_DIR = "/Users/lanforge/local/real_application_test/youtube"
+
 
 class Youtube(Realm):
     """
@@ -409,14 +413,42 @@ class Youtube(Realm):
 
         for i in range(0, len(self.real_sta_os_types)):
             if self.real_sta_os_types[i] == 'windows':
-                cmd = "youtube_stream.bat --url %s --host %s --device_name %s --duration %s --res %s" % (self.url, self.upstream_port, self.real_sta_hostname[i], self.duration, self.resolution)
+                cmd = (
+                    fr'"{WINDOWS_REAL_APP_DIR}\youtube_stream.bat" '
+                    '--url "%s" --host "%s" --device_name "%s" --duration %s --res "%s"'
+                    % (
+                        self.url,
+                        self.upstream_port,
+                        self.real_sta_hostname[i],
+                        self.duration,
+                        self.resolution,
+                    )
+                )
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
             elif self.real_sta_os_types[i] == 'linux':
-                cmd = "su -l lanforge  ctyt.bash %s %s %s %s %s %s" % (self.wifi_interface_list[i], self.url, self.upstream_port, self.real_sta_hostname[i], self.duration, self.resolution)
+                cmd = (
+                    f"su -l lanforge {LINUX_REAL_APP_DIR}/ctyt.bash "
+                    "%s %s %s %s %s %s"
+                ) % (
+                    self.wifi_interface_list[i],
+                    self.url,
+                    self.upstream_port,
+                    self.real_sta_hostname[i],
+                    self.duration,
+                    self.resolution,
+                )
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
-
             elif self.real_sta_os_types[i] == 'macos':
-                cmd = "sudo bash ctyt.bash --url %s --host %s --device_name %s --duration %s --res %s" % (self.url, self.upstream_port, self.real_sta_hostname[i], self.duration, self.resolution)
+                cmd = (
+                    f"sudo bash {MACOS_REAL_APP_DIR}/ctyt.bash "
+                    "--url %s --host %s --device_name %s --duration %s --res %s"
+                ) % (
+                    self.url,
+                    self.upstream_port,
+                    self.real_sta_hostname[i],
+                    self.duration,
+                    self.resolution,
+                )
                 self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[i], cmd)
 
         if self.generic_endps_profile.create(ports=self.lanforge_port_list, sleep_time=.5, real_client_os_types=self.lanforge_os_type,):
@@ -427,17 +459,9 @@ class Youtube(Realm):
 
         for i in range(0, len(self.lanforge_os_type)):
             cmd = (
-                "su - lanforge -c "
-                "\"cd /home/lanforge && "
-                "python3 /home/lanforge/lanforge-scripts/py-scripts/real_application_tests/youtube/youtube_android_test.py "
-                "--url '%s' --duration '%s' --devices '%s' --upstream_port '%s' --resolution '%s'\""
-            ) % (
-                self.url,
-                self.duration,
-                self.serial_list_str,
-                self.host,
-                self.resolution,
-            )
+                "python3 /home/lanforge/lanforge-scripts/py-scripts/real_application_tests/youtube/youtube_android_test.py --url %s --duration %s --devices %s --upstream_port %s --resolution %s "
+            ) % (self.url, self.duration, self.serial_list_str, self.host, self.resolution)
+
             logging.info(f"Setting command for Android devices: {cmd}")
             self.generic_endps_profile.set_cmd(self.generic_endps_profile.created_endp[-(i + 1)], cmd)
 


### PR DESCRIPTION
lf_interop_youtube.py: Add platform-specific paths for YouTube automation scripts
-->Define absolute directory paths for Windows, Linux, and macOS real applications.
-->Update generic endpoint creation to use these platform-specific paths for youtube_stream.bat   and ctyt.bash.
-->Fix argument quoting and improve formatting in the command string for Android devices.

Tested on macos(Macs-Air.ctinb.candelatechindia).
Verified CLI: python3 lf_interop_youtube.py \
    --mgr 192.168.244.97 \
    --url "https://youtu.be/BHACKCNDMW8?si=psTEUzrc77p38aU1" \
    --duration 1 \
    --res 1080p \
    --upstream_port 1.1.eth1