### PR TITLE
lf_interop_port_reset_test.py: harden against LANforge API failures

### DIFF
--- a/py-scripts/lf_interop_port_reset_test.py
+++ b/py-scripts/lf_interop_port_reset_test.py
@@ -75,7 +75,6 @@ realm = importlib.import_module("py-json.realm")
 Realm = realm.Realm
 lf_report_pdf = importlib.import_module("py-scripts.lf_report")
 lf_graph = importlib.import_module("py-scripts.lf_graph")
-LFUtils = importlib.import_module("py-json.LANforge.LFUtils")
 logger = logging.getLogger(__name__)
 lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
 
@@ -189,6 +188,29 @@ class InteropPortReset(Realm):
             )
 
         return response
+
+    def change_port_to_ip(self, upstream_port):
+        # Resolves an ethernet port name (e.g. "eth1") to its IP via LANforge, used
+        # for --mgr_ip. This is only called once, at test start, and we cannot
+        # proceed without a resolved manager IP, so retry for a while and then
+        # abort instead of silently continuing with an unresolved port name.
+        if upstream_port.count('.') != 3:
+            target_port_list = self.name_to_eid(upstream_port)
+            shelf, resource, port, _ = target_port_list
+            response = self.json_get_with_retry(f'/port/{shelf}/{resource}/{port}?fields=ip')
+            try:
+                upstream_port = response['interface']['ip']
+            except (TypeError, KeyError) as e:
+                logging.error(
+                    f"change_port_to_ip: could not resolve upstream port '{upstream_port}' to an IP; LANforge "
+                    f"response is not in expected format ({e}). Data received: {response}")
+                logging.critical("Aborting the test: a valid manager IP is required to proceed.")
+                exit(1)
+            logging.info(f"Upstream port IP {upstream_port}")
+        else:
+            logging.info(f"Upstream port IP {upstream_port}")
+
+        return upstream_port
 
     def selecting_devices_from_available(self):
         # If device list is not provided by user, then it shows the available devices to choose from
@@ -1607,23 +1629,6 @@ class InteropPortReset(Realm):
         print(df_summary)
 
 
-def change_port_to_ip(upstream_port, lfclient_host, lfclient_port):
-    if upstream_port.count('.') != 3:
-        target_port_list = LFUtils.name_to_eid(upstream_port)
-        shelf, resource, port, _ = target_port_list
-        try:
-            realm_obj = Realm(lfclient_host=lfclient_host, lfclient_port=lfclient_port)
-            target_port_ip = realm_obj.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
-            upstream_port = target_port_ip
-        except Exception:
-            logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
-        logging.info(f"Upstream port IP {upstream_port}")
-    else:
-        logging.info(f"Upstream port IP {upstream_port}")
-
-    return upstream_port
-
-
 def main():
     help_summary = '''\
     The LANforge interop port reset test enables users to use real Wi-Fi stations and connect them to the Access Point
@@ -1757,8 +1762,6 @@ INCLUDE_IN_README: False
 
     if args.log_level:
         logger_config.set_level(level=args.log_level)
-    args.mgr_ip = change_port_to_ip(args.mgr_ip, args.host, args.port)
-    print(args.mgr_ip)
     if args.lf_logger_config_json:
         # logger_config.lf_logger_config_json = "lf_logger_config.json"
         logger_config.lf_logger_config_json = args.lf_logger_config_json
@@ -1789,6 +1792,15 @@ INCLUDE_IN_README: False
                            get_live_view=args.get_live_view,
                            total_floors=args.total_floors
                            )
+
+    # mgr_ip may have been given as a port name (e.g. "eth1") rather than an IP;
+    # resolve it now that we have an instance to reuse for the LANforge lookup.
+    # base_interop_profile.server_ip was already captured from the unresolved
+    # mgr_ip at construction time above, so it must be patched too.
+    obj.mgr_ip = obj.change_port_to_ip(obj.mgr_ip)
+    obj.base_interop_profile.server_ip = obj.mgr_ip
+    print(obj.mgr_ip)
+
     obj.selecting_devices_from_available()
     if obj.robot_test:
         obj.run()

--- a/py-scripts/lf_interop_port_reset_test.py
+++ b/py-scripts/lf_interop_port_reset_test.py
@@ -451,12 +451,19 @@ class InteropPortReset(Realm):
             local_dict[str(phn_name)]["Association Rejection"] = adb_association_rejection
             if adb_connected_count > 0:
                 _, shelf, serial = phn_name.split('.')
-                resource_id = self.json_get_with_retry('/adb/1/{}/{}?fields=resource-id'.format(shelf, serial))
-                resource_id = resource_id['devices']['resource-id']
-
-                port_ssid_query = self.json_get_with_retry('port/1/{}/wlan0?fields=cx time (us)'.format(resource_id.split('.')[1]))
-                uptime = port_ssid_query['interface']['cx time (us)']
-                local_dict[str(phn_name)]['cx time (us)'] = uptime
+                resource_id_resp = self.json_get_with_retry('/adb/1/{}/{}?fields=resource-id'.format(shelf, serial))
+                port_ssid_query = None
+                try:
+                    resource_id = resource_id_resp['devices']['resource-id']
+                    port_ssid_query = self.json_get_with_retry('port/1/{}/wlan0?fields=cx time (us)'.format(resource_id.split('.')[1]))
+                    uptime = port_ssid_query['interface']['cx time (us)']
+                    local_dict[str(phn_name)]['cx time (us)'] = uptime
+                except (TypeError, KeyError) as e:
+                    logging.error(
+                        f"get_time_from_wifi_msgs: could not fetch cx time (us) for device {phn_name}; LANforge "
+                        f"response is not in expected format ({e}). resource-id response: {resource_id_resp}, "
+                        f"port response: {port_ssid_query}")
+                    local_dict[str(phn_name)]['cx time (us)'] = 'NA'
             else:
                 local_dict[str(phn_name)]['cx time (us)'] = 'NA'
         else:
@@ -499,9 +506,16 @@ class InteropPortReset(Realm):
                         if win_connected_count > 1 or win_connected_count == 0:
                             port_name = phn_name.split(".")
                             port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=ssid,ip")
-                            if port_ssid_query['interface']['ssid'] == self.ssid and port_ssid_query['interface']['ip'] != "0.0.0.0":
-                                win_connected_count = 1
-                            else:
+                            try:
+                                if port_ssid_query['interface']['ssid'] == self.ssid and port_ssid_query['interface']['ip'] != "0.0.0.0":
+                                    win_connected_count = 1
+                                else:
+                                    win_connected_count = 0
+                            except (TypeError, KeyError) as e:
+                                logging.error(
+                                    f"get_time_from_wifi_msgs: could not verify connection state for device "
+                                    f"{phn_name}; LANforge response is not in expected format ({e}). Data "
+                                    f"received: {port_ssid_query}")
                                 win_connected_count = 0
                 logging.info("Final Connected Count for %s: %s" % (phn_name, win_connected_count))
                 local_dict[str(phn_name)]["Connected"] = win_connected_count
@@ -519,8 +533,14 @@ class InteropPortReset(Realm):
                 if win_connected_count > 0:
                     port_name = phn_name.split(".")
                     port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=cx time (us)")
-                    uptime = port_ssid_query['interface']['cx time (us)']
-                    local_dict[str(phn_name)]['cx time (us)'] = uptime
+                    try:
+                        uptime = port_ssid_query['interface']['cx time (us)']
+                        local_dict[str(phn_name)]['cx time (us)'] = uptime
+                    except (TypeError, KeyError) as e:
+                        logging.error(
+                            f"get_time_from_wifi_msgs: could not fetch cx time (us) for device {phn_name}; "
+                            f"LANforge response is not in expected format ({e}). Data received: {port_ssid_query}")
+                        local_dict[str(phn_name)]['cx time (us)'] = 'NA'
                 else:
                     local_dict[str(phn_name)]['cx time (us)'] = 'NA'
             else:  # other means (for linux, mac)
@@ -563,9 +583,16 @@ class InteropPortReset(Realm):
                         if other_connected_count > 1 or other_connected_count == 0:
                             port_name = phn_name.split(".")
                             port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=ssid,ip")
-                            if port_ssid_query['interface']['ssid'] == self.ssid and port_ssid_query['interface']['ip'] != "0.0.0.0":
-                                other_connected_count = 1
-                            else:
+                            try:
+                                if port_ssid_query['interface']['ssid'] == self.ssid and port_ssid_query['interface']['ip'] != "0.0.0.0":
+                                    other_connected_count = 1
+                                else:
+                                    other_connected_count = 0
+                            except (TypeError, KeyError) as e:
+                                logging.error(
+                                    f"get_time_from_wifi_msgs: could not verify connection state for device "
+                                    f"{phn_name}; LANforge response is not in expected format ({e}). Data "
+                                    f"received: {port_ssid_query}")
                                 other_connected_count = 0
                 logging.info("Final Connected Count for %s: %s" % (phn_name, other_connected_count))
                 local_dict[str(phn_name)]["Connected"] = other_connected_count
@@ -583,8 +610,14 @@ class InteropPortReset(Realm):
                 if other_connected_count > 0:
                     port_name = phn_name.split(".")
                     port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=cx time (us)")
-                    uptime = port_ssid_query['interface']['cx time (us)']
-                    local_dict[str(phn_name)]['cx time (us)'] = uptime
+                    try:
+                        uptime = port_ssid_query['interface']['cx time (us)']
+                        local_dict[str(phn_name)]['cx time (us)'] = uptime
+                    except (TypeError, KeyError) as e:
+                        logging.error(
+                            f"get_time_from_wifi_msgs: could not fetch cx time (us) for device {phn_name}; "
+                            f"LANforge response is not in expected format ({e}). Data received: {port_ssid_query}")
+                        local_dict[str(phn_name)]['cx time (us)'] = 'NA'
                 else:
                     local_dict[str(phn_name)]['cx time (us)'] = 'NA'
         logging.info("local_dict " + str(local_dict))

--- a/py-scripts/lf_interop_port_reset_test.py
+++ b/py-scripts/lf_interop_port_reset_test.py
@@ -170,6 +170,26 @@ class InteropPortReset(Realm):
         # logging.basicConfig(filename='port_reset.log', filemode='w', format='%(asctime)s - %(message)s',
         #                     level=logging.INFO, force=True)
 
+    def json_get_with_retry(self, url, wait_time=40, poll_interval=5, debug_=False):
+        """
+        Calls self.json_get(url), retrying every poll_interval seconds for up
+        to wait_time seconds if LANforge returns no response.
+        """
+        start_time = time.time()
+        response = self.json_get(url, debug_=debug_)
+        while response is None and (time.time() - start_time) < wait_time:
+            logging.warning(f"GET {url} returned no response from LANforge; retrying...")
+            time.sleep(poll_interval)
+            response = self.json_get(url, debug_=debug_)
+
+        if response is None:
+            logging.error(
+                f"GET {url} returned no response from LANforge after waiting "
+                f"{wait_time} seconds."
+            )
+
+        return response
+
     def selecting_devices_from_available(self):
         # If device list is not provided by user, then it shows the available devices to choose from
         if self.device_list is None:
@@ -236,7 +256,7 @@ class InteropPortReset(Realm):
                     file_names[file_name] = file_path
 
     def get_last_wifi_msg(self):
-        a = self.json_get("/wifi-msgs/last/1", debug_=True)
+        a = self.json_get_with_retry("/wifi-msgs/last/1", debug_=True)
         last = a['wifi-messages']['time-stamp']
         logging.info(f"Last WiFi Message Time Stamp: {last}")
         return last
@@ -305,7 +325,7 @@ class InteropPortReset(Realm):
     def get_time_from_wifi_msgs(self, local_dict=None, phn_name=None, timee=None, file_name="dummy.json", reset_cnt=None):
         # print("Waiting for 20 sec to fetch the logs...")
         # time.sleep(20)
-        a = self.json_get("/wifi-msgs/since=time/" + str(timee), debug_=True)
+        a = self.json_get_with_retry("/wifi-msgs/since=time/" + str(timee), debug_=True)
         values = a['wifi-messages']
         # print("Wifi msgs Response : ", values)
         logging.info(
@@ -323,7 +343,7 @@ class InteropPortReset(Realm):
         # print("Key list", keys_list)
         # android (flag) check for clustered lanforge cases
         android = False
-        for device_data in self.json_get('/adb/')['devices']:
+        for device_data in self.json_get_with_retry('/adb/')['devices']:
             device_name, _ = list(device_data.keys())[0], list(device_data.values())[0]
             if phn_name in device_name:
                 android = True
@@ -383,10 +403,10 @@ class InteropPortReset(Realm):
             local_dict[str(phn_name)]["Association Rejection"] = adb_association_rejection
             if adb_connected_count > 0:
                 _, shelf, serial = phn_name.split('.')
-                resource_id = self.json_get('/adb/1/{}/{}?fields=resource-id'.format(shelf, serial))
+                resource_id = self.json_get_with_retry('/adb/1/{}/{}?fields=resource-id'.format(shelf, serial))
                 resource_id = resource_id['devices']['resource-id']
 
-                port_ssid_query = self.json_get('port/1/{}/wlan0?fields=cx time (us)'.format(resource_id.split('.')[1]))
+                port_ssid_query = self.json_get_with_retry('port/1/{}/wlan0?fields=cx time (us)'.format(resource_id.split('.')[1]))
                 uptime = port_ssid_query['interface']['cx time (us)']
                 local_dict[str(phn_name)]['cx time (us)'] = uptime
             else:
@@ -430,7 +450,7 @@ class InteropPortReset(Realm):
                         # Double-checking
                         if win_connected_count > 1 or win_connected_count == 0:
                             port_name = phn_name.split(".")
-                            port_ssid_query = self.json_get(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=ssid,ip")
+                            port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=ssid,ip")
                             if port_ssid_query['interface']['ssid'] == self.ssid and port_ssid_query['interface']['ip'] != "0.0.0.0":
                                 win_connected_count = 1
                             else:
@@ -450,7 +470,7 @@ class InteropPortReset(Realm):
                 local_dict[str(phn_name)]["Remarks"] = remarks
                 if win_connected_count > 0:
                     port_name = phn_name.split(".")
-                    port_ssid_query = self.json_get(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=cx time (us)")
+                    port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=cx time (us)")
                     uptime = port_ssid_query['interface']['cx time (us)']
                     local_dict[str(phn_name)]['cx time (us)'] = uptime
                 else:
@@ -494,7 +514,7 @@ class InteropPortReset(Realm):
                         # Double-checking & adding remarks if any
                         if other_connected_count > 1 or other_connected_count == 0:
                             port_name = phn_name.split(".")
-                            port_ssid_query = self.json_get(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=ssid,ip")
+                            port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=ssid,ip")
                             if port_ssid_query['interface']['ssid'] == self.ssid and port_ssid_query['interface']['ip'] != "0.0.0.0":
                                 other_connected_count = 1
                             else:
@@ -514,7 +534,7 @@ class InteropPortReset(Realm):
                 local_dict[str(phn_name)]["Remarks"] = remarks
                 if other_connected_count > 0:
                     port_name = phn_name.split(".")
-                    port_ssid_query = self.json_get(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=cx time (us)")
+                    port_ssid_query = self.json_get_with_retry(f"port/{port_name[0]}/{port_name[1]}/{port_name[2]}?fields=cx time (us)")
                     uptime = port_ssid_query['interface']['cx time (us)']
                     local_dict[str(phn_name)]['cx time (us)'] = uptime
                 else:

--- a/py-scripts/lf_interop_port_reset_test.py
+++ b/py-scripts/lf_interop_port_reset_test.py
@@ -279,7 +279,13 @@ class InteropPortReset(Realm):
 
     def get_last_wifi_msg(self):
         a = self.json_get_with_retry("/wifi-msgs/last/1", debug_=True)
-        last = a['wifi-messages']['time-stamp']
+        try:
+            last = a['wifi-messages']['time-stamp']
+        except (TypeError, KeyError) as e:
+            logging.error(
+                f"get_last_wifi_msg: LANforge response is not in expected format ({e}). Data received: {a}")
+            logging.warning("Could not establish a wifi-msgs baseline timestamp; falling back to 'NA' for this reset.")
+            return "NA"
         logging.info(f"Last WiFi Message Time Stamp: {last}")
         return last
 
@@ -348,7 +354,17 @@ class InteropPortReset(Realm):
         # print("Waiting for 20 sec to fetch the logs...")
         # time.sleep(20)
         a = self.json_get_with_retry("/wifi-msgs/since=time/" + str(timee), debug_=True)
-        values = a['wifi-messages']
+        try:
+            values = a['wifi-messages']
+        except (TypeError, KeyError) as e:
+            logging.error(
+                f"get_time_from_wifi_msgs: LANforge response is not in expected format ({e}) while fetching "
+                f"wifi-msgs for device {phn_name}. Data received: {a}")
+            logging.warning(f"Marking device {phn_name} stats as 'NA' for this reset and continuing.")
+            for key in ("ConnectAttempt", "Disconnected", "Scanning", "Association Rejection", "Connected",
+                        "Remarks", "cx time (us)"):
+                local_dict[str(phn_name)][key] = "NA"
+            return local_dict
         # print("Wifi msgs Response : ", values)
         logging.info(
             f"Counting the DISCONNECTIONS, SCANNING, ASSOC ATTEMPTS, ASSOC RECJECTIONS, CONNECTS for device {phn_name}")
@@ -365,7 +381,17 @@ class InteropPortReset(Realm):
         # print("Key list", keys_list)
         # android (flag) check for clustered lanforge cases
         android = False
-        for device_data in self.json_get_with_retry('/adb/')['devices']:
+        adb_response = self.json_get_with_retry('/adb/')
+        try:
+            adb_devices = adb_response['devices']
+        except (TypeError, KeyError) as e:
+            logging.error(
+                f"get_time_from_wifi_msgs: LANforge response is not in expected format ({e}) while fetching "
+                f"/adb/ devices. Data received: {adb_response}")
+            logging.warning(
+                f"Could not fetch adb device list; relying only on the '1.1.' prefix heuristic for {phn_name}.")
+            adb_devices = []
+        for device_data in adb_devices:
             device_name, _ = list(device_data.keys())[0], list(device_data.values())[0]
             if phn_name in device_name:
                 android = True

--- a/py-scripts/lf_interop_port_reset_test.py
+++ b/py-scripts/lf_interop_port_reset_test.py
@@ -360,10 +360,12 @@ class InteropPortReset(Realm):
             logging.error(
                 f"get_time_from_wifi_msgs: LANforge response is not in expected format ({e}) while fetching "
                 f"wifi-msgs for device {phn_name}. Data received: {a}")
-            logging.warning(f"Marking device {phn_name} stats as 'NA' for this reset and continuing.")
-            for key in ("ConnectAttempt", "Disconnected", "Scanning", "Association Rejection", "Connected",
-                        "Remarks", "cx time (us)"):
-                local_dict[str(phn_name)][key] = "NA"
+            logging.warning(f"Defaulting device {phn_name} stats to 0 for this reset and continuing.")
+            for key in ("ConnectAttempt", "Disconnected", "Scanning", "Association Rejection", "Connected"):
+                local_dict[str(phn_name)][key] = 0
+            local_dict[str(phn_name)]["Remarks"] = "Data unavailable - LANforge API error, stats defaulted to 0"
+            local_dict[str(phn_name)]["cx time (us)"] = "NA"
+            self.write_reset_csvs(local_dict, reset_cnt)
             return local_dict
         # print("Wifi msgs Response : ", values)
         logging.info(
@@ -490,6 +492,7 @@ class InteropPortReset(Realm):
                 local_dict[str(phn_name)]["Association Rejection"] = win_association_rejection
                 win_connected_count = self.get_count(value=values, keys_list=keys_list, device=phn_name,
                                                      filter="connected")
+                win_connection_state_unverified = False
                 # assoc-rejection based logic
                 if win_association_rejection:
                     # Updating the connects
@@ -517,6 +520,7 @@ class InteropPortReset(Realm):
                                     f"{phn_name}; LANforge response is not in expected format ({e}). Data "
                                     f"received: {port_ssid_query}")
                                 win_connected_count = 0
+                                win_connection_state_unverified = True
                 logging.info("Final Connected Count for %s: %s" % (phn_name, win_connected_count))
                 local_dict[str(phn_name)]["Connected"] = win_connected_count
                 # Updating the association-rejections
@@ -529,6 +533,8 @@ class InteropPortReset(Realm):
                     remarks = "No Disconnections are seen but Client is UP and connected to user given SSID."
                 elif win_disconnect_count >= 1 and win_connected_count == 0:
                     remarks = "The Disconnections are seen but Client did not connected to user given SSID."
+                if win_connection_state_unverified:
+                    remarks = "Connection state unverified - LANforge API error while double-checking connect count"
                 local_dict[str(phn_name)]["Remarks"] = remarks
                 if win_connected_count > 0:
                     port_name = phn_name.split(".")
@@ -567,6 +573,7 @@ class InteropPortReset(Realm):
 
                 other_connected_count = self.get_count(value=values, keys_list=keys_list, device=phn_name,
                                                        filter="<3>CTRL-EVENT-CONNECTED")
+                other_connection_state_unverified = False
                 # assoc-rejection based logic
                 if other_association_rejection:
                     # Updating the connects
@@ -594,6 +601,7 @@ class InteropPortReset(Realm):
                                     f"{phn_name}; LANforge response is not in expected format ({e}). Data "
                                     f"received: {port_ssid_query}")
                                 other_connected_count = 0
+                                other_connection_state_unverified = True
                 logging.info("Final Connected Count for %s: %s" % (phn_name, other_connected_count))
                 local_dict[str(phn_name)]["Connected"] = other_connected_count
                 # Updating the association-rejections
@@ -606,6 +614,8 @@ class InteropPortReset(Realm):
                     remarks = "No Disconnections are seen but Client is UP and connected to user given SSID."
                 elif other_disconnect_count >= 1 and other_connected_count == 0:
                     remarks = "The Disconnections are seen but Client did not connected to user given SSID."
+                if other_connection_state_unverified:
+                    remarks = "Connection state unverified - LANforge API error while double-checking connect count"
                 local_dict[str(phn_name)]["Remarks"] = remarks
                 if other_connected_count > 0:
                     port_name = phn_name.split(".")
@@ -621,13 +631,16 @@ class InteropPortReset(Realm):
                 else:
                     local_dict[str(phn_name)]['cx time (us)'] = 'NA'
         logging.info("local_dict " + str(local_dict))
+        self.write_reset_csvs(local_dict, reset_cnt)
+
+        return local_dict
+
+    def write_reset_csvs(self, local_dict, reset_cnt):
         # storing results in csv file for each reset
         for interface_name, metrics in local_dict.items():
             df = pd.DataFrame([metrics])
             filename = f"{self.report_path}/{interface_name}_{reset_cnt}.csv"
             df.to_csv(filename, index=False)
-
-        return local_dict
 
     def aggregate_reset_dict(self, reset_dict):
         aggregated = {}


### PR DESCRIPTION
## Summary
- Add a retry wrapper (`json_get_with_retry`, 5s poll for up to 40s) around
  every LANforge API call in the reset loop, so a transient hiccup no
  longer crashes the test with an unhandled NoneType error.
- Wrap every response-parsing call site (wifi-msgs, /adb/ device list,
  port ssid/ip/cx-time lookups) in try/except: log the raw response on
  failure, and either fail loudly where the test genuinely can't proceed
  without the data (mgr_ip resolution) or degrade gracefully otherwise.
- Make the graceful-degradation path numeric-safe: fall back to `0` (not
  the string `'NA'`, which crashed every downstream aggregator doing raw
  `+`/`sum()`/`int()`) and flag the row via `Remarks` so an API failure
  can't be misread as a genuine connection failure in the generated
  report.
- Fold `change_port_to_ip` into `InteropPortReset` as a method, reusing
  the instance's retry-safe `json_get_with_retry` instead of a
  throwaway `Realm` object.

## Test plan
- [x] Verified CLI run against real LANforge/DUT:
      `python3 lf_interop_port_reset_test.py --host 192.168.207.75 --mgr_ip 192.168.9.14 --dut DemoDUT --ssid NETGEAR_2G_wpa2 --passwd Password@123 --encryp psk2 --reset 3 --time_int 5 --release 11`
