### PR TITLE
lf_interop_zoom.py: fix stale upstream_port and host/client script paths

### DIFF
--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -121,6 +121,12 @@ lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
 
 robo_base_class = importlib.import_module("py-scripts.lf_base_robo")
 
+# Directories on the real client stations where the Zoom automation scripts
+# (zoom.bat, ctzoom.bash) are deployed.
+WINDOWS_ZOOM_DIR = r".\local\real_application_test\zoom_automation"
+LINUX_ZOOM_DIR = "./local/real_application_test/zoom_automation"
+MACOS_ZOOM_DIR = "./local/real_application_test/zoom_automation"
+
 
 class ZoomAutomation(Realm):
     def __init__(
@@ -1124,12 +1130,13 @@ class ZoomAutomation(Realm):
             exit(0)
 
         if self.real_sta_os_type[0] == "windows":
-            cmd = f"py zoom_host.py --ip {self.upstream_port}"
+            cmd = fr'"{WINDOWS_ZOOM_DIR}\zoom.bat" --ip {self.upstream_port} host'
             self.generic_endps_profile.set_cmd(
                 self.generic_endps_profile.created_endp[0], cmd
             )
         elif self.real_sta_os_type[0] == "linux":
-            cmd = "su -l lanforge ctzoom.bash %s %s %s" % (
+            cmd = "su -l lanforge %s/ctzoom.bash %s %s %s" % (
+                LINUX_ZOOM_DIR,
                 self.wifi_interface_list[0],
                 self.upstream_port,
                 "host",
@@ -1138,7 +1145,7 @@ class ZoomAutomation(Realm):
                 self.generic_endps_profile.created_endp[0], cmd
             )
         elif self.real_sta_os_type[0] == "macos":
-            cmd = "sudo bash ctzoom.bash %s %s" % (self.upstream_port, "host")
+            cmd = "sudo bash %s/ctzoom.bash %s %s" % (MACOS_ZOOM_DIR, self.upstream_port, "host")
             self.generic_endps_profile.set_cmd(
                 self.generic_endps_profile.created_endp[0], cmd
             )
@@ -1210,12 +1217,13 @@ class ZoomAutomation(Realm):
 
         for i in range(1, len(self.real_sta_os_type)):
             if self.real_sta_os_type[i] == "windows":
-                cmd = f"py zoom_client.py --ip {self.upstream_port}"
+                cmd = fr'"{WINDOWS_ZOOM_DIR}\zoom.bat" --ip {self.upstream_port} client'
                 self.generic_endps_profile.set_cmd(
                     self.generic_endps_profile.created_endp[i], cmd
                 )
             elif self.real_sta_os_type[i] == "linux":
-                cmd = "su -l lanforge ctzoom.bash %s %s %s" % (
+                cmd = "su -l lanforge %s/ctzoom.bash %s %s %s" % (
+                    LINUX_ZOOM_DIR,
                     self.wifi_interface_list[i],
                     self.upstream_port,
                     "client",
@@ -1224,7 +1232,7 @@ class ZoomAutomation(Realm):
                     self.generic_endps_profile.created_endp[i], cmd
                 )
             elif self.real_sta_os_type[i] == "macos":
-                cmd = "sudo bash ctzoom.bash %s %s" % (self.upstream_port, "client")
+                cmd = "sudo bash %s/ctzoom.bash %s %s" % (MACOS_ZOOM_DIR, self.upstream_port, "client")
                 self.generic_endps_profile.set_cmd(
                     self.generic_endps_profile.created_endp[i], cmd
                 )
@@ -4600,6 +4608,7 @@ def main():
         if args.download_csv:
             zoom_automation.download_csv = True
         args.upstream_port = zoom_automation.change_port_to_ip(args.upstream_port)
+        zoom_automation.upstream_port = args.upstream_port
         realdevice = RealDevice(
             manager_ip=args.lanforge_ip,
             server_ip="192.168.1.61",

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -165,10 +165,16 @@ class ZoomAutomation(Realm):
         wait_at_point=30,
         resource_ip=None,
         do_roam=False,
+        window_dir=WINDOWS_ZOOM_DIR,
+        linux_dir=LINUX_ZOOM_DIR,
+        mac_dir=MACOS_ZOOM_DIR,
     ):
 
         super().__init__(lfclient_host=lanforge_ip)
         self.upstream_port = upstream_port
+        self.window_dir = window_dir
+        self.linux_dir = linux_dir
+        self.mac_dir = mac_dir
         self.mgr_ip = lanforge_ip
         self.app = Flask(__name__)
         self.devices = devices
@@ -1130,13 +1136,13 @@ class ZoomAutomation(Realm):
             exit(0)
 
         if self.real_sta_os_type[0] == "windows":
-            cmd = fr'"{WINDOWS_ZOOM_DIR}\zoom.bat" --ip {self.upstream_port} host'
+            cmd = fr'"{self.window_dir}\zoom.bat" --ip {self.upstream_port} host'
             self.generic_endps_profile.set_cmd(
                 self.generic_endps_profile.created_endp[0], cmd
             )
         elif self.real_sta_os_type[0] == "linux":
             cmd = "su -l lanforge %s/ctzoom.bash %s %s %s" % (
-                LINUX_ZOOM_DIR,
+                self.linux_dir,
                 self.wifi_interface_list[0],
                 self.upstream_port,
                 "host",
@@ -1145,7 +1151,7 @@ class ZoomAutomation(Realm):
                 self.generic_endps_profile.created_endp[0], cmd
             )
         elif self.real_sta_os_type[0] == "macos":
-            cmd = "sudo bash %s/ctzoom.bash %s %s" % (MACOS_ZOOM_DIR, self.upstream_port, "host")
+            cmd = "sudo bash %s/ctzoom.bash %s %s" % (self.mac_dir, self.upstream_port, "host")
             self.generic_endps_profile.set_cmd(
                 self.generic_endps_profile.created_endp[0], cmd
             )
@@ -1217,13 +1223,13 @@ class ZoomAutomation(Realm):
 
         for i in range(1, len(self.real_sta_os_type)):
             if self.real_sta_os_type[i] == "windows":
-                cmd = fr'"{WINDOWS_ZOOM_DIR}\zoom.bat" --ip {self.upstream_port} client'
+                cmd = fr'"{self.window_dir}\zoom.bat" --ip {self.upstream_port} client'
                 self.generic_endps_profile.set_cmd(
                     self.generic_endps_profile.created_endp[i], cmd
                 )
             elif self.real_sta_os_type[i] == "linux":
                 cmd = "su -l lanforge %s/ctzoom.bash %s %s %s" % (
-                    LINUX_ZOOM_DIR,
+                    self.linux_dir,
                     self.wifi_interface_list[i],
                     self.upstream_port,
                     "client",
@@ -1232,7 +1238,7 @@ class ZoomAutomation(Realm):
                     self.generic_endps_profile.created_endp[i], cmd
                 )
             elif self.real_sta_os_type[i] == "macos":
-                cmd = "sudo bash %s/ctzoom.bash %s %s" % (MACOS_ZOOM_DIR, self.upstream_port, "client")
+                cmd = "sudo bash %s/ctzoom.bash %s %s" % (self.mac_dir, self.upstream_port, "client")
                 self.generic_endps_profile.set_cmd(
                     self.generic_endps_profile.created_endp[i], cmd
                 )
@@ -4421,6 +4427,26 @@ def main():
             help="Specify if wanted to collect csv from dashboard. Only works with business account",
         )
 
+        # arguments related to the paths of the zoom automation scripts on real client stations
+        parser.add_argument(
+            "--window_dir",
+            type=str,
+            default=WINDOWS_ZOOM_DIR,
+            help="Directory on Windows real client stations where zoom.bat is deployed",
+        )
+        parser.add_argument(
+            "--linux_dir",
+            type=str,
+            default=LINUX_ZOOM_DIR,
+            help="Directory on Linux real client stations where ctzoom.bash is deployed",
+        )
+        parser.add_argument(
+            "--mac_dir",
+            type=str,
+            default=MACOS_ZOOM_DIR,
+            help="Directory on macOS real client stations where ctzoom.bash is deployed",
+        )
+
         # Arguments related to robo feature
         robo_group = parser.add_argument_group(
             "Robo Arguments", "Arguments related to robot movement and coordinates"
@@ -4604,6 +4630,9 @@ def main():
             cycles=args.cycles,
             bssids=bssids,
             do_roam=args.do_roam,
+            window_dir=args.window_dir,
+            linux_dir=args.linux_dir,
+            mac_dir=args.mac_dir,
         )
         if args.download_csv:
             zoom_automation.download_csv = True


### PR DESCRIPTION
Sync zoom_automation.upstream_port with the resolved IP after change_port_to_ip() converts a LANforge port name (e.g. 1.1.eth1) to an IP. Previously only the local args.upstream_port variable was updated, so the Flask client on the host device kept using the raw port name and failing with NameResolutionError.

Also point the generated host/client commands at the deployed zoom.bat/ctzoom.bash locations via WINDOWS_ZOOM_DIR, LINUX_ZOOM_DIR, and MACOS_ZOOM_DIR instead of relying on scripts in the working directory.
Verified CLI: python3 lf_interop_zoom.py --duration 2  --lanforge_ip "192.168.244.97" --signin_email "demo@gmail.com" --signin_passwd 'demo' --participants 2 --audio --video --upstream_port 1.1.eth1 --api_stats_collection --env_file .env