### PR TITLE
lf_ftp.py — Robot/band-steering resilience to unresponsive devices + cleaner missing-CX logging

### DIFF
--- a/py-scripts/lf_ftp.py
+++ b/py-scripts/lf_ftp.py
@@ -285,6 +285,7 @@ class FtpTest(LFCliBase):
         self.cx_status_log = {}
         self.monitoring_start_time = None
         self.all_devices_stopped = False
+        self.bandsteering_start_time = None
         self.uc_min = []
         self.uc_max = []
         self.url_data = []
@@ -1160,6 +1161,9 @@ class FtpTest(LFCliBase):
     # FOR WEB-UI // function usd to fetch runtime values and fill the csv.
 
     def monitor_for_runtime_csv(self):
+        if self.do_bandsteering and self.all_devices_stopped:
+            # Exit early to preserve the last valid results.
+            return False
         if self.do_bandsteering:
             # Band steering invokes this function repeatedly as a per-tick callback within one
             # continuous session, so only set this once for the whole session.
@@ -1169,7 +1173,13 @@ class FtpTest(LFCliBase):
             # Non-bandsteering flows restart the grace period on every call.
             self.monitoring_start_time = datetime.now()
         time_now = datetime.now()
-        start_time = time_now.strftime("%d/%m %I:%M:%S %p")
+        if self.do_bandsteering:
+            # Report the session's start, not this tick's timestamp.
+            if self.bandsteering_start_time is None:
+                self.bandsteering_start_time = time_now
+            start_time = self.bandsteering_start_time.strftime("%d/%m %I:%M:%S %p")
+        else:
+            start_time = time_now.strftime("%d/%m %I:%M:%S %p")
         duration = self.traffic_duration
         endtime = time_now + timedelta(seconds=duration)
         end_time = endtime
@@ -1177,6 +1187,9 @@ class FtpTest(LFCliBase):
         current_time = datetime.now()
         self.data = {}
         self.data["url_data"] = []
+        # Seeded so these keys exist even if traffic_duration <= 0 and the loop below never runs.
+        self.data["start_time"] = [start_time] * len(self.cx_list)
+        self.data["end_time"] = [end_time.strftime("%d/%m %I:%M:%S %p")] * len(self.cx_list)
         client_id_list = []
         test_stopped_by_user = False
         for port in self.input_devices_list:
@@ -1250,13 +1263,14 @@ class FtpTest(LFCliBase):
             # If every CX has stopped responding, retry for up to 40 seconds before giving up
             # on this monitor loop. This does not fail the test: the loop just ends gracefully
             # and execution continues with whatever data was already collected.
+            no_devices_data_found = False
             if self.cx_list and len(self.missing_cx_logged) == len(self.cx_list):
                 logger.warning("All devices have stopped responding during monitoring, retrying "
                                "for up to 40 seconds before ending the monitor loop.")
                 recovery = self.wait_for_any_cx_recovery(timeout=40, poll_interval=5)
                 if recovery == 'stopped':
                     test_stopped_by_user = True
-                    break
+                    no_devices_data_found = True
                 elif recovery == 'timeout':
                     logger.error("No devices responded within 40 seconds during monitoring, "
                                  "ending the monitor loop gracefully; the test will continue with "
@@ -1266,7 +1280,7 @@ class FtpTest(LFCliBase):
                     # navigation state.
                     if self.robot_test:
                         self.robot_obj.update_nav_data_for_all_cxs_stopped()
-                    break
+                    no_devices_data_found = True
 
             self.data["client"] = self.cx_list
             self.data["MAC"] = self.mac_id_list
@@ -1327,6 +1341,9 @@ class FtpTest(LFCliBase):
                 # To update end time at each interval
                 end_time = endtime
             self.data["end_time"] = [end_time.strftime("%d/%m %I:%M:%S %p")] * len(self.cx_list)
+            if no_devices_data_found:
+                # Record the actual give-up time instead of the never-reached planned end_time.
+                self.data["end_time"] = [datetime.now().strftime("%d/%m %I:%M:%S %p")] * len(self.cx_list)
             self.data["remaining_time"] = [[str(int(total_hours)) + " hr and " + str(
                 int(remaining_minutes)) + " min" if int(total_hours) != 0 or int(
                 remaining_minutes) != 0 else '<1 min'][0]] * len(self.cx_list)
@@ -1368,6 +1385,8 @@ class FtpTest(LFCliBase):
             # Reusing monitor logic for band steering, but only need one record per call,
             # so break after first iteration instead of running for full duration.
             if self.do_bandsteering:
+                break
+            if no_devices_data_found:
                 break
             current_time = datetime.now()
         individual_device_csv_names = []

--- a/py-scripts/lf_ftp.py
+++ b/py-scripts/lf_ftp.py
@@ -1449,12 +1449,13 @@ class FtpTest(LFCliBase):
                         cx_found = True
             if not cx_found:
                 if cx not in self.missing_cx_logged:
+                    response_cx_names = [cx_name for i in l4_data for cx_name in i.keys()]
                     logger.warning(
                         "CX '{}' is missing from the monitoring data, the device may have "
                         "disconnected or its connection was not created. Continuing the test "
                         "with the remaining devices.\n"
-                        "URL     : {}\n"
-                        "Response: {}".format(cx, url_str, l4_data))
+                        "URL          : {}\n"
+                        "Response CXs : {}".format(cx, url_str, response_cx_names))
                     self.missing_cx_logged.add(cx)
                     self.failed_cx.append(cx)
                     self.record_device_issue(cx, "CX missing from monitoring data")

--- a/py-scripts/lf_ftp.py
+++ b/py-scripts/lf_ftp.py
@@ -1262,6 +1262,10 @@ class FtpTest(LFCliBase):
                                  "ending the monitor loop gracefully; the test will continue with "
                                  "the data collected so far.")
                     self.all_devices_stopped = True
+                    # Mark the WebUI as completed instead of leaving it at a later planned
+                    # navigation state.
+                    if self.robot_test:
+                        self.robot_obj.update_nav_data_for_all_cxs_stopped()
                     break
 
             self.data["client"] = self.cx_list

--- a/py-scripts/lf_ftp.py
+++ b/py-scripts/lf_ftp.py
@@ -1160,7 +1160,14 @@ class FtpTest(LFCliBase):
     # FOR WEB-UI // function usd to fetch runtime values and fill the csv.
 
     def monitor_for_runtime_csv(self):
-        self.monitoring_start_time = datetime.now()
+        if self.do_bandsteering:
+            # Band steering invokes this function repeatedly as a per-tick callback within one
+            # continuous session, so only set this once for the whole session.
+            if self.monitoring_start_time is None:
+                self.monitoring_start_time = datetime.now()
+        else:
+            # Non-bandsteering flows restart the grace period on every call.
+            self.monitoring_start_time = datetime.now()
         time_now = datetime.now()
         start_time = time_now.strftime("%d/%m %I:%M:%S %p")
         duration = self.traffic_duration

--- a/py-scripts/lf_ftp.py
+++ b/py-scripts/lf_ftp.py
@@ -284,6 +284,7 @@ class FtpTest(LFCliBase):
         self.missing_device_logged = set()
         self.cx_status_log = {}
         self.monitoring_start_time = None
+        self.all_devices_stopped = False
         self.uc_min = []
         self.uc_max = []
         self.url_data = []
@@ -1187,6 +1188,13 @@ class FtpTest(LFCliBase):
             client_id_list.append('.'.join(r_id[:2]))
         monitor_charge_time = current_time
         while (current_time < endtime):
+            if self.all_devices_stopped:
+                # An earlier call already gave up waiting for devices to recover. Band steering
+                # invokes this function repeatedly as its own monitor_function tick, so return
+                # immediately instead of re-running the 40s recovery wait on every tick.
+                if self.do_bandsteering:
+                    return test_stopped_by_user
+                break
             # If robot test mode is enabled, periodically check if a battery pause is needed
             if self.robot_test:
                 # Check if enough time has passed to trigger a battery check (300 sec)
@@ -1246,6 +1254,7 @@ class FtpTest(LFCliBase):
                     logger.error("No devices responded within 40 seconds during monitoring, "
                                  "ending the monitor loop gracefully; the test will continue with "
                                  "the data collected so far.")
+                    self.all_devices_stopped = True
                     break
 
             self.data["client"] = self.cx_list
@@ -3313,16 +3322,19 @@ class FtpTest(LFCliBase):
             self.robot_obj.do_bandsteering = True
             self.start(False, False)
             for coordinate in cycle_coords:
-                if test_stopped_by_user:
+                if test_stopped_by_user or self.all_devices_stopped:
                     break
                 # Check for battery status before moving to next coordinate
                 if_paused, test_stopped_by_user, test_status = self.robot_obj.wait_for_battery(monitor_function=lambda: self.monitor_for_runtime_csv())
                 # If test is stopped by user during battery wait
-                if test_stopped_by_user:
+                if test_stopped_by_user or self.all_devices_stopped:
                     break
                 robo_moved, abort, test_status = self.robot_obj.move_to_coordinate(coordinate, monitor_function=lambda: self.monitor_for_runtime_csv())
                 # If robot failed to reach the coordinate
                 if abort:
+                    break
+                if self.all_devices_stopped:
+                    logger.warning("Band-steering test stopped because no devices recovered within 40 seconds.")
                     break
                 if robo_moved:
                     logger.info("Reached the coordinate {}".format(coordinate))
@@ -3331,7 +3343,9 @@ class FtpTest(LFCliBase):
             return
 
         for coordinate in range(len(self.coordinate_list)):
-            if test_stopped_by_user:
+            if test_stopped_by_user or self.all_devices_stopped:
+                if self.all_devices_stopped:
+                    logger.warning("Robot test stopped because no devices recovered within 40 seconds.")
                 break
             # Check for battery status before moving to next coordinate
             if_paused, test_stopped_by_user = self.robot_obj.wait_for_battery()
@@ -3357,6 +3371,8 @@ class FtpTest(LFCliBase):
                 # if rotation mode
                 else:
                     for angle in range(len(self.rotation_list)):
+                        if self.all_devices_stopped:
+                            break
                         # Check for battery status before rotating to next angle
                         is_paused, test_stopped_by_user = self.robot_obj.wait_for_battery()
                         # If test is stopped by user during battery wait


### PR DESCRIPTION
# PR: `lf_ftp.py` — Robot/band-steering resilience to unresponsive devices + cleaner missing-CX logging

**Commits:** `bdeafed5` → `8982f268`

## What's handled

### **All devices go unresponsive during monitoring** (`bdeafed5`)
Instead of hanging indefinitely, the monitor loop now retries for up to **40s** (`wait_for_any_cx_recovery`), then gives up gracefully and stops the robot/band-steering run early, using whatever data was already collected.

Band-steering's coordinate loop and the plain robot coordinate/rotation loop both check `all_devices_stopped` and break out cleanly instead of continuing to move the robot.

---

### **Grace-period timing differs by test mode** (`3439f307`)
Band-steering calls `monitor_for_runtime_csv()` repeatedly within one continuous session, so `monitoring_start_time` is set once.

Plain robot coordinate/rotation tests call it once per coordinate with CXs freshly restarted each time, so the grace period now resets on every call instead of only the first.

---

### **WebUI left in a stale "in progress" nav state** (`5ccf7acb`)
When the **40s** recovery wait times out on a robot test, `update_nav_data_for_all_cxs_stopped()` is now called so the WebUI shows the run as completed rather than stuck on a step that will never be reached.

---

### **Crash when band steering ends after all devices stop** (`2c1d6daa`)
`monitor_for_runtime_csv()` now:
- bails out immediately if band steering already gave up on a prior tick (before `self.data` gets reset, so the last good snapshot survives for `stop()` to read),
- seeds `start_time`/`end_time` defensively in case `traffic_duration <= 0`,
- uses the band-steering session's actual start time instead of each tick's timestamp,
- records the real give-up time as `end_time` instead of the never-reached planned end.

---

### **Missing-CX warning dumped the entire nested API response** (`8982f268`)
Now logs just the **CX names** present in the response, making the log readable instead of printing the full stats dict for every connection.

---

## Net effect

Robot/band-steering FTP tests degrade gracefully (**stop early, keep partial data, update WebUI state, no crash**) when devices disconnect mid-test, and diagnostic logging for missing CXs is now scannable at a glance.
```
test logs : 

1785742108.137854 INFO     Test is about to start lf_ftp.py 222
1785742108.314358 INFO     Test is Initialized lf_ftp.py 351
1785742108.516930 INFO     Connected (version 2.0, client OpenSSH_8.8) transport.py 1938
1785742109.049552 INFO     Authentication (password) successful! transport.py 1938
1785742110.131999 INFO     ['True\n'] lf_ftp.py 980
1785742121.213474 INFO     File creation done 5MB lf_ftp.py 988
1785742124.285852 INFO     Upstream port IP 172.16.0.1 lf_ftp.py 611
1785742124.465448 WARNING  1.1.98ccc885 is in phantom state. Please make sure debugging is enabled in developer settings. DeviceConfig.py 393
1785742124.465659 WARNING  1.1.BYEQ6LSCDQOVO7GE is in phantom state. Please make sure debugging is enabled in developer settings. DeviceConfig.py 393
1785742125.379221 INFO     The laptop on port 1.105 is in phantom state. DeviceConfig.py 868
1785742125.823332 INFO     The laptop on port 1.128 is in phantom state. DeviceConfig.py 868
1785742125.823491 INFO     The laptop on port 1.151 is in phantom state. DeviceConfig.py 868
1785742126.444824 ERROR    Malformed response. Response does not have interfaces data. Setting the station name to default i.e., wlan0 DeviceConfig.py 953
1785742126.444959 INFO     The laptop on port 1.192 has no wiphy port available. DeviceConfig.py 875
1785742126.445001 INFO     The laptop on port 1.255 is in phantom state. DeviceConfig.py 868
1.10  1.10 Lin hp80-HP-ProBook-445R-G6
1.11  1.11 Lin user-ThinkPad-T450
1.15  1.15 android googlepixel
1.16  1.16 android Samsung_F41
1.18  1.18 android Oppo2375
1.22  1.22 android Pixel4a_1
1.25  1.25 android samsung
1.26  1.26 Lin lin-01
1.109  1.109 Lin user-HP-ProBook-445R-G6
1.113  1.113 Win DESKTOP-F0HLI17
1.153  1.153 Mac lanforges-Air.ctinb.candelatech
1785742127.464884 INFO     AVAILABLE DEVICES TO RUN TEST: ['1.10 Lin hp80-HP-ProBook-445R-G6', '1.11 Lin user-ThinkPad-T450', '1.15 android googlepixel', '1.16 android Samsung_F41', '1.18 android Oppo2375', '1.22 android Pixel4a_1', '1.25 android samsung', '1.26 Lin lin-01', '1.109 Lin user-HP-ProBook-445R-G6', '1.113 Win DESKTOP-F0HLI17', '1.153 Mac lanforges-Air.ctinb.candelatech'] lf_ftp.py 498
1785742127.465059 INFO     ['1.10 Lin hp80-HP-ProBook-445R-G6', '1.11 Lin user-ThinkPad-T450', '1.15 android googlepixel', '1.16 android Samsung_F41', '1.18 android Oppo2375', '1.22 android Pixel4a_1', '1.25 android samsung', '1.26 Lin lin-01', '1.109 Lin user-HP-ProBook-445R-G6', '1.113 Win DESKTOP-F0HLI17', '1.153 Mac lanforges-Air.ctinb.candelatech'] lf_ftp.py 499
1785742127.465134 INFO     Test is initiated on devices: ['1.26', '1.109'] lf_ftp.py 522
1785742127.465198 INFO     device got from webui are: 1.26,1.109 lf_ftp.py 539
1785742127.465271 INFO     INPUT DEVICES LIST ['1.26.wlan0', '1.109.wlan0'] lf_ftp.py 557
REAL CLIENT LIST ['1.26 Lin lin-01', '1.109 Lin user-HP-ProBook-445R-G6']
1785742127.465342 INFO     MAC ID LIST ['ac:ed:5c:36:a6:1e', 'd8:12:65:0d:74:59'] lf_ftp.py 576
1785742127.465541 INFO     Cleaning up cxs and endpoints http_profile.py 77
1785742127.465658 INFO     Cleaning up stations station_profile.py 474
1785742127.465706 INFO     INFO: StationProfile cleanup, list is empty station_profile.py 480
1785742128.466100 INFO     precleanup done lf_ftp.py 677
1785742129.264034 INFO     Create HTTP CXs...py-json.http_profile http_profile.py 119
1785742129.510039 INFO     ###### url:dl ftp://lanforge:lanforge@172.16.0.1/ftp_test.txt /dev/null http_profile.py 184
1785742130.430204 INFO     ###### url:dl ftp://lanforge:lanforge@172.16.0.1/ftp_test.txt /dev/null http_profile.py 184
1785742132.777391 INFO     Test Build done lf_ftp.py 842
1785742132.777791 ERROR    passes: zero test results, Chamberview tests will show zero test results so not an error lfcli_base.py 530
1785742133.506250 INFO     cross connections found for all devices lf_ftp.py 3197
1785742133.506574 INFO     Test started on the devices : ['1.26.wlan0', '1.109.wlan0'] lf_ftp.py 4075
1785742133.506699 INFO     Traffic started running at 2026-08-03 12:58:53.506653 lf_ftp.py 4078
1785742133.507301 INFO     Starting CXs... http_profile.py 59
1785742134.020154 INFO     Test Started lf_ftp.py 865
1785742162.759352 WARNING  CX 'wlan0_ftp109_l4' status changed: Run -> Stopped lf_ftp.py 1120
1785742168.832036 INFO     CX 'wlan0_ftp109_l4' recovered: Stopped -> Run lf_ftp.py 1123
1785742180.096454 WARNING  CX 'wlan0_ftp109_l4' is missing from the monitoring data, the device may have disconnected or its connection was not created. Continuing the test with the remaining devices.
URL          : layer4/wlan0_ftp26_l4,wlan0_ftp109_l4/list?fields=uc-avg,uc-max,uc-min,total-urls,rx rate (1m),bytes-rd,total-err,status
Response CXs : ['wlan0_ftp26_l4'] lf_ftp.py 1457
1785742196.479403 ERROR    All l4 data not found lf_ftp.py 1406
1785742196.895932 INFO     Monitoring complete lf_ftp.py 1714
1785742196.897068 INFO     Stopping CXs... http_profile.py 68
1785742197.100678 ERROR    
 = = LANforge Error Messages = =
 = = URL: http://192.168.245.117:8080/cli-json/set_cx_state
  X-Error-00: unable to execute set_cx_state rv: 22 (22  Invalid argument)
  X-Error-01: URL: /cli-json/set_cx_state
 = = = = = = = = = = = = = = = = LFRequest.py 396
1785742197.299331 ERROR    
 = = LANforge Error Messages = =
 = = URL: http://192.168.245.117:8080/cli-json/set_cx_state
  X-Error-00: unable to execute set_cx_state rv: 22 (22  Invalid argument)
  X-Error-01: URL: /cli-json/set_cx_state
 = = = = = = = = = = = = = = = = LFRequest.py 396
Traffic stopped running
1785742197.301829 INFO     Cleaning up cxs and endpoints http_profile.py 77
1785742197.461776 ERROR    
 = = LANforge Error Messages = =
 = = URL: http://192.168.245.117:8080/cli-json/rm_cx
  X-Error-00: unable to execute rm_cx rv: 22 (22  Invalid argument)
  X-Error-01: URL: /cli-json/rm_cx
 = = = = = = = = = = = = = = = = LFRequest.py 396
1785742197.708680 ERROR    
 = = LANforge Error Messages = =
 = = URL: http://192.168.245.117:8080/cli-json/rm_endp
  X-Error-00: unable to execute rm_endp rv: 22 (22  Invalid argument)
  X-Error-01: URL: /cli-json/rm_endp
 = = = = = = = = = = = = = = = = LFRequest.py 396
1785742197.914173 ERROR    
 = = LANforge Error Messages = =
 = = URL: http://192.168.245.117:8080/cli-json/rm_cx
  X-Error-00: unable to execute rm_cx rv: 22 (22  Invalid argument)
  X-Error-01: URL: /cli-json/rm_cx
 = = = = = = = = = = = = = = = = LFRequest.py 396
1785742198.123818 ERROR    
 = = LANforge Error Messages = =
 = = URL: http://192.168.245.117:8080/cli-json/rm_endp
  X-Error-00: unable to execute rm_endp rv: 22 (22  Invalid argument)
  X-Error-01: URL: /cli-json/rm_endp
 = = = = = = = = = = = = = = = = LFRequest.py 396
1785742198.124161 INFO     Cleaning up stations station_profile.py 474
1785742198.124259 INFO     INFO: StationProfile cleanup, list is empty station_profile.py 480
1785742198.124361 INFO     Test ended at 2026-08-03 12:59:58.124329 lf_ftp.py 4107
1785742198.126399 INFO     path set:  lf_report.py 85
1785742198.126628 INFO     path_date_time 2026-08-03-12-59-58_ftp_test lf_report.py 239
1785742198.127806 INFO     report path : 2026-08-03-12-59-58_ftp_test lf_report.py 248
1785742198.130478 INFO     path set: /home/Sidartha/myhome/local/interop-webGUI/results/safsaf lf_report.py 85
1785742198.130757 INFO     path_date_time /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test lf_report.py 239
1785742198.131922 INFO     report path : /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test lf_report.py 248
1785742198.135152 ERROR    failed to create all layer 4 csv lf_ftp.py 2520
                        Client names  Download
0                    1.26 Lin lin-01         0
1  1.109 Lin user-HP-ProBook-445R-G6         4
graph name Total-url_ftp.png
1785742198.509482 INFO     graph_src_file: Total-url_ftp.png lf_report.py 212
1785742198.509673 INFO     graph_dst_file: /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/Total-url_ftp.png lf_report.py 213
1785742198.509800 INFO     csv_src_file: Total-url_ftp.csv lf_report.py 219
1785742198.509838 INFO     csv_dst_file: /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/Total-url_ftp.csv lf_report.py 220
                        Client names  Download
0                    1.26 Lin lin-01      0.00
1  1.109 Lin user-HP-ProBook-445R-G6    197.25
graph name ucg-avg_ftp.png
1785742198.769928 INFO     graph_src_file: ucg-avg_ftp.png lf_report.py 212
1785742198.770284 INFO     graph_dst_file: /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/ucg-avg_ftp.png lf_report.py 213
1785742198.770510 INFO     csv_src_file: ucg-avg_ftp.csv lf_report.py 219
1785742198.770596 INFO     csv_dst_file: /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/ucg-avg_ftp.csv lf_report.py 220
1785742209.778145 INFO     write_output_html: /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/ftp_test.html lf_report.py 368
1785742209.778360 INFO     returned file /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/ftp_test.html lf_ftp.py 2810
1785742209.778409 INFO     /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/ftp_test.html lf_ftp.py 2811
1785742210.339556 INFO     Monitoring Duration: 1m 2s lf_ftp.py 2813
1785742210.339726 INFO     output file /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/_2026-08-03-13-00-10-test_l4_ftp.csv lf_report.py 350
1785742210.339787 INFO     csv output file : /home/Sidartha/myhome/local/interop-webGUI/results/safsaf/2026-08-03-12-59-58_ftp_test/_2026-08-03-13-00-10-test_l4_ftp.csv lf_ftp.py 2999

```