### PR TITLE
lf_interop_video_streaming.py: Make robot-test monitoring resilient to unresponsive devices, and fix report bugs

### DIFF
--- a/py-scripts/lf_interop_video_streaming.py
+++ b/py-scripts/lf_interop_video_streaming.py
@@ -712,11 +712,12 @@ class VideoStreamingTest(Realm):
         match = re.search(r'(\d+)_l4$', cx_name)
         return "1.{}".format(match.group(1)) if match else cx_name
 
-    def record_device_issue(self, device, issue):
+    def record_device_issue(self, device, issue, api_response=None):
         self.device_issue_log.append({
             "Time": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             "Device": device,
             "Issue": issue,
+            "API Response": api_response if api_response is not None else '',
         })
 
     def my_monitor_runtime(self):
@@ -802,7 +803,8 @@ class VideoStreamingTest(Realm):
                         )
                         self.missing_cx_logged.add(cx_name)
                         self.record_device_issue(self.port_label_from_cx_name(cx_name),
-                                                 "CX '{}' missing from monitoring data".format(cx_name))
+                                                 "CX '{}' missing from monitoring data".format(cx_name),
+                                                 api_response=list(cx_metrics.keys()))
                     value = dict(default_cx_metrics, name=cx_name)
                 else:
                     if cx_name in self.missing_cx_logged:
@@ -819,7 +821,8 @@ class VideoStreamingTest(Realm):
                             logger.warning("CX '{}' status is '{}', not running.".format(cx_name, status))
                             self.cx_not_running_logged.add(cx_name)
                             self.record_device_issue(self.port_label_from_cx_name(cx_name),
-                                                     "CX '{}' status is '{}', not running".format(cx_name, status))
+                                                     "CX '{}' status is '{}', not running".format(cx_name, status),
+                                                     api_response=value)
                     elif cx_name in self.cx_not_running_logged:
                         logger.info("CX '{}' status is back to running.".format(cx_name))
                         self.cx_not_running_logged.discard(cx_name)
@@ -1019,7 +1022,8 @@ class VideoStreamingTest(Realm):
                         "Response keys: {}".format(resource_id, signal_url, response_keys)
                     )
                     self.missing_signal_logged.add(resource_id)
-                    self.record_device_issue("1.{}".format(resource_id), "Signal data unavailable (device may have disconnected)")
+                    self.record_device_issue("1.{}".format(resource_id), "Signal data unavailable (device may have disconnected)",
+                                             api_response=response_keys)
                 value = default_signal
             else:
                 if resource_id in self.missing_signal_logged:

--- a/py-scripts/lf_interop_video_streaming.py
+++ b/py-scripts/lf_interop_video_streaming.py
@@ -1253,7 +1253,7 @@ class VideoStreamingTest(Realm):
                     if from_coordinate == to_coordinate:
                         return test_stopped_by_user
                     individual_df_data.extend([robot_x, robot_y, from_coordinate, to_coordinate])
-                if self.robot_test and self.rotation_enabled:
+                elif self.robot_test and self.rotation_enabled:
                     individual_df_data.append(self.current_angle)
                 individual_df.loc[len(individual_df)] = individual_df_data
                 new_row_df = individual_df.tail(1)
@@ -1342,7 +1342,10 @@ class VideoStreamingTest(Realm):
                 individual_df_data.extend([sum(overall_video_rate), present_time, iteration + 1, actual_start_time.strftime('%Y-%m-%d %H:%M:%S'),
                                            self.data['end_time_webGUI'][0], self.data['remaining_time_webGUI'][0], "Stopped"])
 
-            if self.robot_test and self.rotation_enabled:
+            if self.robot_test and self.do_bandsteering:
+                robot_x, robot_y, from_coordinate, to_coordinate = self.robot.get_robot_pose()
+                individual_df_data.extend([robot_x, robot_y, from_coordinate, to_coordinate])
+            elif self.robot_test and self.rotation_enabled:
                 individual_df_data.append(self.current_angle)
 
             individual_df.loc[len(individual_df)] = individual_df_data

--- a/py-scripts/lf_interop_video_streaming.py
+++ b/py-scripts/lf_interop_video_streaming.py
@@ -790,14 +790,15 @@ class VideoStreamingTest(Realm):
 
             for cx_name in self.created_cx.keys():
                 value = cx_metrics.get(cx_name)
-                if value is None:
+                was_missing = value is None
+                if was_missing:
                     if cx_name not in self.missing_cx_logged:
                         logger.warning(
                             "CX '{}' is missing from the monitoring data, the device may have disconnected "
                             "or its connection was not created. Continuing the test with the remaining "
                             "devices.\n"
                             "URL     : {}\n"
-                            "Response: {}".format(cx_name, monitor_url, data)
+                            "Response keys: {}".format(cx_name, monitor_url, list(cx_metrics.keys()))
                         )
                         self.missing_cx_logged.add(cx_name)
                         self.record_device_issue(self.port_label_from_cx_name(cx_name),
@@ -809,19 +810,19 @@ class VideoStreamingTest(Realm):
                         self.missing_cx_logged.discard(cx_name)
 
                 status = value.get('status', 'Stopped')
-                # Give devices a 10s grace period after monitoring starts before treating a
-                # non-'Run' status as noteworthy, since it's normal for CXs to still be starting
-                # up right after the monitor loop begins.
-                past_grace_period = (self.monitor_start_time is None or (datetime.now() - self.monitor_start_time).total_seconds() >= 10)
-                if status != 'Run':
-                    if past_grace_period and cx_name not in self.cx_not_running_logged:
-                        logger.warning("CX '{}' status is '{}', not running.".format(cx_name, status))
-                        self.cx_not_running_logged.add(cx_name)
-                        self.record_device_issue(self.port_label_from_cx_name(cx_name),
-                                                 "CX '{}' status is '{}', not running".format(cx_name, status))
-                elif cx_name in self.cx_not_running_logged:
-                    logger.info("CX '{}' status is back to running.".format(cx_name))
-                    self.cx_not_running_logged.discard(cx_name)
+                # skip the status check for an already-missing CX, since it defaults to 'Stopped' and would just be a redundant warning
+                if not was_missing:
+                    # 10s grace period after monitor start, since CXs may still be starting up
+                    past_grace_period = (self.monitor_start_time is None or (datetime.now() - self.monitor_start_time).total_seconds() >= 10)
+                    if status != 'Run':
+                        if past_grace_period and cx_name not in self.cx_not_running_logged:
+                            logger.warning("CX '{}' status is '{}', not running.".format(cx_name, status))
+                            self.cx_not_running_logged.add(cx_name)
+                            self.record_device_issue(self.port_label_from_cx_name(cx_name),
+                                                     "CX '{}' status is '{}', not running".format(cx_name, status))
+                    elif cx_name in self.cx_not_running_logged:
+                        logger.info("CX '{}' status is back to running.".format(cx_name))
+                        self.cx_not_running_logged.discard(cx_name)
 
                 names.append(value.get('name', cx_name))
                 statuses.append(status)
@@ -1010,11 +1011,12 @@ class VideoStreamingTest(Realm):
             value = signal_by_resource.get(resource_id)
             if value is None:
                 if resource_id not in self.missing_signal_logged:
+                    response_keys = [key for iface in eid_data.get("interfaces", []) for key in iface]
                     logger.warning(
                         "Signal data for device on port 1.{} is unavailable, it may have disconnected. "
                         "Continuing the test with the remaining devices.\n"
                         "URL     : {}\n"
-                        "Response: {}".format(resource_id, signal_url, eid_data)
+                        "Response keys: {}".format(resource_id, signal_url, response_keys)
                     )
                     self.missing_signal_logged.add(resource_id)
                     self.record_device_issue("1.{}".format(resource_id), "Signal data unavailable (device may have disconnected)")
@@ -1112,13 +1114,20 @@ class VideoStreamingTest(Realm):
                     # This pre-check runs on every call to monitor_for_runtime_csv, which in
                     # bandsteering/robot mode is invoked repeatedly as the monitor_function tick.
                     # Only print this summary once per test instead of on every tick.
+                    last_response_endpoint = self.last_monitor_response.get('endpoint') if self.last_monitor_response else None
+                    if isinstance(last_response_endpoint, list):
+                        response_keys = [key for endpoint in last_response_endpoint for key in endpoint]
+                    elif isinstance(last_response_endpoint, dict):
+                        response_keys = list(last_response_endpoint.keys())
+                    else:
+                        response_keys = []
                     logger.warning("The following device(s) are missing before monitoring starts, "
                                    "continuing the test with the remaining {} device(s): {}\n"
                                    "URL     : {}\n"
-                                   "Response: {}".format(
+                                   "Response keys: {}".format(
                                        len(self.created_cx) - len(self.missing_cx_logged),
                                        sorted(self.port_label_from_cx_name(cx) for cx in self.missing_cx_logged),
-                                       self.last_monitor_url, self.last_monitor_response))
+                                       self.last_monitor_url, response_keys))
                     self.pre_monitoring_missing_logged = True
 
             # Loop until the current time is less than the end time

--- a/py-scripts/lf_interop_video_streaming.py
+++ b/py-scripts/lf_interop_video_streaming.py
@@ -1138,6 +1138,9 @@ class VideoStreamingTest(Realm):
             # Loop until the current time is less than the end time
             while current_time < endtime_check or self.background_run:
                 if self.test_stopped:
+                    # bandsteering re-enters this function per tick, so return now instead of falling through to code that assumes a loop iteration ran
+                    if self.do_bandsteering:
+                        return test_stopped_by_user
                     break
                 if self.robot_test:
                     # monitor_charge_time is None when this function is invoked as the
@@ -1207,6 +1210,11 @@ class VideoStreamingTest(Realm):
                         logger.error("No devices responded within 40 seconds during monitoring, "
                                      "ending the monitor loop gracefully; the test will continue with "
                                      "the data collected so far.")
+                        # stop the whole robot test instead of moving on to another coordinate/rotation
+                        self.test_stopped = True
+                        # mark the WebUI as completed instead of leaving it at a later planned navigation state
+                        if self.robot_test:
+                            self.robot.update_nav_data_for_all_cxs_stopped()
                         break
 
                 overall_video_rate = []
@@ -2441,6 +2449,9 @@ class VideoStreamingTest(Realm):
                 for angle in range(len(self.rotation_list)):
                     self.current_angle = self.rotation_list[angle]
                     coord, ang = self.coordinate_list[coordinate], self.rotation_list[angle]
+                    # a stopped test may not have reached every configured angle, so skip missing ones
+                    if ang not in self.vs_data[int(coord)]:
+                        continue
                     self.data = self.vs_data[int(coord)][ang]["self_data"]
                     self.generate_individual_coordinate(report, device_type, username, ssid, mac, channel, mode, rssi, tx_rate, created_incremental_values, keys)
                 shutil.move('video_streaming_realtime_data{}.csv'.format(csv_suffix), report_path_date_time)
@@ -2744,16 +2755,24 @@ class VideoStreamingTest(Realm):
             self.start_specific(cx_order_list[i])
             individual_df = pd.DataFrame(columns=individual_dataframe_columns)
             for coord in coordinate_list_with_robo:
-                #  To check for battery level before moving to next coordinate and also monitor cx while moving to next coordinate in bandsteering mode
-                pause, stopped, all_data_frames = self.robot.wait_for_battery(
-                    monitor_function=lambda: self.monitor_for_runtime_csv(
-                        args.duration, file_path, individual_df, i, actual_start_time, cx_order_list[i]))
-                if stopped:
+                try:
+                    #  To check for battery level before moving to next coordinate and also monitor cx while moving to next coordinate in bandsteering mode
+                    pause, stopped, all_data_frames = self.robot.wait_for_battery(
+                        monitor_function=lambda: self.monitor_for_runtime_csv(
+                            args.duration, file_path, individual_df, i, actual_start_time, cx_order_list[i]))
+                    if stopped:
+                        break
+                    # Moving to next coordinate and also monitor cx while moving to next coordinate in bandsteering mode
+                    matched, abort, all_data_frames = self.robot.move_to_coordinate(
+                        coord, monitor_function=lambda: self.monitor_for_runtime_csv(
+                            args.duration, file_path, individual_df, i, actual_start_time, cx_order_list[i]))
+                except RuntimeError as e:
+                    logger.debug("Stopping bandsteering test: %s", e)
+                    # no devices ever responded; stop the test and report with the data collected so far
+                    self.test_stopped = True
+                    if self.robot_test:
+                        self.robot.update_nav_data_for_all_cxs_stopped()
                     break
-                # Moving to next coordinate and also monitor cx while moving to next coordinate in bandsteering mode
-                matched, abort, all_data_frames = self.robot.move_to_coordinate(
-                    coord, monitor_function=lambda: self.monitor_for_runtime_csv(
-                        args.duration, file_path, individual_df, i, actual_start_time, cx_order_list[i]))
                 if coord == self.coordinate_list[0]:
                     curr_cycle += 1
                     if curr_cycle > int(self.total_cycles):
@@ -2762,14 +2781,15 @@ class VideoStreamingTest(Realm):
                         logger.info("current cycle {}".format(curr_cycle))
                 if abort:
                     break
-            # To get add last entry in the csv
-            last_idx = individual_df.index[-1]
-            individual_df.loc[last_idx, "status"] = "Stopped"
-            last_row_df = individual_df.loc[[last_idx]]
-            if self.dowebgui:
-                last_row_df.to_csv(f"{args.result_dir}/video_streaming_realtime_data.csv", mode="a", header=False, index=False)
-            else:
-                last_row_df.to_csv("video_streaming_realtime_data.csv", mode="a", header=False, index=False)
+            # add last entry in the csv, skipping if no data was ever collected
+            if len(individual_df) > 0:
+                last_idx = individual_df.index[-1]
+                individual_df.loc[last_idx, "status"] = "Stopped"
+                last_row_df = individual_df.loc[[last_idx]]
+                if self.dowebgui:
+                    last_row_df.to_csv(f"{args.result_dir}/video_streaming_realtime_data.csv", mode="a", header=False, index=False)
+                else:
+                    last_row_df.to_csv("video_streaming_realtime_data.csv", mode="a", header=False, index=False)
             #  stop cx's after completing all cycles in bandsteering mode or if test is stopped by user in between the test
             self.stop()
             test_setup_info = self.create_test_setup_info(media_source=self.media_source_name, media_quality=self.media_quality_name)
@@ -2829,9 +2849,24 @@ class VideoStreamingTest(Realm):
                                     if data["status"] != "Running":
                                         self.test_stopped = True
                                         break
-                            test_stopped_by_user = self.monitor_for_runtime_csv(args.duration, file_path, coordinate_df, i, actual_start_time, cx_order_list[i])
+                            try:
+                                test_stopped_by_user = self.monitor_for_runtime_csv(args.duration, file_path, coordinate_df, i, actual_start_time, cx_order_list[i])
+                            except RuntimeError as e:
+                                logger.debug("Stopping robot test at coordinate {}: {}".format(self.current_coordinate, e))
+                                # no devices ever responded at this coordinate; stop the whole robot test
+                                self.test_stopped = True
+                                if self.robot_test:
+                                    self.robot.update_nav_data_for_all_cxs_stopped()
+                                break
                         else:
-                            test_stopped_by_user = self.monitor_for_runtime_csv(args.duration, file_path, coordinate_df, i, actual_start_time, cx_order_list[i])
+                            try:
+                                test_stopped_by_user = self.monitor_for_runtime_csv(args.duration, file_path, coordinate_df, i, actual_start_time, cx_order_list[i])
+                            except RuntimeError as e:
+                                logger.debug("Stopping robot test at coordinate {}: {}".format(self.current_coordinate, e))
+                                self.test_stopped = True
+                                if self.robot_test:
+                                    self.robot.update_nav_data_for_all_cxs_stopped()
+                                break
                         if not test_stopped_by_user:
                             # Append current iteration index to iterations_before_test_stopped_by_user
                             iterations_before_test_stopped_by_user.append(i)
@@ -2851,6 +2886,8 @@ class VideoStreamingTest(Realm):
                     else:
                         exit_from_monitor = False
                         for angle in range(len(self.rotation_list)):
+                            if self.test_stopped:
+                                break
                             final_angle = 0
                             # Check battery level: if below 20% robot charges fully before resuming
                             pause_angle, test_stopped_by_user = self.robot.wait_for_battery(stop=self.stop)
@@ -2899,27 +2936,44 @@ class VideoStreamingTest(Realm):
                                         if data["status"] != "Running":
                                             self.test_stopped = True
                                             break
-                                test_stopped_by_user = self.monitor_for_runtime_csv(
-                                    args.duration,
-                                    file_path,
-                                    individual_df,
-                                    i,
-                                    actual_start_time,
-                                    cx_order_list[i],
-                                    curr_coordinate=coordinate,
-                                    curr_rotation=self.rotation_list[angle],
-                                    monitor_charge_time=monitor_charge_time)
+                                try:
+                                    test_stopped_by_user = self.monitor_for_runtime_csv(
+                                        args.duration,
+                                        file_path,
+                                        individual_df,
+                                        i,
+                                        actual_start_time,
+                                        cx_order_list[i],
+                                        curr_coordinate=coordinate,
+                                        curr_rotation=self.rotation_list[angle],
+                                        monitor_charge_time=monitor_charge_time)
+                                except RuntimeError as e:
+                                    logger.debug("Stopping robot test at coordinate {} angle {}: {}".format(
+                                        coordinate, self.rotation_list[angle], e))
+                                    # stop the whole robot test; breaking here also stops the outer coordinate loop
+                                    self.test_stopped = True
+                                    if self.robot_test:
+                                        self.robot.update_nav_data_for_all_cxs_stopped()
+                                    break
                             else:
-                                test_stopped_by_user = self.monitor_for_runtime_csv(
-                                    args.duration,
-                                    file_path,
-                                    individual_df,
-                                    i,
-                                    actual_start_time,
-                                    cx_order_list[i],
-                                    curr_coordinate=coordinate,
-                                    curr_rotation=self.rotation_list[angle],
-                                    monitor_charge_time=monitor_charge_time)
+                                try:
+                                    test_stopped_by_user = self.monitor_for_runtime_csv(
+                                        args.duration,
+                                        file_path,
+                                        individual_df,
+                                        i,
+                                        actual_start_time,
+                                        cx_order_list[i],
+                                        curr_coordinate=coordinate,
+                                        curr_rotation=self.rotation_list[angle],
+                                        monitor_charge_time=monitor_charge_time)
+                                except RuntimeError as e:
+                                    logger.debug("Stopping robot test at coordinate {} angle {}: {}".format(
+                                        coordinate, self.rotation_list[angle], e))
+                                    self.test_stopped = True
+                                    if self.robot_test:
+                                        self.robot.update_nav_data_for_all_cxs_stopped()
+                                    break
                             if not test_stopped_by_user:
                                 # Append current iteration index to iterations_before_test_stopped_by_user
                                 iterations_before_test_stopped_by_user.append(i)
@@ -2928,6 +2982,9 @@ class VideoStreamingTest(Realm):
                                 iterations_before_test_stopped_by_user.append(i)
                                 params = self.build_report_params_for_robo(args, cx_order_list, individual_df, iterations_before_test_stopped_by_user)
                                 params["self_data"] = self.data.copy()
+                                if int(coordinate) not in self.vs_data:
+                                    self.vs_data[int(coordinate)] = {}
+                                self.vs_data[int(coordinate)][self.rotation_list[angle]] = params
                                 break
                             self.stop()
                             params = self.build_report_params_for_robo(args, cx_order_list, individual_df, iterations_before_test_stopped_by_user)

--- a/py-scripts/lf_interop_video_streaming.py
+++ b/py-scripts/lf_interop_video_streaming.py
@@ -1042,7 +1042,12 @@ class VideoStreamingTest(Realm):
             resource_ids = list(map(int, self.resource_ids.split(',')))
             self.data_for_webui['resources'] = resource_ids
             starttime = datetime.now()
-            if self.monitor_start_time is None:
+            if self.do_bandsteering:
+                # bandsteering runs one continuous session, so only set this once
+                if self.monitor_start_time is None:
+                    self.monitor_start_time = starttime
+            else:
+                # other robot_test flows restart CXs per coordinate/rotation, so restart this too
                 self.monitor_start_time = starttime
             self.data["name"] = self.my_monitor('name')
             current_time = datetime.now()

--- a/py-scripts/lf_interop_video_streaming.py
+++ b/py-scripts/lf_interop_video_streaming.py
@@ -2311,7 +2311,7 @@ class VideoStreamingTest(Realm):
         """
         date = str(datetime.now()).split(",")[0].replace(" ", "-").split(".")[0]
 
-        test_setup_info = self.create_test_setup_info(media_source=args.media_source, media_quality=args.media_quality)
+        test_setup_info = self.create_test_setup_info(media_source=self.media_source_name, media_quality=self.media_quality_name)
         params = {
             "date": None,
             "iterations_before_test_stopped_by_user": None,
@@ -2772,7 +2772,7 @@ class VideoStreamingTest(Realm):
                 last_row_df.to_csv("video_streaming_realtime_data.csv", mode="a", header=False, index=False)
             #  stop cx's after completing all cycles in bandsteering mode or if test is stopped by user in between the test
             self.stop()
-            test_setup_info = self.create_test_setup_info(media_source=self.media_source, media_quality=self.media_quality)
+            test_setup_info = self.create_test_setup_info(media_source=self.media_source_name, media_quality=self.media_quality_name)
             date = str(datetime.now()).split(",")[0].replace(" ", "-").split(".")[0]
             self.generate_report(date, [0], test_setup_info=test_setup_info, realtime_dataset=individual_df, iot_summary=None)
             if self.postcleanup:
@@ -2935,7 +2935,7 @@ class VideoStreamingTest(Realm):
                             if int(coordinate) not in self.vs_data:
                                 self.vs_data[int(coordinate)] = {}
                             self.vs_data[int(coordinate)][self.rotation_list[angle]] = params
-        test_setup_info = self.create_test_setup_info(media_source=args.media_source, media_quality=args.media_quality)
+        test_setup_info = self.create_test_setup_info(media_source=self.media_source_name, media_quality=self.media_quality_name)
         if self.dowebgui:
             self.copy_reports_to_home_dir()
             with open(nav_data, 'r') as x:
@@ -3506,6 +3506,9 @@ def main():
                              bssids=args.bssids.split(",") if args.bssids else [],
                              duration_to_skip=args.duration_to_skip
                              )
+    # preserve the human-readable names so the report shows e.g. "Hls" instead of the numeric code "3"
+    obj.media_source_name = media_source
+    obj.media_quality_name = media_quality
     args.upstream_port = obj.change_port_to_ip(args.upstream_port)
     obj.upstream_port = args.upstream_port
     obj.validate_args()


### PR DESCRIPTION
This PR improves the stability of robot monitoring and handling of CX/device failures during test execution in Video Streaming Test. It also reduces unnecessary log spam and makes reports more useful for debugging.

Changes
- Log only response keys instead of the full response in missing CX/signal warnings; skip the redundant CX-status check for CXs already flagged as missing.
- Restart the not-running grace period per robot-test coordinate (previously only set once for the whole test).
- Fix "cannot set a row with mismatched columns" when bandsteering and rotation are both enabled.
- Show media source/quality names (e.g. "Hls") instead of numeric codes in the report's Input Parameters table.
- Stop the whole robot test — instead of crashing or silently moving to the next coordinate/angle — when no devices respond within the 40s retry, either before or during monitoring.


Below is one of the logs where we got empty response from the api and how we are handling it:
```
1785824752.870647 WARNING CX 'vs_wlan0_http18_l4' is missing from the monitoring data, the device may have disconnected or its connection was not created. Continuing the test with the remaining devices.
URL : layer4/vs_wlan0_http10_l4,vs_wlan0_http16_l4,vs_wlan0_http18_l4,vs_wlan0_http22_l4,vs_wlan0_http25_l4/list?fields=name,status,total-urls,urls/s,total-err,video-format-bitrate,bytes-rd,total-wait-time,total-buffers,total-err,rx rate,frame-rate,video-quality
Response keys: [] lf_interop_video_streaming.py 797
1785824752.870666 WARNING CX 'vs_wlan0_http25_l4' is missing from the monitoring data, the device may have disconnected or its connection was not created. Continuing the test with the remaining devices.
URL : layer4/vs_wlan0_http10_l4,vs_wlan0_http16_l4,vs_wlan0_http18_l4,vs_wlan0_http22_l4,vs_wlan0_http25_l4/list?fields=name,status,total-urls,urls/s,total-err,video-format-bitrate,bytes-rd,total-wait-time,total-buffers,total-err,rx rate,frame-rate,video-quality
Response keys: [] lf_interop_video_streaming.py 797
1785824752.870691 WARNING All devices have stopped responding during monitoring, retrying for up to 40 seconds before ending the monitor loop. lf_interop_video_streaming.py 121