### PR TITLE
lf_interop_throughput.py : Improved CX monitoring, graceful robot/band-steering termination, and device-issue reporting

### DIFF
--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -1430,6 +1430,9 @@ class Throughput(Realm):
         return throughput
 
     def monitor(self, iteration, individual_df, device_names, incremental_capacity_list, overall_start_time, overall_end_time, is_device_configured):
+        # Skip re-polling once a stop is already decided while the robot is still moving.
+        if self.do_bandsteering and self.stop_test:
+            return individual_df, True
         individual_df_for_webui = individual_df.copy()  # for webui
         throughput, upload, download, upload_throughput, download_throughput, connections_upload, connections_download = {}, [], [], [], [], {}, {}
         drop_a, drop_a_per, drop_b, drop_b_per, state, state_of_device, avg_rtt = [], [], [], [], [], [], []  # noqa: F841
@@ -1440,10 +1443,23 @@ class Throughput(Realm):
             raise ValueError("Monitor needs a list of Layer 3 connections")
 
         start_time = datetime.now()
+        if self.monitor_start_time is None:
+            self.monitor_start_time = start_time
 
         logger.info("Monitoring cx and endpoints")
         end_time = start_time + timedelta(seconds=int(self.test_duration))
         self.overall = []
+
+        # Don't start an interval if every CX is already missing; give recovery a chance first.
+        if self.cx_profile.created_cx:
+            self.get_layer3_endp_data()
+            if self.should_stop_for_missing_cx():
+                return individual_df, True
+            if self.missing_cx_logged and not self.pre_monitoring_missing_logged:
+                logger.warning("Missing before monitoring; continuing with %s device(s): %s\nURL     : %s\nResponse: %s",
+                               len(self.cx_profile.created_cx) - len(self.missing_cx_logged),
+                               sorted(self.missing_cx_logged), self.last_monitor_url, self.last_monitor_response)
+                self.pre_monitoring_missing_logged = True
 
         # Initialize variables for real-time connections data
         index = -1
@@ -1462,11 +1478,22 @@ class Throughput(Realm):
         time_break = 0
         # Continuously collect data until end time is reached
         while datetime.now() < end_time:
+            if self.all_devices_stopped and self.do_bandsteering:
+                logger.info("All devices previously stopped during bandsteering; returning early.")
+                return individual_df, True
             index += 1
             current_time = datetime.now()
             signal_list, channel_list, mode_list, link_speed_list, rx_rate_list, bssid_list = self.get_signal_and_channel_data(self.input_devices_list)
             signal_list = [int(i) if str(i).lstrip('-').isdigit() else 0 for i in signal_list]
+            if self.stop_test:
+                logger.info("Stop already requested; ending monitoring interval.")
+                test_stopped_by_user = True
+                break
             throughput[index] = self.get_layer3_endp_data()
+            if self.cx_profile.created_cx and self.should_stop_for_missing_cx():
+                logger.error("No devices recovered; ending this monitoring interval with collected data.")
+                test_stopped_by_user = True
+                break
             # Check if next sleep would overshoot the end_time
             is_last_iteration = ((current_time + timedelta(seconds=1 if self.dowebgui else self.report_timer)) >= end_time)
             # For the WebUI, data is appended as "STOPPED" outside the loop.
@@ -1560,9 +1587,11 @@ class Throughput(Realm):
                         logger.warning('Test is stopped by the user')
                         test_stopped_by_user = True
                         if self.do_bandsteering:
+                            self.actual_monitoring_duration_seconds += (datetime.now() - start_time).total_seconds()
                             return individual_df, test_stopped_by_user
                         break
                 if self.do_bandsteering:
+                    self.actual_monitoring_duration_seconds += (datetime.now() - start_time).total_seconds()
                     return individual_df, test_stopped_by_user
                 # Adjust time_gap based on elapsed time since start (for webui)
                 d = datetime.now()
@@ -1662,6 +1691,7 @@ class Throughput(Realm):
                 individual_df.loc[len(individual_df)] = individual_df_data
                 individual_df.to_csv('throughput_data.csv', index=False)
                 if self.do_bandsteering:
+                    self.actual_monitoring_duration_seconds += (datetime.now() - start_time).total_seconds()
                     return individual_df, test_stopped_by_user
 
             if self.stop_test:
@@ -1758,6 +1788,7 @@ class Throughput(Realm):
         logger.info("connections download {}".format(connections_download))
         logger.info("connections upload {}".format(connections_upload))
 
+        self.actual_monitoring_duration_seconds += (datetime.now() - start_time).total_seconds()
         return individual_df, test_stopped_by_user
 
     def monitor_for_robo(self, iteration, individual_df, device_names, incremental_capacity_list, overall_start_time, overall_end_time, is_device_configured):
@@ -1788,10 +1819,17 @@ class Throughput(Realm):
             raise ValueError("Monitor needs a list of Layer 3 connections")
 
         start_time = datetime.now()
+        if self.monitor_start_time is None:
+            self.monitor_start_time = start_time
 
         logger.info("Monitoring cx and endpoints")
         end_time = start_time + timedelta(seconds=int(self.test_duration))
         self.overall = []
+
+        if self.cx_profile.created_cx:
+            self.get_layer3_endp_data()
+            if self.should_stop_for_missing_cx():
+                return individual_df, True
 
         # Initialize variables for real-time connections data
         index = -1
@@ -1846,11 +1884,22 @@ class Throughput(Realm):
 
             # Continuously collect data until end time is reached
             while datetime.now() < end_time:
+                if self.all_devices_stopped and self.do_bandsteering:
+                    logger.info("All devices previously stopped during bandsteering; returning early.")
+                    return individual_df, True
                 index += 1
                 current_time = datetime.now()
                 signal_list, channel_list, mode_list, link_speed_list, rx_rate_list, bssid_list = self.get_signal_and_channel_data(self.input_devices_list)
                 signal_list = [int(i) if str(i).lstrip('-').isdigit() else 0 for i in signal_list]
+                if self.stop_test:
+                    logger.info("Stop already requested; ending monitoring interval.")
+                    test_stopped_by_user = True
+                    break
                 throughput[index] = self.get_layer3_endp_data()
+                if self.cx_profile.created_cx and self.should_stop_for_missing_cx():
+                    logger.error("No devices recovered; ending this monitoring interval with collected data.")
+                    test_stopped_by_user = True
+                    break
                 # Check if next sleep would overshoot the end_time
                 is_last_iteration = ((current_time + timedelta(seconds=1 if self.dowebgui else self.report_timer)) >= end_time)
                 # For the WebUI, data is appended as "STOPPED" outside the loop.
@@ -2233,6 +2282,7 @@ class Throughput(Realm):
         logger.info("connections download {}".format(connections_download))
         logger.info("connections upload {}".format(connections_upload))
 
+        self.actual_monitoring_duration_seconds += (datetime.now() - start_time).total_seconds()
         return individual_df, test_stopped_by_user
 
     def perform_intended_load(self, iteration, incremental_capacity_list):

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -1134,6 +1134,15 @@ class Throughput(Realm):
         for port in port_data:
             interfaces_dict.update(port)
         for sta in station_names:
+            if sta not in interfaces_dict:
+                if sta not in self.missing_signal_logged:
+                    logger.warning("Signal data for station '%s' is unavailable; continuing with default metrics.", sta)
+                    self.missing_signal_logged.add(sta)
+                    self.record_device_issue(sta, "Signal data unavailable (device may have disconnected)")
+            elif sta in self.missing_signal_logged:
+                logger.info("Signal data for station '%s' is available again.", sta)
+                self.missing_signal_logged.discard(sta)
+        for sta in station_names:
             if sta in interfaces_dict:
                 if "dBm" in interfaces_dict[sta]['signal']:
                     signal_list.append(interfaces_dict[sta]['signal'].split(" ")[0])

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -1306,6 +1306,9 @@ class Throughput(Realm):
                 "cx_name": cx_name,
                 "cx_state": "RUNNING"
             }, debug_=self.debug)
+        # Re-sync local CX state with LANforge right after starting, so the very first
+        # get_layer3_endp_data() poll sees each CX's real state instead of a stale one.
+        self.cx_profile.refresh_cx()
         # self.cx_profile.start_cx_specific(cx_list)
 
     def stop_specific(self, cx_list):
@@ -1324,10 +1327,26 @@ class Throughput(Realm):
         self.cx_profile.stop_cx()
         self.station_profile.admin_down()
 
+    def remove_missing_cx(self):
+        """Drop CXs still marked missing out of created_cx so stop()/cleanup() skip them."""
+        if not self.missing_cx_logged or not self.cx_profile.created_cx:
+            return
+        missing_cxs = set(self.missing_cx_logged).intersection(self.cx_profile.created_cx.keys())
+        if missing_cxs:
+            logger.warning(
+                "Excluding %s missing CX(s) because endpoints were unavailable: %s",
+                len(missing_cxs), sorted(missing_cxs)
+            )
+            for cx in missing_cxs:
+                self.cx_profile.created_cx.pop(cx, None)
+
     def pre_cleanup(self):
         self.cx_profile.cleanup()
 
     def cleanup(self):
+        if self.robo_ip:
+            self.remove_missing_cx()
+        logger.info("self.cx_profile.created_cx %s", self.cx_profile.created_cx)
         logger.info("cleanup done")
         self.cx_profile.cleanup()
 
@@ -5253,6 +5272,7 @@ Copyright (C) 2020-2026 Candela Technologies Inc.
 
     #     logger.info("connections download {}".format(connections_download))
     #     logger.info("connections upload {}".format(connections_upload))
+    throughput.remove_missing_cx()
     throughput.stop()
     if args.postcleanup:
         throughput.cleanup()

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -1324,47 +1324,100 @@ class Throughput(Realm):
             [3]: RX drop percentage at the B endpoint
             [4]: Status of the Device ("Run" or "Stopped")
         """
-        cx_list_endp = []
-        cx_list_l3 = []
-        for i in self.cx_profile.created_cx.keys():
-            cx_list_endp.append(i + '-A')
-            cx_list_endp.append(i + '-B')
-            cx_list_l3.append(i)
-        # Fetch required throughput data from Lanforge
-        try:
-            # for dynamic data, taken rx rate lasts from layer3 endp tab
-            l3_endp_data = list(self.json_get('/endp/{}/list?fields=rx rate (last),rx drop %25,name,run,name'.format(','.join(cx_list_endp)))['endpoint'])
-            l3_cx_data = self.json_get('/cx/all')
-        except Exception as e:
-            cx_data = self.json_get('/cx/all/')
-            logger.info(cx_data)
-            logger.error(f"Endpoint not fetched from API {e}")
-        # Extracting and storing throughput data
         cx_list = list(self.cx_profile.created_cx.keys())
-        i = 0
+        # One URL fetching both A/B endpoints for every CX in a single request.
+        endpoint_names = [endpoint for cx in cx_list for endpoint in (cx + '-A', cx + '-B')]
+        monitor_url = '/endp/{}/list?fields=rx rate (last),rx drop %25,name,run'.format(','.join(endpoint_names))
+        endpoint_response = {}
+        cx_response = {}
+        try:
+            endpoint_response = self.json_get(monitor_url) or {}
+            cx_response = self.json_get('/cx/all') or {}
+        except Exception as e:
+            # Partial /endp response is expected for phantom clients; continue with default metrics.
+            logger.error("Endpoint not fetched from API: %s", e)
+            logger.error("URL     : %s", monitor_url)
+            logger.error("Response: %s", endpoint_response)
+
+        if not endpoint_response:
+            # json_get() returned None/empty with no exception; surface it instead of
+            # silently treating every CX as missing with no clue why.
+            logger.warning("Empty response fetching endpoint data.")
+            logger.warning("URL     : %s", monitor_url)
+            logger.warning("Response: %s", endpoint_response)
+
+        self.last_monitor_url = monitor_url
+        self.last_monitor_response = endpoint_response
+        # Normalize the two response shapes /endp/.../list can return into one name->metrics lookup.
+        endpoint_data = endpoint_response.get('endpoint', []) if isinstance(endpoint_response, dict) else []
+        if isinstance(endpoint_data, dict):
+            endpoint_data = [endpoint_data]
+        elif not isinstance(endpoint_data, (list, tuple)):
+            endpoint_data = []
+
+        metrics_by_endpoint = {}
+        for item in endpoint_data:
+            if not isinstance(item, dict):
+                continue
+            if 'name' in item:
+                value = item
+                name = value.get('name')
+                if name:
+                    metrics_by_endpoint[name] = value
+            else:
+                for name, value in item.items():
+                    if isinstance(value, dict):
+                        metrics_by_endpoint[value.get('name', name)] = value
+
+        rtt_by_cx = {}
+        state_by_cx = {}
+        # /cx/all keys its entries by index, not by name, so look up 'name' per value.
+        if isinstance(cx_response, dict):
+            for value in cx_response.values():
+                if isinstance(value, dict) and value.get('name'):
+                    rtt_by_cx[value['name']] = value.get('avg rtt', 0)
+                    state_by_cx[value['name']] = value.get("state", "Stopped")
+
         throughput = {}
-        # mapping the data based upon the cx_list order
-        for cx in cx_list:
-            throughput[i] = [0, 0, 0, 0, "Stopped", 0]
-            for j in l3_endp_data:
-                key, value = next(iter(j.items()))
-                endp_a = cx + '-A'
-                endp_b = cx + '-B'
-                if value['name'] == endp_a:
-                    throughput[i][0] = value['rx rate (last)']
-                    throughput[i][2] = value['rx drop %']
-                elif value['name'] == endp_b:
-                    throughput[i][1] = value['rx rate (last)']
-                    throughput[i][3] = value['rx drop %']
-                if value['name'] == endp_a or value['name'] == endp_b:
-                    throughput[i][4] = 'Run' if value['run'] else 'Stopped'
-            # To add average RTT
-            for j in l3_cx_data:
-                if not isinstance(l3_cx_data[j], dict):
-                    continue
-                if cx == l3_cx_data[j]['name']:
-                    throughput[i][5] = l3_cx_data[j]['avg rtt']
-            i += 1
+        # Suppress "not running" warnings for the first 10s so fresh CXs don't false-positive.
+        past_grace_period = (self.monitor_start_time is None or
+                             (datetime.now() - self.monitor_start_time).total_seconds() >= 10)
+        for index, cx in enumerate(cx_list):
+            endp_a, endp_b = cx + '-A', cx + '-B'
+            a_metrics = metrics_by_endpoint.get(endp_a)
+            b_metrics = metrics_by_endpoint.get(endp_b)
+            # Neither endpoint reported: log once when it first goes missing, not every poll.
+            if a_metrics is None and b_metrics is None:
+                if cx not in self.missing_cx_logged:
+                    logger.warning("CX '%s' is missing from monitoring data; continuing with the remaining devices.\nURL     : %s\nResponse: %s",
+                                   cx, monitor_url, endpoint_response)
+                    self.missing_cx_logged.add(cx)
+                    self.record_device_issue(cx, "CX missing from monitoring data")
+            elif cx in self.missing_cx_logged:
+                # It came back: clear the flag and log the recovery once.
+                logger.info("CX '%s' data is available again.", cx)
+                self.missing_cx_logged.discard(cx)
+
+            # Either endpoint reporting "run" counts the CX as running.
+            running = any(bool(metrics and metrics.get('run')) for metrics in (a_metrics, b_metrics))
+            status = 'Run' if running else state_by_cx.get(cx, "Stopped")
+            if status != 'Run' and past_grace_period and cx not in self.cx_not_running_logged:
+                # Log the transition into "not running" once, not on every poll.
+                logger.warning("CX '%s' status is '%s', not running.", cx, status)
+                self.cx_not_running_logged.add(cx)
+                self.record_device_issue(cx, "CX status is '{}', not running".format(status))
+            elif status == 'Run' and cx in self.cx_not_running_logged:
+                logger.info("CX '%s' status is back to running.", cx)
+                self.cx_not_running_logged.discard(cx)
+
+            throughput[index] = [
+                (a_metrics or {}).get('rx rate (last)', 0),
+                (b_metrics or {}).get('rx rate (last)', 0),
+                (a_metrics or {}).get('rx drop %', 0),
+                (b_metrics or {}).get('rx drop %', 0),
+                status,
+                rtt_by_cx.get(cx, 0),
+            ]
         return throughput
 
     def monitor(self, iteration, individual_df, device_names, incremental_capacity_list, overall_start_time, overall_end_time, is_device_configured):

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -3595,10 +3595,13 @@ class Throughput(Realm):
                 self.add_live_view_images_to_report(report)
         if iot_summary:
             self.build_iot_report_section(report, iot_summary)
+        if self.device_issue_log:
+            pd.DataFrame(self.device_issue_log).to_csv(os.path.join(report_path_date_time, "clients_issue.csv"), index=False)
         # report.build_custom()
         report.build_footer()
         report.write_html()
         report.write_pdf(_orientation="Landscape")
+        logger.info("Monitoring Duration: %s", self.format_monitoring_duration())
 
     def generate_report_robo(self, iterations_before_test_stopped_by_user, incremental_capacity_list, data=None, data1=None, report_path='', result_dir_name='Throughput_Test_report',
                              selected_real_clients_names=None):
@@ -4178,10 +4181,13 @@ class Throughput(Realm):
                         report.set_custom_html('<hr>')
                         report.build_custom()
 
+        if self.device_issue_log:
+            pd.DataFrame(self.device_issue_log).to_csv(os.path.join(report_path_date_time, "clients_issue.csv"), index=False)
         # report.build_custom()
         report.build_footer()
         report.write_html()
         report.write_pdf(_orientation="Landscape")
+        logger.info("Monitoring Duration: %s", self.format_monitoring_duration())
 
     # Creates a separate DataFrame for each group of devices.
 

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -386,6 +386,18 @@ class Throughput(Realm):
         self.do_bandsteering = do_bandsteering
         self.total_cycles = total_cycles
         self.bssids = bssids if bssids else []
+        # Keep monitoring output stable when a client disconnects or temporarily disappears
+        # from LANforge.  Reports still retain one row per configured client.
+        self.missing_cx_logged = set()
+        self.all_devices_stopped = False
+        self.missing_signal_logged = set()
+        self.cx_not_running_logged = set()
+        self.device_issue_log = []
+        self.actual_monitoring_duration_seconds = 0
+        self.pre_monitoring_missing_logged = False
+        self.last_monitor_url = None
+        self.last_monitor_response = None
+        self.monitor_start_time = None
         # Variables related to Robo
         self.robo_ip = robo_ip
         self.angle_list = angle_list if angle_list else [0]
@@ -401,6 +413,67 @@ class Throughput(Realm):
             self.robot.time_to_reach = int(duration_to_skip) * 60
             self.robot.coordinate_list = self.coordinate_list
             self.robot.total_cycles = self.total_cycles
+
+    def record_device_issue(self, device, issue):
+        """Append a timestamped device/issue entry, later written out as clients_issue.csv."""
+        self.device_issue_log.append({
+            "Time": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            "Device": device,
+            "Issue": issue,
+        })
+
+    def should_stop_for_missing_cx(self, timeout=40, poll_interval=5):
+        """Stop the current test run when every CX disappears and recovery never succeeds."""
+        if self.stop_test:
+            logger.info("Stop already requested; skipping missing-CX recovery wait.")
+            return True
+        if not self.cx_profile.created_cx:
+            return False
+        if len(self.missing_cx_logged) != len(self.cx_profile.created_cx):
+            return False
+        logger.warning("All CXs are missing from monitoring data; stopping the current test run.")
+        if not self.wait_for_any_cx_recovery(timeout=timeout, poll_interval=poll_interval):
+            logger.error("No devices recovered after the retry window; stopping the test run.")
+            self.stop_test = True
+            self.all_devices_stopped = True
+            if self.robo_ip:
+                self.robot.update_nav_data_for_all_cxs_stopped()
+            if self.actual_monitoring_duration_seconds == 0:
+                raise RuntimeError(
+                    "All {} CX(s) are missing right from the start of monitoring; no data was ever collected.".format(
+                        len(self.cx_profile.created_cx)))
+            return True
+        return self.stop_test
+
+    def wait_for_any_cx_recovery(self, timeout=40, poll_interval=5):
+        """Wait briefly for a CX to recover, while honoring WebUI stop requests."""
+        wait_start = datetime.now()
+        while (datetime.now() - wait_start).total_seconds() < timeout:
+            time.sleep(poll_interval)
+            if self.dowebgui:
+                running_file = os.path.join(
+                    self.result_dir, "../../Running_instances/{}_{}_running.json".format(self.ip, self.test_name))
+                try:
+                    with open(running_file, 'r') as file:
+                        if json.load(file).get("status") != "Running":
+                            logger.info("Test was stopped by the user during the CX recovery wait.")
+                            self.stop_test = True
+                            return True
+                except (FileNotFoundError, json.JSONDecodeError) as error:
+                    logger.warning("Unable to read WebUI test status during CX recovery: %s", error)
+            self.get_layer3_endp_data()
+            elapsed = (datetime.now() - wait_start).total_seconds()
+            if len(self.missing_cx_logged) < len(self.cx_profile.created_cx):
+                logger.info("Device(s) responded again after {:.0f}s, resuming.".format(elapsed))
+                return True
+            logger.warning("Still no devices responding after {:.0f}s, retrying...".format(elapsed))
+        return False
+
+    def format_monitoring_duration(self):
+        """Render self.actual_monitoring_duration_seconds as an 'Xm Ys' string for logging."""
+        total_seconds = int(self.actual_monitoring_duration_seconds)
+        minutes, seconds = divmod(total_seconds, 60)
+        return "{}m {}s".format(minutes, seconds)
 
     def perform_robo(self, args, clients_to_run):
         """

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -904,7 +904,7 @@ class Throughput(Realm):
 
         if "resources" not in response.keys():
             logger.error("There are no real devices.")
-            exit(1)
+            raise RuntimeError("'resources' key not found in /resource/all response; no real devices available. Response: {}".format(response))
 
         # Iterate over the response to categorize resources
         for key, value in response.items():
@@ -956,7 +956,7 @@ class Throughput(Realm):
         response_port = self.json_get("/port/all")
         if "interfaces" not in response_port.keys():
             logger.error("Error: 'interfaces' key not found in port data")
-            exit(1)
+            raise RuntimeError("'interfaces' key not found in /port/all response; no port data available. Response: {}".format(response_port))
 
         # mac_id1_list=[]
 
@@ -1027,7 +1027,7 @@ class Throughput(Realm):
                 self.device_found = False
                 if self.device_list != "all":
                     logger.warning("Test can not be initiated on any selected devices")
-                    exit(1)
+                    raise RuntimeError("No devices available to continue the test")
 
         else:
             devices_list = ","
@@ -1094,7 +1094,7 @@ class Throughput(Realm):
             if not self.config and not self.interopability_config:
                 if len(self.mac_id_list) == 0:
                     logger.error("Devices selected is less than given incremental capacity")
-                    return False, self.real_client_list
+                    raise RuntimeError("Devices selected (0) is less than given incremental capacity ({})".format(self.incremental_capacity))
                 configured_devices = len(self.mac_id_list)
                 given_capacity = list(map(int, self.incremental_capacity.split(",")))
                 adjusted_capacity = [cap for cap in given_capacity if cap <= configured_devices]

--- a/py-scripts/lf_interop_throughput.py
+++ b/py-scripts/lf_interop_throughput.py
@@ -550,6 +550,9 @@ class Throughput(Realm):
             logger.info("Current Cycle: {}".format(curr_cycle))
             # Iterate through all the points and monitoring throughput,bandsteering stats and as well as robot position
             for coord in coordinate_list_with_robo:
+                if self.stop_test:
+                    logger.info("Stopping band-steering run because all CXs are missing or the test was stopped.")
+                    break
                 pause, stopped = self.robot.wait_for_battery(lambda: self.monitor(
                     0,
                     individual_df,
@@ -560,7 +563,7 @@ class Throughput(Realm):
                     is_device_configured
                 )
                 )
-                if stopped:
+                if self.stop_test or stopped:
                     break
 
                 matched, abort, all_dataframes = self.robot.move_to_coordinate(
@@ -575,6 +578,9 @@ class Throughput(Realm):
                         is_device_configured
                     )
                 )
+                if abort or self.stop_test:
+                    break
+
                 if coord == self.coordinate_list[0]:
                     curr_cycle += 1
                     if curr_cycle > int(self.total_cycles):
@@ -582,8 +588,6 @@ class Throughput(Realm):
                     else:
                         logger.info("current cycle {}".format(curr_cycle))
 
-                if abort:
-                    break
                 if not matched:
                     continue
             # To add last entry in the csv
@@ -610,6 +614,9 @@ class Throughput(Realm):
 
         # Loop through the coordinate list when coordinates are specified.
         for coord in self.coordinate_list:
+            if self.stop_test:
+                logger.info("Stopping robot run because all CXs are missing or the test was stopped.")
+                break
             # checking the battery status of robot before moving to a point
             pause_coord, test_stopped_by_user = self.robot.wait_for_battery()
             if test_stopped_by_user:
@@ -701,13 +708,17 @@ class Throughput(Realm):
                     iterations_before_test_stopped_by_user.append(i)
                     break
 
+            # Stop the whole robot run on a user stop or an unrecoverable CX loss.
+            if test_stopped_by_user:
+                break
+
         #     logger.info("connections download {}".format(connections_download))
         #     logger.info("connections upload {}".format(connections_upload))
             self.stop()
         if args.postcleanup:
             self.cleanup()
 
-        # Clear navigation status fields in nav_data.json when the test completes from Web UI
+        # Mark nav_data.json as completed for the Web UI.
         if args.dowebgui:
             with open(nav_data, 'r') as x:
                 navdata = json.load(x)


### PR DESCRIPTION
**PR: lf_interop_throughput.py — Improved CX monitoring, graceful robot/band-steering termination + device-issue reporting**
Commits: f3e2e46b → 5e8022f9
What’s handled
-Adds CX state tracking, a 40-second recovery wait, device-issue recording, and monitoring-duration tracking.
-Handles partial or empty endpoint responses and logs missing or stopped CXs only when their state changes.
-Records unavailable station signal data and logs when the signal information becomes available again.
-Stops monitoring after the recovery timeout while preserving partial results and the actual monitoring duration.
-Stops robot and band-steering coordinate loops from continuing after unrecoverable CX loss or a user stop.
-Refreshes CX state after startup and excludes missing CXs before stop and cleanup operations.
-Replaces abrupt exits and silent failures with descriptive runtime errors for missing or insufficient device data.
-Writes device problems to clients_issue.csv and logs the actual monitoring duration after report generation.

Test logs:
```
1785830825.835319 INFO     Upstream port IP 192.168.245.233 lf_interop_throughput.py 4480
1785830826.283353 INFO     AVAILABLE DEVICES TO RUN TEST : ['1.10 android GalaxyTabA9', '1.15 android googlepixel', '1.16 android Samsung_F41','1.18 android Oppo2375', '1.22 android Pixel4a_1', '1.25 android samsung'] lf_interop_throughput.py 992
Select the desired resources to run the test:1.10,1.15,1.16,1.25
1785830840.322017 INFO     Test is intiated on these devices ['1.10', '1.15', '1.16', '1.25'] lf_interop_throughput.py 1022
1785830840.322568 INFO     devices list 1.10,1.15,1.16,1.25 ['1.10', '1.15', '1.16', '1.25'] lf_interop_throughput.py 1044
1785830840.322659 INFO     resource eid list ['1.10.', '1.15.', '1.16.', '1.25.'] lf_interop_throughput.py 1049
1785830840.322687 INFO     INPUT DEVICES LIST ['1.10.wlan0', '1.15.wlan0', '1.16.wlan0', '1.25.wlan0'] lf_interop_throughput.py 1058
1785830840.322953 INFO     cx_list['1.10androidGalaxyTabA9_UDP_DL', '1.15androidgooglepixel_UDP_DL', '1.16androidSamsung_F41_UDP_DL', '1.25androidsamsung_UDP_DL'] lf_interop_throughput.py 1255
1785830840.323203 INFO     Creating connections for endpoint type: lf_udp cx-count: 0 lf_interop_throughput.py 1265
1785830843.257880 INFO     Creating connections for endpoint type: lf_udp cx-count: 1 lf_interop_throughput.py 1265
1785830847.165615 INFO     Creating connections for endpoint type: lf_udp cx-count: 2 lf_interop_throughput.py 1265
1785830850.353387 INFO     Creating connections for endpoint type: lf_udp cx-count: 3 lf_interop_throughput.py 1265
1785830853.005300 INFO     cross connections with created lf_interop_throughput.py 1270
1785830853.005687 INFO     cx build finished lf_interop_throughput.py 1224
1785830863.009730 INFO     Test started at : 2026-08-04 13:37:43  lf_interop_throughput.py 1290
1785830863.737725 INFO     Starting CXs... lf_interop_throughput.py 1300
1785830865.127928 INFO     Monitoring cx and endpoints lf_interop_throughput.py 1479
1785830883.133058 WARNING  CX '1.16androidSamsung_F41_UDP_DL' is missing from monitoring data; continuing with the remaining devices.
URL     : /endp/1.10androidGalaxyTabA9_UDP_DL-A,1.10androidGalaxyTabA9_UDP_DL-B,1.15androidgooglepixel_UDP_DL-A,1.15androidgooglepixel_UDP_DL-B,1.16androidSamsung_F41_UDP_DL-A,1.16androidSamsung_F41_UDP_DL-B,1.25androidsamsung_UDP_DL-A,1.25androidsamsung_UDP_DL-B/list?fields=rx rate (last),rx drop %25,name,run
Response: {'handler': 'candela.lanforge.HttpEndp$JsonResponse', 'uri': 'endp/:endp_id', 'candela.lanforge.HttpEndp': {'duration': '0'}, 'endpoint': [{'1.10androidGalaxyTabA9_UDP_DL-B': {'name': '1.10androidGalaxyTabA9_UDP_DL-B', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}, {'1.15androidgooglepixel_UDP_DL-B': {'name': '1.15androidgooglepixel_UDP_DL-B', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}, {'1.10androidGalaxyTabA9_UDP_DL-A': {'name': '1.10androidGalaxyTabA9_UDP_DL-A', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}, {'1.15androidgooglepixel_UDP_DL-A': {'name': '1.15androidgooglepixel_UDP_DL-A', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}], 'warnings': ['Endpoint not found: 1.16androidSamsung_F41_UDP_DL-A', 'Endpoint not found: 1.16androidSamsung_F41_UDP_DL-B', 'Endpoint not found: 1.25androidsamsung_UDP_DL-A', 'Endpoint not found: 1.25androidsamsung_UDP_DL-B']} lf_interop_throughput.py 1431
1785830883.135088 WARNING  CX '1.16androidSamsung_F41_UDP_DL' status is 'Stopped', not running. lf_interop_throughput.py 1445
1785830883.135154 WARNING  CX '1.25androidsamsung_UDP_DL' is missing from monitoring data; continuing with the remaining devices.
URL     : /endp/1.10androidGalaxyTabA9_UDP_DL-A,1.10androidGalaxyTabA9_UDP_DL-B,1.15androidgooglepixel_UDP_DL-A,1.15androidgooglepixel_UDP_DL-B,1.16androidSamsung_F41_UDP_DL-A,1.16androidSamsung_F41_UDP_DL-B,1.25androidsamsung_UDP_DL-A,1.25androidsamsung_UDP_DL-B/list?fields=rx rate (last),rx drop %25,name,run
Response: {'handler': 'candela.lanforge.HttpEndp$JsonResponse', 'uri': 'endp/:endp_id', 'candela.lanforge.HttpEndp': {'duration': '0'}, 'endpoint': [{'1.10androidGalaxyTabA9_UDP_DL-B': {'name': '1.10androidGalaxyTabA9_UDP_DL-B', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}, {'1.15androidgooglepixel_UDP_DL-B': {'name': '1.15androidgooglepixel_UDP_DL-B', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}, {'1.10androidGalaxyTabA9_UDP_DL-A': {'name': '1.10androidGalaxyTabA9_UDP_DL-A', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}, {'1.15androidgooglepixel_UDP_DL-A': {'name': '1.15androidgooglepixel_UDP_DL-A', 'run': True, 'rx drop %': 100.0, 'rx rate (last)': 0}}], 'warnings': ['Endpoint not found: 1.16androidSamsung_F41_UDP_DL-A', 'Endpoint not found: 1.16androidSamsung_F41_UDP_DL-B', 'Endpoint not found: 1.25androidsamsung_UDP_DL-A', 'Endpoint not found: 1.25androidsamsung_UDP_DL-B']} lf_interop_throughput.py 1431
1785830883.139210 WARNING  CX '1.25androidsamsung_UDP_DL' status is 'Stopped', not running. lf_interop_throughput.py 1445
1785830923.027196 INFO     connections download {'1.10androidGalaxyTabA9_UDP_DL': 0.0, '1.15androidgooglepixel_UDP_DL': 0.0, '1.16androidSamsung_F41_UDP_DL': 0.0, '1.25androidsamsung_UDP_DL': 0.0} lf_interop_throughput.py 1818
1785830923.027994 INFO     connections upload {'1.10androidGalaxyTabA9_UDP_DL': 0.0, '1.15androidgooglepixel_UDP_DL': 0.0, '1.16androidSamsung_F41_UDP_DL': 0.0, '1.25androidsamsung_UDP_DL': 0.0} lf_interop_throughput.py 1819
1785830923.028315 WARNING  Excluding 2 missing CX(s) because endpoints were unavailable: ['1.16androidSamsung_F41_UDP_DL', '1.25androidsamsung_UDP_DL'] lf_interop_throughput.py 1336
1785830923.028476 INFO     Stopping CXs... l3_cxprofile.py 425
1785830924.009367 INFO     path set:  lf_report.py 85
1785830924.009718 INFO     path_date_time 2026-08-04-13-38-44_Throughput_Test_report lf_report.py 239
1785830924.009926 INFO     report path : 2026-08-04-13-38-44_Throughput_Test_report lf_report.py 248
1785830924.018025 INFO     path:  lf_interop_throughput.py 2734
1785830924.018127 INFO     path_date_time: 2026-08-04-13-38-44_Throughput_Test_report lf_interop_throughput.py 2735
libEGL warning: DRI3 error: Could not get DRI3 device
libEGL warning: Ensure your X server supports DRI3 to get accelerated rendering
1785830924.482333 INFO     Using categorical units to plot a list of strings that are all parsable as floats or dates. If these strings should be plotted as numbers, cast to the appropriate data type before plotting. category.py 224
1785830924.484653 INFO     Using categorical units to plot a list of strings that are all parsable as floats or dates. If these strings should be plotted as numbers, cast to the appropriate data type before plotting. category.py 224
1785830924.653990 INFO     graph name line_graph0.png lf_interop_throughput.py 3086
1785830924.656253 INFO     graph_src_file: line_graph0.png lf_report.py 212
1785830924.656297 INFO     graph_dst_file: 2026-08-04-13-38-44_Throughput_Test_report/line_graph0.png lf_report.py 213
1785830924.730654 INFO     graph name image_name0.png lf_interop_throughput.py 3111
1785830924.801895 INFO     graph_src_file: image_name0.png lf_report.py 212
1785830924.802303 INFO     graph_dst_file: 2026-08-04-13-38-44_Throughput_Test_report/image_name0.png lf_report.py 213
1785830924.881785 INFO     graph name signal_image_name0.png lf_interop_throughput.py 3133
1785830924.965897 INFO     graph_src_file: signal_image_name0.png lf_report.py 212
1785830924.966142 INFO     graph_dst_file: 2026-08-04-13-38-44_Throughput_Test_report/signal_image_name0.png lf_report.py 213
1785830924.975195 INFO     write_output_html: 2026-08-04-13-38-44_Throughput_Test_report/throughput.html lf_report.py 368
