### PR TITLE
lf_webpage.py: Add API response to client_issue.csv

### DIFF
--- a/py-scripts/lf_webpage.py
+++ b/py-scripts/lf_webpage.py
@@ -775,7 +775,7 @@ class HttpDownload(Realm):
                         l4_dict['bytes_rd'].append(value['bytes-rd'])
                         l4_dict['total_err'].append(value['total-err'])
                         l4_dict['status'].append(value.get('status', ''))
-                        self.track_cx_status(cx, value.get('status', ''))
+                        self.track_cx_status(cx, value.get('status', ''), api_response=value)
                         cx_found = True
             if not cx_found:
                 if cx not in self.missing_cx_logged:
@@ -789,7 +789,7 @@ class HttpDownload(Realm):
                         "Response keys: %s", cx, url_str, response_keys)
                     self.missing_cx_logged.add(cx)
                     self.failed_cx.append(cx)
-                    self.record_device_issue(cx, "CX missing from monitoring data")
+                    self.record_device_issue(cx, "CX missing from monitoring data", api_response=response_keys)
                 l4_dict['uc_avg_data'].append(0 if not self.tracking_map else self.tracking_map['uc_avg_data'][idx])
                 l4_dict['uc_max_data'].append(0 if not self.tracking_map else self.tracking_map['uc_max_data'][idx])
                 l4_dict['uc_min_data'].append(0 if not self.tracking_map else self.tracking_map['uc_min_data'][idx])
@@ -808,11 +808,12 @@ class HttpDownload(Realm):
 
         return l4_dict
 
-    def record_device_issue(self, device, issue):
+    def record_device_issue(self, device, issue, api_response=None):
         self.device_issue_log.append({
             "Time": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             "Device": device,
             "Issue": issue,
+            "API Response": api_response if api_response is not None else '',
         })
 
     def monitoring_elapsed_seconds(self):
@@ -820,7 +821,7 @@ class HttpDownload(Realm):
             return 0
         return (datetime.now() - self.monitor_start_time).total_seconds()
 
-    def track_cx_status(self, cx, status):
+    def track_cx_status(self, cx, status, api_response=None):
         """Tracks the CXs status and logs any changes."""
         if not status or self.monitoring_elapsed_seconds() < 10:
             return
@@ -828,10 +829,10 @@ class HttpDownload(Realm):
         if previous is not None and previous != status:
             if status.lower() != 'run':
                 logger.warning("CX '%s' status changed: %s -> %s", cx, previous, status)
-                self.record_device_issue(cx, "Status changed: {} -> {}".format(previous, status))
+                self.record_device_issue(cx, "Status changed: {} -> {}".format(previous, status), api_response=api_response)
             elif previous.lower() != 'run':
                 logger.info("CX '%s' recovered: %s -> %s", cx, previous, status)
-                self.record_device_issue(cx, "Recovered: {} -> {}".format(previous, status))
+                self.record_device_issue(cx, "Recovered: {} -> {}".format(previous, status), api_response=api_response)
         self.cx_status_log[cx] = status
 
     def format_monitoring_duration(self):
@@ -2210,7 +2211,8 @@ class HttpDownload(Realm):
                         "Signal data for device '%s' is unavailable, it may have disconnected. "
                         "Continuing the test with the remaining devices.", sta)
                     self.missing_device_logged.add(sta)
-                    self.record_device_issue(sta, "Signal data unavailable (device may have disconnected)")
+                    self.record_device_issue(sta, "Signal data unavailable (device may have disconnected)",
+                                             api_response=list(interfaces_dict.keys()))
                 signal_list.append('-')
                 link_speed_list.append('-')
                 rx_rate_list.append('-')


### PR DESCRIPTION
- Added API response to client_issue.csv and logs

Test logs:
```
python3 lf_webpage.py --mgr 192.168.245.117 --upstream_port eth1 --duration 3m --bands 5G --client_type Real --file_size 2MB
{'5G': {'dl_time': None, 'min': None, 'max': None, 'avg': None, 'bytes_rd': None, 'speed': None, 'url_times': None}}
2026-08-04 15:30:27,636 root INFO: Upstream port IP 192.168.245.233
2026-08-04 15:30:28,372 __main__ INFO: 1.10  1.10 android GalaxyTabA9
2026-08-04 15:30:28,372 __main__ INFO: 1.15  1.15 android googlepixel
2026-08-04 15:30:28,372 __main__ INFO: 1.16  1.16 android Samsung_F41
2026-08-04 15:30:28,372 __main__ INFO: 1.18  1.18 android Oppo2375
2026-08-04 15:30:28,373 __main__ INFO: 1.22  1.22 android Pixel4a_1
2026-08-04 15:30:28,373 __main__ INFO: 1.25  1.25 android samsung
2026-08-04 15:30:28,373 __main__ INFO: AVAILABLE DEVICES TO RUN TEST : ['1.10 android GalaxyTabA9', '1.15 android googlepixel', '1.16 android Samsung_F41', '1.18 android Oppo2375', '1.22 android Pixel4a_1', '1.25 android samsung']
Enter the desired resources to run the test:1.10
2026-08-04 15:30:39,887 __main__ INFO: Test is initiated on devices: ['1.10']
2026-08-04 15:30:39,888 __main__ INFO: devices list 1.10 ['1.10']
2026-08-04 15:30:39,888 __main__ INFO: resource eid list ['1.10.'] ['1.10.wlan0', '1.15.wlan0', '1.16.wlan0', '1.18.wlan0', '1.22.wlan0', '1.25.wlan0']
2026-08-04 15:30:39,888 __main__ INFO: INPUT DEVICES LIST ['1.10.wlan0']
2026-08-04 15:30:39,888 __main__ INFO: REAL CLIENT LIST: ['1.10 android GalaxyTabA9']
2026-08-04 15:30:39,888 __main__ INFO: MAC ID LIST: ['36:5c:7d:f5:30:4c']
2026-08-04 15:30:40,031 paramiko.transport INFO: Connected (version 2.0, client OpenSSH_8.8)
2026-08-04 15:30:40,539 paramiko.transport INFO: Authentication (password) successful!
File creation done 2MB
2026-08-04 15:30:54,185 py-json.http_profile INFO: Cleaning up cxs and endpoints
2026-08-04 15:30:54,185 py-json.station_profile INFO: Cleaning up stations
2026-08-04 15:30:55,410 py-json.LANforge.LFUtils INFO: LFUtils: Waiting until 1 ports disappear...
2026-08-04 15:30:55,630 py-json.LANforge.LFUtils INFO: LFUtils::wait_until_ports_disappear:: Request returned None: [http://192.168.245.117:8080/port/1/1/http_sta0000?fields=alias]
2026-08-04 15:30:55,630 py-json.LANforge.LFUtils INFO: LFUtils: Waiting until 1 ports disappear...
2026-08-04 15:30:55,777 py-json.LANforge.LFUtils INFO: LFUtils::wait_until_ports_disappear:: Request returned None: [http://192.168.245.117:8080/port/1/1/http_sta0000?fields=alias]
precleanup done
2026-08-04 15:30:57,219 __main__ INFO: Upstream IP: 192.168.245.233
2026-08-04 15:30:57,407 py-json.http_profile INFO: Create HTTP CXs...py-json.http_profile
2026-08-04 15:30:57,595 py-json.http_profile INFO: HTTP url:dl http://192.168.245.233/webpage.html /dev/null
2026-08-04 15:30:59,129 __main__ INFO: Created 1 CX(s)
Test Build done
2026-08-04 15:30:59,344 __main__ INFO: cross connections found for all devices
2026-08-04 15:30:59,344 __main__ INFO: Test started on the devices : ['1.10.wlan0']
Test started at  2026 04 15:30:59
2026-08-04 15:30:59,345 py-json.http_profile INFO: Starting CXs...
2026-08-04 15:34:03,903 py-json.http_profile INFO: Stopping CXs...
2026-08-04 15:34:04,094 __main__ INFO: [0.0] [0] [0]
result {'5G': {'dl_time': [0.0], 'min': [0.0], 'max': [0.0], 'avg': [0.0], 'bytes_rd': [0], 'speed': [0], 'url_times': [0]}}
Test Finished
Test ended at  2026 04 15:34:04
total test duration  0:03:05
2026-08-04 15:34:04,095 py-scripts.lf_report INFO: path set: 
2026-08-04 15:34:04,095 py-scripts.lf_report INFO: path_date_time 2026-08-04-15-34-04_webpage_test
2026-08-04 15:34:04,096 py-scripts.lf_report INFO: report path : 2026-08-04-15-34-04_webpage_test
[0]
['1.10 android GalaxyTabA9']
               Client names  Download
0  1.10 android GalaxyTabA9         0
graph name Total-url_http.png
2026-08-04 15:34:04,206 py-scripts.lf_report INFO: csv_src_file: Total-url_http.csv
2026-08-04 15:34:04,206 py-scripts.lf_report INFO: csv_dst_file: 2026-08-04-15-34-04_webpage_test/Total-url_http.csv
2026-08-04 15:34:04,206 py-scripts.lf_report INFO: graph_src_file: Total-url_http.png
2026-08-04 15:34:04,206 py-scripts.lf_report INFO: graph_dst_file: 2026-08-04-15-34-04_webpage_test/Total-url_http.png
2026-08-04 15:34:04,206 __main__ INFO: [0.0] ['1.10 android GalaxyTabA9']
               Client names  Download
0  1.10 android GalaxyTabA9       0.0
graph name ucg-avg_http.png
2026-08-04 15:34:04,267 py-scripts.lf_report INFO: csv_src_file: ucg-avg_http.csv
2026-08-04 15:34:04,267 py-scripts.lf_report INFO: csv_dst_file: 2026-08-04-15-34-04_webpage_test/ucg-avg_http.csv
2026-08-04 15:34:04,267 py-scripts.lf_report INFO: graph_src_file: ucg-avg_http.png
2026-08-04 15:34:04,267 py-scripts.lf_report INFO: graph_dst_file: 2026-08-04-15-34-04_webpage_test/ucg-avg_http.png
kpi_path :2026-08-04-15-34-04_webpage_test
self.kpi_path 2026-08-04-15-34-04_webpage_test
self.kpi_filename kpi.csv
kpifile 2026-08-04-15-34-04_webpage_test/kpi.csv
2026-08-04 15:34:07,605 py-scripts.lf_report INFO: output file 2026-08-04-15-34-04_webpage_test/_2026-08-04-15-34-07-test_l3_longevity.csv
csv output file : 2026-08-04-15-34-04_webpage_test/_2026-08-04-15-34-07-test_l3_longevity.csv
2026-08-04 15:34:07,611 py-scripts.lf_report INFO: write_output_html: 2026-08-04-15-34-04_webpage_test/Webpage.html
returned file 2026-08-04-15-34-04_webpage_test/Webpage.html
2026-08-04-15-34-04_webpage_test/Webpage.html
2026-08-04 15:34:08,168 __main__ INFO: Monitoring Duration: 3m 4s
2026-08-04 15:34:08,168 py-json.http_profile INFO: Cleaning up cxs and endpoints
2026-08-04 15:34:08,548 py-json.station_profile INFO: Cleaning up stations
2026-08-04 15:34:08,548 py-json.station_profile INFO: INFO: StationProfile cleanup, list is empty