### PR TITLE
lf_interop_zoom.py: fail fast instead of hanging, skip failed rounds, fix endpoint cleanup

### DIFF
--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-from datetime import datetime, timedelta
-import uiautomator2 as u2
-import time
+"""Drive a single Android device through a Zoom call for LANforge interop tests."""
+
 import argparse
-import re
-import xml.etree.ElementTree as ET
-from ppadb.client import Client as AdbClient
-import requests
-import pytz
-import sys
 import logging
 import os
+import re
+import sys
+import time
+from datetime import datetime, timedelta
+from xml.etree.ElementTree import fromstring
+
+import pytz
+import requests
+import uiautomator2 as u2
+from ppadb.client import Client as AdbClient
 
 # from ping_monitor import PingMonitor
 
@@ -18,6 +21,14 @@ ZOOM_PACKAGE = "us.zoom.videomeetings"
 
 
 class ZoomAutomator:
+    """Drive one Android device through a Zoom meeting.
+
+    Talks to the device over ADB for shell commands and uiautomator2 for UI
+    interaction, and to the host's Flask server for meeting timing and stop
+    signals. One instance drives one device; the participant name keys both
+    its log file and everything it uploads to the host.
+    """
+
     def __init__(
         self,
         host="127.0.0.1",
@@ -26,6 +37,11 @@ class ZoomAutomator:
         server_port=5000,
         participant_name=None,
     ):
+        """Set up the ADB client and this participant's logger.
+
+        host/port address the ADB server, server_ip/server_port the host's
+        Flask server. No device is attached yet — call set_device() for that.
+        """
         self.host = host
         self.port = port
         self.client = AdbClient(host=host, port=port)
@@ -40,14 +56,16 @@ class ZoomAutomator:
         self.stop_signal = False
         self.tz = pytz.timezone("Asia/Kolkata")
         self.participant_name = participant_name or "android_zoom"
-        # Which stage of the run we are in. Everything up to and including
-        # JOIN is the lobby and is fatal; everything after it is best-effort.
-        self.phase = None
-        self.in_meeting = False
         self.logger = self._create_logger()
         # self.ping_monitor = PingMonitor(self.participant_name)
 
     def _create_logger(self):
+        """Build this participant's logger, writing to file and to stdout.
+
+        The file is zoom_mobile_logs/<participant>.log, which upload_log() later
+        pushes to the host, and stdout is what LANforge captures for this device's
+        generic endpoint.
+        """
         log_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "zoom_mobile_logs"
         )
@@ -60,17 +78,7 @@ class ZoomAutomator:
         logger.propagate = False
 
         if not logger.handlers:
-            # Participant, serial and phase are stamped onto every record
-            # rather than written into each message: the serial is unknown
-            # until set_device() runs, and hand-written prefixes were missing
-            # from a good third of the call sites. stdout is what LANforge
-            # captures for the generic endpoint, so the context has to be on
-            # the line itself to be any use there.
-            logger.addFilter(self._build_context_filter())
-            formatter = logging.Formatter(
-                "%(asctime)s %(levelname)-7s [%(participant)s %(serial)s] "
-                "%(phase)s%(message)s"
-            )
+            formatter = logging.Formatter("%(asctime)s %(levelname)-7s %(message)s")
 
             file_handler = logging.FileHandler(
                 os.path.join(log_dir, f"{self.participant_name}.log"), mode="w"
@@ -85,52 +93,26 @@ class ZoomAutomator:
 
         return logger
 
-    def _build_context_filter(self):
-        """Stamp the current participant, serial and phase onto every record."""
-        automator = self
-
-        class _ContextFilter(logging.Filter):
-            def filter(self, record):
-                record.participant = automator.participant_name
-                record.serial = automator.device_serial or "no-device"
-                record.phase = f"{automator.phase}: " if automator.phase else ""
-                return True
-
-        return _ContextFilter()
-
     def _set_phase(self, phase):
-        """Move to a new stage of the run and say so once, in one place."""
-        self.phase = phase
-        self.logger.info("---")
-
-    def _abort(self, detail):
-        """End this device's run now, because it never reached the meeting.
-
-        Every step before the participant is actually in the call is fatal.
-        A device that silently stalls in the lobby contributes nothing for the
-        rest of the test, and previously the failure was raised, swallowed by
-        main()'s `except Exception`, and the process still exited 0 — so the
-        run looked successful while one client was never in the meeting.
-
-        SystemExit is not an Exception subclass, so it passes straight through
-        that handler while main()'s finally block still uploads this log and
-        restores the interop app.
-        """
-        self.logger.error(f"{detail} — aborting, this device never joined.")
-        sys.exit(1)
-
-    def _warn_non_fatal(self, detail):
-        """Note a post-join problem that the run deliberately carries on past."""
-        self.logger.warning(f"{detail} — continuing, the client is in the call.")
+        """Mark a new stage of the run in the log, in one place."""
+        self.logger.info(f"--- {phase} ---")
 
     @staticmethod
     def _parse_bounds(bounds):
+        """Turn a uiautomator bounds string into (left, top, right, bottom).
+
+        Returns None if bounds is missing or does not match "[x1,y1][x2,y2]".
+        """
         match = re.match(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", bounds or "")
         if not match:
             return None
         return tuple(map(int, match.groups()))
 
     def tap_bounds_center(self, d, bounds):
+        """Tap the middle of a uiautomator bounds rectangle.
+
+        Returns False without tapping if the bounds could not be parsed.
+        """
         parsed = self._parse_bounds(bounds)
         if not parsed:
             return False
@@ -140,6 +122,11 @@ class ZoomAutomator:
         return True
 
     def reveal_zoom_controls(self, d, tap_coords):
+        """Tap the screen until Zoom's auto-hiding meeting toolbar is showing.
+
+        Returns as soon as the audio or video button is visible, after at most
+        two taps; the controls have to be on screen before they can be read.
+        """
         audio_state, _, _ = self.get_audio_control_info(d)
         video_state, _, _ = self.get_video_control_info(d)
         if audio_state is not None or video_state is not None:
@@ -159,7 +146,7 @@ class ZoomAutomator:
     def get_audio_control_info(self, d):
         """Return audio state and bounds by parsing the current hierarchy dump."""
         try:
-            root = ET.fromstring(d.dump_hierarchy())
+            root = fromstring(d.dump_hierarchy())
         except Exception as e:
             self.logger.error(
                 f"Failed to parse audio hierarchy: {e}"
@@ -178,7 +165,7 @@ class ZoomAutomator:
     def get_video_control_info(self, d):
         """Return Video state and bounds by parsing the current hierarchy dump."""
         try:
-            root = ET.fromstring(d.dump_hierarchy())
+            root = fromstring(d.dump_hierarchy())
         except Exception as e:
             self.logger.error(
                 f"Failed to parse video hierarchy: {e}"
@@ -197,7 +184,7 @@ class ZoomAutomator:
     def get_leave_control_info(self, d):
         """Return leave button bounds by parsing the current hierarchy dump."""
         try:
-            root = ET.fromstring(d.dump_hierarchy())
+            root = fromstring(d.dump_hierarchy())
         except Exception as e:
             self.logger.error(
                 f"Failed to parse leave hierarchy: {e}"
@@ -240,7 +227,6 @@ class ZoomAutomator:
         """Set the target device for automation using its ADB serial number."""
         self.device_serial = serial
         try:
-            # Get the device object via ADB client
             self.adb_device = self.client.device(serial)
             if self.adb_device is None:
                 raise Exception(f"Device with serial {serial} not found via ADB.")
@@ -248,15 +234,20 @@ class ZoomAutomator:
             # Fail fast before the slow uiautomator2 connect if Zoom is missing.
             self.verify_zoom_installed()
 
-            # Connect using uiautomator2 for UI interaction
             self.u2_device = u2.connect(serial)
-            self.logger.info("Successfully connected to device.")
+            self.logger.info(f"Successfully connected to device {serial}.")
 
         except Exception as e:
             self.logger.error(f"Failed to connect: {e}")
             raise
 
     def start_interop_app(self):
+        """Force-stop Zoom and hand the device back to the interop app.
+
+        The interop app is restarted with auto_start so it reconnects to
+        LANforge on its own. Called from main()'s finally block, so the device
+        is restored whether the run succeeded or failed.
+        """
         if not self.adb_device:
             raise RuntimeError("Device not set. Call set_device() first.")
         self.logger.info("Launching Interop App...")
@@ -280,7 +271,6 @@ class ZoomAutomator:
 
                 stop_signal_from_server = response.json().get("stop", False)
 
-                # Only update if the server's stop signal is True
                 if stop_signal_from_server:
                     self.stop_signal = True
                     self.logger.info(
@@ -292,6 +282,14 @@ class ZoomAutomator:
             return self.stop_signal
 
     def join_zoom_meeting(self, meeting_url, participant_name):
+        """Drive one device through a full Zoom call, start to finish.
+
+        Opens the meeting deep link, clears permission prompts, and types
+        participant_name into either the preview screen or the older name dialog,
+        whichever this Zoom build shows. Then enables audio and video, polls the
+        host for the meeting end time, stays in the call until it passes or the
+        server signals a stop, and leaves.
+        """
         if not self.u2_device:
             raise RuntimeError("Device not set. Call set_device() first.")
 
@@ -310,7 +308,6 @@ class ZoomAutomator:
         self.logger.info(f"Starting Zoom automation for {participant_name}.")
         self.logger.info(f"Screen {width}x{height}, centre tap at {tap_coords}.")
 
-        # 1. Launch Zoom using the meeting link
         self.logger.info(f"Starting {ZOOM_PACKAGE} and opening the meeting link.")
         d.app_start(ZOOM_PACKAGE, stop=True)
         time.sleep(2)
@@ -321,7 +318,6 @@ class ZoomAutomator:
         self.logger.info(f"Meeting link handed to Zoom: {meeting_url}")
         time.sleep(8)
 
-        # 2. Handle permission prompts first
         self._set_phase("PERMISSIONS")
         self.logger.info("Checking for permission prompts.")
         allow_while_using = d(text="While using the app")
@@ -339,12 +335,10 @@ class ZoomAutomator:
         else:
             self.logger.info("No permission prompt appeared; already granted.")
 
-        # 3. Detect preview screen
         preview_join = d(text="Editing display name")
         if preview_join.wait(timeout=5):
             self.logger.info("Preview screen detected.")
 
-            # Enter name if field is present
             name_input = d(className="android.widget.EditText")
             if name_input.wait(timeout=10):
                 self.logger.info(
@@ -369,7 +363,6 @@ class ZoomAutomator:
                     "Zoom may not have launched correctly or the UI flow changed."
                 )
 
-            # Tap join on preview
             join_btn = d(text="Join")
             if join_btn.wait(timeout=10):
                 join_btn.click()
@@ -378,7 +371,7 @@ class ZoomAutomator:
                 raise RuntimeError("'Join' button not found within 10 seconds on preview screen.")
 
         else:
-            # 4. Old flow: check for name input screen
+            # Old flow: check for name input screen
             name_input = d(resourceId="us.zoom.videomeetings:id/edtScreenName")
             if name_input.wait(timeout=15):
                 self.logger.info(
@@ -403,14 +396,11 @@ class ZoomAutomator:
                     "Zoom may not have launched correctly or the UI flow changed."
                 )
 
-        # 5. Wait to join the meeting
         self.logger.info("Waiting to join meeting...")
         time.sleep(10)
 
-        # Reveal controls before checking meeting state or toggles.
         self.reveal_zoom_controls(d, (width // 2, height // 2))
 
-        # 6. Check if in meeting
         leave_bounds, _leave_status = self.get_leave_control_info(d)
         if leave_bounds:
             self.logger.info(
@@ -464,11 +454,9 @@ class ZoomAutomator:
                 break
             time.sleep(2)
 
-        # 7. Leave Meeting
         try:
             self.reveal_zoom_controls(d, (width // 2, height // 2))
 
-            # 8. Leave the meeting
             self.logger.info("Leaving meeting...")
             leave_bounds, _leave_status = self.get_leave_control_info(d)
             if leave_bounds and self.tap_bounds_center(d, leave_bounds):
@@ -490,6 +478,11 @@ class ZoomAutomator:
             )
 
     def get_start_and_end_time(self):
+        """Fetch the meeting's start and end time from the host and store them.
+
+        Sets self.start_time and self.end_time. On any failure it logs and
+        leaves both unchanged, which is why the caller polls until they arrive.
+        """
         endpoint_url = f"{self.base_url}/get_start_end_time"
         try:
             response = requests.get(endpoint_url, timeout=10)
@@ -505,9 +498,7 @@ class ZoomAutomator:
             self.logger.error(f"Request error: {e}")
 
     def enable_audio_video(self, d, max_retries=15, tap_coords=(500, 500)):
-        """
-        Continuously check and enable audio and video until both are enabled or retries exhausted.
-        """
+        """Continuously check and enable audio and video until both are enabled or retries exhausted."""
         self.logger.info("Ensuring audio and video are enabled...")
 
         retries = 0
@@ -520,7 +511,6 @@ class ZoomAutomator:
 
             self.reveal_zoom_controls(d, tap_coords)
             if not audio_enabled:
-                # --- AUDIO check ---
                 try:
                     audio_enabled_state, audio_bounds, audio_status = (
                         self.get_audio_control_info(d)
@@ -562,7 +552,6 @@ class ZoomAutomator:
                 except Exception as e:
                     self.logger.error(f"Error checking audio: {e}")
 
-            # --- VIDEO check ---
             if not video_enabled:
                 try:
                     video_enabled_state, video_bounds, video_status = (
@@ -615,6 +604,11 @@ class ZoomAutomator:
             )
 
     def upload_ping_log(self):
+        """POST this participant's ping log to the host as a file upload.
+
+        Warns and returns without uploading if PingMonitor never wrote the
+        file, which is the case while the ping monitor is commented out.
+        """
         log_path = os.path.join(self.log_dir, f"{self.participant_name}_ping.log")
         if not os.path.exists(log_path):
             self.logger.warning(f"Ping log not found: {log_path}")
@@ -639,10 +633,10 @@ class ZoomAutomator:
             self.logger.error(f"Error uploading ping log: {e}")
 
     def upload_log(self):
-        """
-        Push this run's log to the host's /upload_log endpoint. The server
-        namespaces the saved filename by the current robo coordinate (and
-        angle, if rotations are enabled) and archives it into the report
+        """Push this run's log to the host's /upload_log endpoint.
+
+        The server namespaces the saved filename by the current robo coordinate
+        (and angle, if rotations are enabled) and archives it into the report
         folder at the end of the test — same mechanism used for the
         Windows/Linux/macOS real-device client logs.
         """
@@ -673,6 +667,11 @@ class ZoomAutomator:
 
 
 def main():
+    """Parse the command line and run one device through the meeting.
+
+    The log is uploaded and the interop app restarted in a finally block, so
+    the device is handed back to LANforge even when the run fails.
+    """
     parser = argparse.ArgumentParser(
         description="Automate joining a Zoom meeting on a single Android device."
     )

--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -14,6 +14,8 @@ import os
 
 # from ping_monitor import PingMonitor
 
+ZOOM_PACKAGE = "us.zoom.videomeetings"
+
 
 class ZoomAutomator:
     def __init__(
@@ -38,6 +40,10 @@ class ZoomAutomator:
         self.stop_signal = False
         self.tz = pytz.timezone("Asia/Kolkata")
         self.participant_name = participant_name or "android_zoom"
+        # Which stage of the run we are in. Everything up to and including
+        # JOIN is the lobby and is fatal; everything after it is best-effort.
+        self.phase = None
+        self.in_meeting = False
         self.logger = self._create_logger()
         # self.ping_monitor = PingMonitor(self.participant_name)
 
@@ -54,7 +60,17 @@ class ZoomAutomator:
         logger.propagate = False
 
         if not logger.handlers:
-            formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            # Participant, serial and phase are stamped onto every record
+            # rather than written into each message: the serial is unknown
+            # until set_device() runs, and hand-written prefixes were missing
+            # from a good third of the call sites. stdout is what LANforge
+            # captures for the generic endpoint, so the context has to be on
+            # the line itself to be any use there.
+            logger.addFilter(self._build_context_filter())
+            formatter = logging.Formatter(
+                "%(asctime)s %(levelname)-7s [%(participant)s %(serial)s] "
+                "%(phase)s%(message)s"
+            )
 
             file_handler = logging.FileHandler(
                 os.path.join(log_dir, f"{self.participant_name}.log"), mode="w"
@@ -68,6 +84,44 @@ class ZoomAutomator:
             logger.addHandler(stream_handler)
 
         return logger
+
+    def _build_context_filter(self):
+        """Stamp the current participant, serial and phase onto every record."""
+        automator = self
+
+        class _ContextFilter(logging.Filter):
+            def filter(self, record):
+                record.participant = automator.participant_name
+                record.serial = automator.device_serial or "no-device"
+                record.phase = f"{automator.phase}: " if automator.phase else ""
+                return True
+
+        return _ContextFilter()
+
+    def _set_phase(self, phase):
+        """Move to a new stage of the run and say so once, in one place."""
+        self.phase = phase
+        self.logger.info("---")
+
+    def _abort(self, detail):
+        """End this device's run now, because it never reached the meeting.
+
+        Every step before the participant is actually in the call is fatal.
+        A device that silently stalls in the lobby contributes nothing for the
+        rest of the test, and previously the failure was raised, swallowed by
+        main()'s `except Exception`, and the process still exited 0 — so the
+        run looked successful while one client was never in the meeting.
+
+        SystemExit is not an Exception subclass, so it passes straight through
+        that handler while main()'s finally block still uploads this log and
+        restores the interop app.
+        """
+        self.logger.error(f"{detail} — aborting, this device never joined.")
+        sys.exit(1)
+
+    def _warn_non_fatal(self, detail):
+        """Note a post-join problem that the run deliberately carries on past."""
+        self.logger.warning(f"{detail} — continuing, the client is in the call.")
 
     @staticmethod
     def _parse_bounds(bounds):
@@ -108,7 +162,7 @@ class ZoomAutomator:
             root = ET.fromstring(d.dump_hierarchy())
         except Exception as e:
             self.logger.error(
-                f"[{self.device_serial}] Failed to parse audio hierarchy: {e}"
+                f"Failed to parse audio hierarchy: {e}"
             )
             return None, None, None
 
@@ -127,7 +181,7 @@ class ZoomAutomator:
             root = ET.fromstring(d.dump_hierarchy())
         except Exception as e:
             self.logger.error(
-                f"[{self.device_serial}] Failed to parse video hierarchy: {e}"
+                f"Failed to parse video hierarchy: {e}"
             )
             return None, None, None
 
@@ -146,7 +200,7 @@ class ZoomAutomator:
             root = ET.fromstring(d.dump_hierarchy())
         except Exception as e:
             self.logger.error(
-                f"[{self.device_serial}] Failed to parse leave hierarchy: {e}"
+                f"Failed to parse leave hierarchy: {e}"
             )
             return None, None
 
@@ -157,6 +211,32 @@ class ZoomAutomator:
 
         return None, None
 
+    def verify_zoom_installed(self):
+        """Abort the test if the Zoom app is not installed on the device.
+
+        Without this check the automation runs blind: app_start() shells out to
+        monkey and ignores the failure, the meeting deep link opens in a browser
+        instead, and the run only dies ~30s later with a misleading "name input
+        screen not found" error.
+        """
+        serial = self.device_serial
+        try:
+            output = self.adb_device.shell(f"pm list packages {ZOOM_PACKAGE}") or ""
+        except Exception as e:
+            self.logger.error(
+                f"Could not query installed packages to confirm Zoom: {e}"
+            )
+            sys.exit(1)
+
+        if f"package:{ZOOM_PACKAGE}" not in output.split():
+            self.logger.error(
+                f"Zoom app ({ZOOM_PACKAGE}) is not installed on this device. "
+                f"Install Zoom on the device and re-run the test."
+            )
+            sys.exit(1)
+
+        self.logger.info(f"Zoom app ({ZOOM_PACKAGE}) is installed.")
+
     def set_device(self, serial):
         """Set the target device for automation using its ADB serial number."""
         self.device_serial = serial
@@ -166,18 +246,21 @@ class ZoomAutomator:
             if self.adb_device is None:
                 raise Exception(f"Device with serial {serial} not found via ADB.")
 
+            # Fail fast before the slow uiautomator2 connect if Zoom is missing.
+            self.verify_zoom_installed()
+
             # Connect using uiautomator2 for UI interaction
             self.u2_device = u2.connect(serial)
-            self.logger.info(f"[{serial}] Successfully connected to device.")
+            self.logger.info(f"Successfully connected to device.")
 
         except Exception as e:
-            self.logger.error(f"[{serial}] Failed to connect: {e}")
+            self.logger.error(f"Failed to connect: {e}")
             raise
 
     def start_interop_app(self):
         if not self.adb_device:
             raise RuntimeError("Device not set. Call set_device() first.")
-        self.logger.info(f"[{self.device_serial}] Launching Interop App...")
+        self.logger.info(f"Launching Interop App...")
         self.adb_device.shell("am force-stop us.zoom.videomeetings")
         time.sleep(1)
         self.adb_device.shell("am force-stop com.candela.wecan")
@@ -186,7 +269,7 @@ class ZoomAutomator:
             "am start --es auto_start 1 -n com.candela.wecan/com.candela.wecan.StartupActivity"
         )
         time.sleep(5)
-        self.logger.info(f"[{self.device_serial}] Interop App launched successfully.")
+        self.logger.info(f"Interop App launched successfully.")
 
     def check_stop_signal(self):
         """Check the stop signal from the Flask server."""
@@ -213,68 +296,77 @@ class ZoomAutomator:
         if not self.u2_device:
             raise RuntimeError("Device not set. Call set_device() first.")
 
-        serial = self.device_serial
         d = self.u2_device
         try:
             width, height = d.window_size()
-        except Exception:
+        except Exception as e:
             # fallback defaults as it throws error in some devices
             width, height = 500, 1000
+            self.logger.warning(
+                f"Could not read window size ({e}); falling back to {width}x{height}."
+            )
+        tap_coords = (width // 2, height // 2)
 
-        self.logger.info(f"[{serial}] Starting Zoom automation for: {participant_name}")
+        self._set_phase("LAUNCH")
+        self.logger.info(f"Starting Zoom automation for {participant_name}.")
+        self.logger.info(f"Screen {width}x{height}, centre tap at {tap_coords}.")
 
         # 1. Launch Zoom using the meeting link
-        self.logger.info(f"[{serial}] Launching Zoom app with meeting link...")
-        d.app_start("us.zoom.videomeetings", stop=True)
+        self.logger.info(f"Starting {ZOOM_PACKAGE} and opening the meeting link.")
+        d.app_start(ZOOM_PACKAGE, stop=True)
         time.sleep(2)
 
         self.adb_device.shell(
             f'am start -a android.intent.action.VIEW -d "{meeting_url}"'
         )
+        self.logger.info(f"Meeting link handed to Zoom: {meeting_url}")
         time.sleep(8)
 
         # 2. Handle permission prompts first
-        self.logger.info(f"[{serial}] Checking for permission prompts...")
+        self._set_phase("PERMISSIONS")
+        self.logger.info("Checking for permission prompts.")
         allow_while_using = d(text="While using the app")
         if allow_while_using.wait(timeout=8):
             allow_while_using.click()
-            self.logger.info(f"[{serial}] Granted 'While using the app' permission")
+            self.logger.info("Granted 'While using the app'.")
             time.sleep(2)
 
             for permission_text in ["Allow", "ALLOW"]:
                 allow_btn = d(text=permission_text, className="android.widget.Button")
                 if allow_btn.wait(timeout=5):
                     allow_btn.click()
-                    self.logger.info(f"[{serial}] Clicked {permission_text}")
+                    self.logger.info(f"Clicked '{permission_text}'.")
                     time.sleep(1)
+        else:
+            self.logger.info("No permission prompt appeared; already granted.")
 
         # 3. Detect preview screen
         preview_join = d(text="Editing display name")
         if preview_join.wait(timeout=5):
-            self.logger.info(f"[{serial}] Preview screen detected.")
+            self.logger.info(f"Preview screen detected.")
 
             # Enter name if field is present
             name_input = d(className="android.widget.EditText")
             if name_input.wait(timeout=10):
                 self.logger.info(
-                    f"[{serial}] Entering participant name: {participant_name}"
+                    f"Entering participant name: {participant_name}"
                 )
                 name_input.set_text(participant_name)
                 time.sleep(1)
                 ok_btn = d(text="OK")
                 if ok_btn.wait(timeout=10):
                     ok_btn.click()
-                    self.logger.info(f"[{serial}] Clicked 'OK' on preview screen.")
+                    self.logger.info(f"Clicked 'OK' on preview screen.")
                 else:
-                    raise RuntimeError(f"[{serial}] 'OK' button not found within 10 seconds on preview screen.")
+                    raise RuntimeError(f"'OK' button not found within 10 seconds on preview screen.")
             else:
                 self.logger.error(
-                    f"[{serial}] Name input screen not found "
+                    f"Name input screen not found "
                     f"(className='android.widget.EditText'). "
                     f"Aborting automation."
                 )
                 raise RuntimeError(
-                    f"[{serial}] Could not find name input screen. "
+                    f"Could not find name input screen. "
                     f"Zoom may not have launched correctly or the UI flow changed."
                 )
 
@@ -282,16 +374,16 @@ class ZoomAutomator:
             join_btn = d(text="Join")
             if join_btn.wait(timeout=10):
                 join_btn.click()
-                self.logger.info(f"[{serial}] Clicked 'Join' on preview screen.")
+                self.logger.info(f"Clicked 'Join' on preview screen.")
             else:
-                raise RuntimeError(f"[{serial}] 'Join' button not found within 10 seconds on preview screen.")
+                raise RuntimeError(f"'Join' button not found within 10 seconds on preview screen.")
 
         else:
             # 4. Old flow: check for name input screen
             name_input = d(resourceId="us.zoom.videomeetings:id/edtScreenName")
             if name_input.wait(timeout=15):
                 self.logger.info(
-                    f"[{serial}] Entering participant name: {participant_name}"
+                    f"Entering participant name: {participant_name}"
                 )
                 name_input.set_text(participant_name)
                 time.sleep(1)
@@ -300,20 +392,20 @@ class ZoomAutomator:
                     ok_btn.click()
                 else:
                     d(resourceId="us.zoom.videomeetings:id/button1").click()
-                self.logger.info(f"[{serial}] Clicked 'Ok Button'")
+                self.logger.info(f"Clicked 'Ok Button'")
             else:
                 self.logger.error(
-                    f"[{serial}] Name input screen not found "
+                    f"Name input screen not found "
                     f"(resourceId='us.zoom.videomeetings:id/edtScreenName'). "
                     f"Aborting automation."
                 )
                 raise RuntimeError(
-                    f"[{serial}] Could not find name input screen. "
+                    f"Could not find name input screen. "
                     f"Zoom may not have launched correctly or the UI flow changed."
                 )
 
         # 5. Wait to join the meeting
-        self.logger.info(f"[{serial}] Waiting to join meeting...")
+        self.logger.info(f"Waiting to join meeting...")
         time.sleep(10)
 
         # Reveal controls before checking meeting state or toggles.
@@ -323,15 +415,15 @@ class ZoomAutomator:
         leave_bounds, _leave_status = self.get_leave_control_info(d)
         if leave_bounds:
             self.logger.info(
-                f"[{serial}] Successfully joined the meeting as {participant_name}."
+                f"Successfully joined the meeting as {participant_name}."
             )
         else:
             self.logger.warning(
-                f"[{serial}] Leave button not found. Checking toolbar..."
+                f"Leave button not found. Checking toolbar..."
             )
             if d(resourceId="us.zoom.videomeetings:id/panelMeetingToolbar").exists:
                 self.logger.info(
-                    f"[{serial}] Found meeting toolbar - likely in meeting."
+                    f"Found meeting toolbar - likely in meeting."
                 )
 
         time.sleep(2)
@@ -342,17 +434,17 @@ class ZoomAutomator:
             count += 1
             if count > 60:
                 self.logger.error(
-                    f"[{serial}] Failed to retrieve meeting end time from server after 5 minutes. Leaving meeting."
+                    f"Failed to retrieve meeting end time from server after 5 minutes. Leaving meeting."
                 )
                 sys.exit(1)
             try:
                 self.get_start_and_end_time()
                 time.sleep(5)
             except Exception as e:
-                self.logger.error(f"[{serial}] Error fetching start/end time: {e}")
+                self.logger.error(f"Error fetching start/end time: {e}")
                 time.sleep(5)
         self.logger.info(
-            f"[{serial}] Meeting scheduled from {self.start_time} to {self.end_time}"
+            f"Meeting scheduled from {self.start_time} to {self.end_time}"
         )
         try:
             end_dt = datetime.fromisoformat(self.end_time.replace("Z", "+00:00"))
@@ -368,7 +460,7 @@ class ZoomAutomator:
         while datetime.now(self.tz) < meeting_end_dt:
             if self.check_stop_signal():
                 self.logger.info(
-                    f"[{serial}] Stop signal received. Leaving meeting early."
+                    f"Stop signal received. Leaving meeting early."
                 )
                 break
             time.sleep(2)
@@ -378,17 +470,17 @@ class ZoomAutomator:
             self.reveal_zoom_controls(d, (width // 2, height // 2))
 
             # 8. Leave the meeting
-            self.logger.info(f"[{serial}] Leaving meeting...")
+            self.logger.info(f"Leaving meeting...")
             leave_bounds, _leave_status = self.get_leave_control_info(d)
             if leave_bounds and self.tap_bounds_center(d, leave_bounds):
                 time.sleep(2)
                 leave_confirm = d(text="Leave meeting")
                 if leave_confirm.wait(timeout=5):
                     leave_confirm.click()
-                    self.logger.info(f"[{serial}] Confirmed leaving meeting.")
+                    self.logger.info(f"Confirmed leaving meeting.")
             else:
                 self.logger.warning(
-                    f"[{serial}] Leave button not found. Pressing back..."
+                    f"Leave button not found. Pressing back..."
                 )
                 d.press("back")
                 time.sleep(1)
@@ -418,7 +510,7 @@ class ZoomAutomator:
         Continuously check and enable audio and video until both are enabled or retries exhausted.
         """
         serial = self.device_serial
-        self.logger.info(f"[{serial}] Ensuring audio and video are enabled...")
+        self.logger.info(f"Ensuring audio and video are enabled...")
 
         retries = 0
         audio_enabled = False
@@ -426,7 +518,7 @@ class ZoomAutomator:
 
         while retries < max_retries and not (audio_enabled and video_enabled):
             retries += 1
-            self.logger.info(f"[{serial}] Check attempt {retries}/{max_retries}")
+            self.logger.info(f"Check attempt {retries}/{max_retries}")
 
             self.reveal_zoom_controls(d, tap_coords)
             if not audio_enabled:
@@ -435,13 +527,13 @@ class ZoomAutomator:
                     audio_enabled_state, audio_bounds, audio_status = (
                         self.get_audio_control_info(d)
                     )
-                    self.logger.info(f"[{serial}] Audio status: {audio_status}")
+                    self.logger.info(f"Audio status: {audio_status}")
 
                     if audio_enabled_state is True:
-                        self.logger.info(f"[{serial}] Audio already enabled")
+                        self.logger.info(f"Audio already enabled")
                         audio_enabled = True
                     elif audio_enabled_state is False:
-                        self.logger.info(f"[{serial}] Audio is disabled. Enabling...")
+                        self.logger.info(f"Audio is disabled. Enabling...")
                         if self.tap_bounds_center(d, audio_bounds):
                             time.sleep(1)
                             (
@@ -450,27 +542,27 @@ class ZoomAutomator:
                                 audio_status,
                             ) = self.get_audio_control_info(d)
                             self.logger.info(
-                                f"[{serial}] Audio status after tap: {audio_status}"
+                                f"Audio status after tap: {audio_status}"
                             )
                             if audio_enabled_state is True:
-                                self.logger.info(f"[{serial}] Audio enabled")
+                                self.logger.info(f"Audio enabled")
                                 audio_enabled = True
                         else:
                             self.logger.warning(
-                                f"[{serial}] Audio button bounds missing: {audio_bounds}"
+                                f"Audio button bounds missing: {audio_bounds}"
                             )
                     else:
                         join_audio = d(text="Join Audio")
                         if join_audio.exists:
                             self.logger.info(
-                                f"[{serial}] Audio prompt found. Joining audio..."
+                                f"Audio prompt found. Joining audio..."
                             )
                             join_audio.click()
                             time.sleep(1)
                         else:
-                            self.logger.warning(f"[{serial}] Audio button not visible")
+                            self.logger.warning(f"Audio button not visible")
                 except Exception as e:
-                    self.logger.error(f"[{serial}] Error checking audio: {e}")
+                    self.logger.error(f"Error checking audio: {e}")
 
             # --- VIDEO check ---
             if not video_enabled:
@@ -478,13 +570,13 @@ class ZoomAutomator:
                     video_enabled_state, video_bounds, video_status = (
                         self.get_video_control_info(d)
                     )
-                    self.logger.info(f"[{serial}] Video status: {video_status}")
+                    self.logger.info(f"Video status: {video_status}")
 
                     if video_enabled_state is True:
-                        self.logger.info(f"[{serial}] Video already enabled")
+                        self.logger.info(f"Video already enabled")
                         video_enabled = True
                     elif video_enabled_state is False:
-                        self.logger.info(f"[{serial}] Video is disabled. Enabling...")
+                        self.logger.info(f"Video is disabled. Enabling...")
                         if self.tap_bounds_center(d, video_bounds):
                             time.sleep(1)
                             (
@@ -493,35 +585,35 @@ class ZoomAutomator:
                                 video_status,
                             ) = self.get_video_control_info(d)
                             self.logger.info(
-                                f"[{serial}] Video status after tap: {video_status}"
+                                f"Video status after tap: {video_status}"
                             )
                             if video_enabled_state is True:
-                                self.logger.info(f"[{serial}] Video enabled")
+                                self.logger.info(f"Video enabled")
                                 video_enabled = True
                         else:
                             self.logger.warning(
-                                f"[{serial}] Video button bounds missing: {video_bounds}"
+                                f"Video button bounds missing: {video_bounds}"
                             )
                     else:
                         join_video = d(text="Join Video")
                         if join_video.exists:
                             self.logger.info(
-                                f"[{serial}] Video prompt found. Joining video..."
+                                f"Video prompt found. Joining video..."
                             )
                             join_video.click()
                             time.sleep(1)
                         else:
-                            self.logger.warning(f"[{serial}] Video button not visible")
+                            self.logger.warning(f"Video button not visible")
                 except Exception as e:
-                    self.logger.error(f"[{serial}] Error checking video: {e}")
+                    self.logger.error(f"Error checking video: {e}")
 
             time.sleep(2)
 
         if audio_enabled and video_enabled:
-            self.logger.info(f"[{serial}] Both audio and video are enabled.")
+            self.logger.info(f"Both audio and video are enabled.")
         else:
             self.logger.warning(
-                f"[{serial}] Could not fully enable audio/video after {max_retries} retries."
+                f"Could not fully enable audio/video after {max_retries} retries."
             )
 
     def upload_ping_log(self):
@@ -539,14 +631,14 @@ class ZoomAutomator:
 
             if resp.status_code == 200:
                 self.logger.info(
-                    f"[{self.device_serial}] Ping log uploaded successfully"
+                    f"Ping log uploaded successfully"
                 )
             else:
                 self.logger.error(
-                    f"[{self.device_serial}] Ping log upload failed: {resp.status_code} {resp.text}"
+                    f"Ping log upload failed: {resp.status_code} {resp.text}"
                 )
         except Exception as e:
-            self.logger.error(f"[{self.device_serial}] Error uploading ping log: {e}")
+            self.logger.error(f"Error uploading ping log: {e}")
 
     def upload_log(self):
         """
@@ -573,13 +665,13 @@ class ZoomAutomator:
             )
 
             if resp.status_code == 200:
-                self.logger.info(f"[{self.device_serial}] Log uploaded successfully")
+                self.logger.info(f"Log uploaded successfully")
             else:
                 self.logger.error(
-                    f"[{self.device_serial}] Log upload failed: {resp.status_code} {resp.text}"
+                    f"Log upload failed: {resp.status_code} {resp.text}"
                 )
         except Exception as e:
-            self.logger.error(f"[{self.device_serial}] Error uploading log: {e}")
+            self.logger.error(f"Error uploading log: {e}")
 
 
 def main():

--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -219,7 +219,6 @@ class ZoomAutomator:
         instead, and the run only dies ~30s later with a misleading "name input
         screen not found" error.
         """
-        serial = self.device_serial
         try:
             output = self.adb_device.shell(f"pm list packages {ZOOM_PACKAGE}") or ""
         except Exception as e:
@@ -251,7 +250,7 @@ class ZoomAutomator:
 
             # Connect using uiautomator2 for UI interaction
             self.u2_device = u2.connect(serial)
-            self.logger.info(f"Successfully connected to device.")
+            self.logger.info("Successfully connected to device.")
 
         except Exception as e:
             self.logger.error(f"Failed to connect: {e}")
@@ -260,7 +259,7 @@ class ZoomAutomator:
     def start_interop_app(self):
         if not self.adb_device:
             raise RuntimeError("Device not set. Call set_device() first.")
-        self.logger.info(f"Launching Interop App...")
+        self.logger.info("Launching Interop App...")
         self.adb_device.shell("am force-stop us.zoom.videomeetings")
         time.sleep(1)
         self.adb_device.shell("am force-stop com.candela.wecan")
@@ -269,7 +268,7 @@ class ZoomAutomator:
             "am start --es auto_start 1 -n com.candela.wecan/com.candela.wecan.StartupActivity"
         )
         time.sleep(5)
-        self.logger.info(f"Interop App launched successfully.")
+        self.logger.info("Interop App launched successfully.")
 
     def check_stop_signal(self):
         """Check the stop signal from the Flask server."""
@@ -343,7 +342,7 @@ class ZoomAutomator:
         # 3. Detect preview screen
         preview_join = d(text="Editing display name")
         if preview_join.wait(timeout=5):
-            self.logger.info(f"Preview screen detected.")
+            self.logger.info("Preview screen detected.")
 
             # Enter name if field is present
             name_input = d(className="android.widget.EditText")
@@ -356,27 +355,27 @@ class ZoomAutomator:
                 ok_btn = d(text="OK")
                 if ok_btn.wait(timeout=10):
                     ok_btn.click()
-                    self.logger.info(f"Clicked 'OK' on preview screen.")
+                    self.logger.info("Clicked 'OK' on preview screen.")
                 else:
-                    raise RuntimeError(f"'OK' button not found within 10 seconds on preview screen.")
+                    raise RuntimeError("'OK' button not found within 10 seconds on preview screen.")
             else:
                 self.logger.error(
-                    f"Name input screen not found "
-                    f"(className='android.widget.EditText'). "
-                    f"Aborting automation."
+                    "Name input screen not found "
+                    "(className='android.widget.EditText'). "
+                    "Aborting automation."
                 )
                 raise RuntimeError(
-                    f"Could not find name input screen. "
-                    f"Zoom may not have launched correctly or the UI flow changed."
+                    "Could not find name input screen. "
+                    "Zoom may not have launched correctly or the UI flow changed."
                 )
 
             # Tap join on preview
             join_btn = d(text="Join")
             if join_btn.wait(timeout=10):
                 join_btn.click()
-                self.logger.info(f"Clicked 'Join' on preview screen.")
+                self.logger.info("Clicked 'Join' on preview screen.")
             else:
-                raise RuntimeError(f"'Join' button not found within 10 seconds on preview screen.")
+                raise RuntimeError("'Join' button not found within 10 seconds on preview screen.")
 
         else:
             # 4. Old flow: check for name input screen
@@ -392,20 +391,20 @@ class ZoomAutomator:
                     ok_btn.click()
                 else:
                     d(resourceId="us.zoom.videomeetings:id/button1").click()
-                self.logger.info(f"Clicked 'Ok Button'")
+                self.logger.info("Clicked 'Ok Button'")
             else:
                 self.logger.error(
-                    f"Name input screen not found "
-                    f"(resourceId='us.zoom.videomeetings:id/edtScreenName'). "
-                    f"Aborting automation."
+                    "Name input screen not found "
+                    "(resourceId='us.zoom.videomeetings:id/edtScreenName'). "
+                    "Aborting automation."
                 )
                 raise RuntimeError(
-                    f"Could not find name input screen. "
-                    f"Zoom may not have launched correctly or the UI flow changed."
+                    "Could not find name input screen. "
+                    "Zoom may not have launched correctly or the UI flow changed."
                 )
 
         # 5. Wait to join the meeting
-        self.logger.info(f"Waiting to join meeting...")
+        self.logger.info("Waiting to join meeting...")
         time.sleep(10)
 
         # Reveal controls before checking meeting state or toggles.
@@ -419,11 +418,11 @@ class ZoomAutomator:
             )
         else:
             self.logger.warning(
-                f"Leave button not found. Checking toolbar..."
+                "Leave button not found. Checking toolbar..."
             )
             if d(resourceId="us.zoom.videomeetings:id/panelMeetingToolbar").exists:
                 self.logger.info(
-                    f"Found meeting toolbar - likely in meeting."
+                    "Found meeting toolbar - likely in meeting."
                 )
 
         time.sleep(2)
@@ -434,7 +433,7 @@ class ZoomAutomator:
             count += 1
             if count > 60:
                 self.logger.error(
-                    f"Failed to retrieve meeting end time from server after 5 minutes. Leaving meeting."
+                    "Failed to retrieve meeting end time from server after 5 minutes. Leaving meeting."
                 )
                 sys.exit(1)
             try:
@@ -460,7 +459,7 @@ class ZoomAutomator:
         while datetime.now(self.tz) < meeting_end_dt:
             if self.check_stop_signal():
                 self.logger.info(
-                    f"Stop signal received. Leaving meeting early."
+                    "Stop signal received. Leaving meeting early."
                 )
                 break
             time.sleep(2)
@@ -470,17 +469,17 @@ class ZoomAutomator:
             self.reveal_zoom_controls(d, (width // 2, height // 2))
 
             # 8. Leave the meeting
-            self.logger.info(f"Leaving meeting...")
+            self.logger.info("Leaving meeting...")
             leave_bounds, _leave_status = self.get_leave_control_info(d)
             if leave_bounds and self.tap_bounds_center(d, leave_bounds):
                 time.sleep(2)
                 leave_confirm = d(text="Leave meeting")
                 if leave_confirm.wait(timeout=5):
                     leave_confirm.click()
-                    self.logger.info(f"Confirmed leaving meeting.")
+                    self.logger.info("Confirmed leaving meeting.")
             else:
                 self.logger.warning(
-                    f"Leave button not found. Pressing back..."
+                    "Leave button not found. Pressing back..."
                 )
                 d.press("back")
                 time.sleep(1)
@@ -509,8 +508,7 @@ class ZoomAutomator:
         """
         Continuously check and enable audio and video until both are enabled or retries exhausted.
         """
-        serial = self.device_serial
-        self.logger.info(f"Ensuring audio and video are enabled...")
+        self.logger.info("Ensuring audio and video are enabled...")
 
         retries = 0
         audio_enabled = False
@@ -530,10 +528,10 @@ class ZoomAutomator:
                     self.logger.info(f"Audio status: {audio_status}")
 
                     if audio_enabled_state is True:
-                        self.logger.info(f"Audio already enabled")
+                        self.logger.info("Audio already enabled")
                         audio_enabled = True
                     elif audio_enabled_state is False:
-                        self.logger.info(f"Audio is disabled. Enabling...")
+                        self.logger.info("Audio is disabled. Enabling...")
                         if self.tap_bounds_center(d, audio_bounds):
                             time.sleep(1)
                             (
@@ -545,7 +543,7 @@ class ZoomAutomator:
                                 f"Audio status after tap: {audio_status}"
                             )
                             if audio_enabled_state is True:
-                                self.logger.info(f"Audio enabled")
+                                self.logger.info("Audio enabled")
                                 audio_enabled = True
                         else:
                             self.logger.warning(
@@ -555,12 +553,12 @@ class ZoomAutomator:
                         join_audio = d(text="Join Audio")
                         if join_audio.exists:
                             self.logger.info(
-                                f"Audio prompt found. Joining audio..."
+                                "Audio prompt found. Joining audio..."
                             )
                             join_audio.click()
                             time.sleep(1)
                         else:
-                            self.logger.warning(f"Audio button not visible")
+                            self.logger.warning("Audio button not visible")
                 except Exception as e:
                     self.logger.error(f"Error checking audio: {e}")
 
@@ -573,10 +571,10 @@ class ZoomAutomator:
                     self.logger.info(f"Video status: {video_status}")
 
                     if video_enabled_state is True:
-                        self.logger.info(f"Video already enabled")
+                        self.logger.info("Video already enabled")
                         video_enabled = True
                     elif video_enabled_state is False:
-                        self.logger.info(f"Video is disabled. Enabling...")
+                        self.logger.info("Video is disabled. Enabling...")
                         if self.tap_bounds_center(d, video_bounds):
                             time.sleep(1)
                             (
@@ -588,7 +586,7 @@ class ZoomAutomator:
                                 f"Video status after tap: {video_status}"
                             )
                             if video_enabled_state is True:
-                                self.logger.info(f"Video enabled")
+                                self.logger.info("Video enabled")
                                 video_enabled = True
                         else:
                             self.logger.warning(
@@ -598,19 +596,19 @@ class ZoomAutomator:
                         join_video = d(text="Join Video")
                         if join_video.exists:
                             self.logger.info(
-                                f"Video prompt found. Joining video..."
+                                "Video prompt found. Joining video..."
                             )
                             join_video.click()
                             time.sleep(1)
                         else:
-                            self.logger.warning(f"Video button not visible")
+                            self.logger.warning("Video button not visible")
                 except Exception as e:
                     self.logger.error(f"Error checking video: {e}")
 
             time.sleep(2)
 
         if audio_enabled and video_enabled:
-            self.logger.info(f"Both audio and video are enabled.")
+            self.logger.info("Both audio and video are enabled.")
         else:
             self.logger.warning(
                 f"Could not fully enable audio/video after {max_retries} retries."
@@ -631,7 +629,7 @@ class ZoomAutomator:
 
             if resp.status_code == 200:
                 self.logger.info(
-                    f"Ping log uploaded successfully"
+                    "Ping log uploaded successfully"
                 )
             else:
                 self.logger.error(
@@ -665,7 +663,7 @@ class ZoomAutomator:
             )
 
             if resp.status_code == 200:
-                self.logger.info(f"Log uploaded successfully")
+                self.logger.info("Log uploaded successfully")
             else:
                 self.logger.error(
                     f"Log upload failed: {resp.status_code} {resp.text}"

--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -42,8 +42,11 @@ class ZoomAutomator:
         # self.ping_monitor = PingMonitor(self.participant_name)
 
     def _create_logger(self):
-        log_dir = os.path.join(os.getcwd(), "zoom_mobile_logs")
+        log_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "zoom_mobile_logs"
+        )
         os.makedirs(log_dir, exist_ok=True)
+        self.log_dir = log_dir
 
         logger_name = f"{__name__}.{self.participant_name}"
         logger = logging.getLogger(logger_name)
@@ -522,9 +525,7 @@ class ZoomAutomator:
             )
 
     def upload_ping_log(self):
-        log_path = os.path.join(
-            os.getcwd(), "zoom_mobile_logs", f"{self.participant_name}_ping.log"
-        )
+        log_path = os.path.join(self.log_dir, f"{self.participant_name}_ping.log")
         if not os.path.exists(log_path):
             self.logger.warning(f"Ping log not found: {log_path}")
             return
@@ -546,6 +547,39 @@ class ZoomAutomator:
                 )
         except Exception as e:
             self.logger.error(f"[{self.device_serial}] Error uploading ping log: {e}")
+
+    def upload_log(self):
+        """
+        Push this run's log to the host's /upload_log endpoint. The server
+        namespaces the saved filename by the current robo coordinate (and
+        angle, if rotations are enabled) and archives it into the report
+        folder at the end of the test — same mechanism used for the
+        Windows/Linux/macOS real-device client logs.
+        """
+        log_path = os.path.join(self.log_dir, f"{self.participant_name}.log")
+        if not os.path.exists(log_path):
+            self.logger.warning(f"Log file not found: {log_path}")
+            return
+
+        endpoint_url = f"{self.base_url}/upload_log"
+        try:
+            with open(log_path, "r", errors="replace") as fp:
+                log_content = fp.read()
+
+            resp = requests.post(
+                endpoint_url,
+                json={"hostname": self.participant_name, "log": log_content},
+                timeout=30,
+            )
+
+            if resp.status_code == 200:
+                self.logger.info(f"[{self.device_serial}] Log uploaded successfully")
+            else:
+                self.logger.error(
+                    f"[{self.device_serial}] Log upload failed: {resp.status_code} {resp.text}"
+                )
+        except Exception as e:
+            self.logger.error(f"[{self.device_serial}] Error uploading log: {e}")
 
 
 def main():
@@ -576,6 +610,7 @@ def main():
         automator.logger.error(f"Error: {e}")
     finally:
         try:
+            automator.upload_log()
             # automator.upload_ping_log()
             automator.start_interop_app()
         except Exception as e:

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -49,32 +49,33 @@ NOTES:
 
 """
 
-import os
-import csv
-import time
-import requests
-import threading
 import argparse
-import pytz
-from datetime import datetime, timedelta
-from flask import Flask, request, jsonify
-import importlib
-import pandas as pd
-import shutil
-import logging
-import json
 import asyncio
-import sys
-import traceback
-import textwrap
-from requests.auth import HTTPBasicAuth
-from dotenv import load_dotenv
-import re
+import csv
 import glob
-from collections import Counter
-import signal
+import importlib
+import json
+import logging
+import os
 import platform
+import re
+import shutil
+import signal
 import subprocess
+import sys
+import textwrap
+import threading
+import time
+import traceback
+from collections import Counter
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytz
+import requests
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+from requests.auth import HTTPBasicAuth
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -1583,10 +1583,11 @@ class ZoomAutomation(Realm):
                 self.generic_endps_profile.created_endp.extend(created_endp)
                 self.generic_endps_profile.created_cx.extend(created_cx)
                 logger.debug(f"create_participants: created_cx now={self.generic_endps_profile.created_cx}")
+                android_zoom_path = os.path.join(SCRIPT_DIR, "android_zoom.py")
                 cmd = (
                     f"su - lanforge -c "
                     f"\"cd /home/lanforge && "
-                    f"python3 /home/lanforge/lanforge-scripts/py-scripts/real_application_tests/zoom_automation/android_zoom.py "
+                    f"python3 {android_zoom_path} "
                     f"--serial {self.serial_list[i]} "
                     f"--meeting_url '{self.meet_link}' "
                     f"--participant_name '{self.real_sta_hostname[i]}' "

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -301,8 +301,21 @@ class ZoomAutomation(Realm):
             logger.info(
                 f"User mentioned coordinates list: {self.robo_obj.coordinate_list}"
             )
+        # Robot navigation only — whether the robot physically reached the
+        # coordinate. Everything that goes wrong *after* arrival belongs in one
+        # of the buckets below, so "the robot couldn't get there" is never
+        # confused with "the round there produced no data".
         self.successful_coords = []
         self.failed_coords = []
+        # Angles the robot could not rotate to, {coordinate: [angles]}.
+        self.failed_angles = {}
+        # Rounds abandoned because the host device failed or never signalled
+        # the start of the test.
+        self.host_failure_coords = []
+        # Rounds abandoned because none of the round's generic endpoints could
+        # be read — they may have been deleted, or the manager may have been
+        # unreachable; the poll can't tell those apart.
+        self.endpoint_loss_coords = []
         self.host_ever_ready = False
         self.is_csv_available = False
         self.wait_at_point = int(wait_at_point)
@@ -1023,9 +1036,13 @@ class ZoomAutomation(Realm):
         are not logged or written again.
 
         If every created endpoint is missing from the response, retries
-        every poll_interval seconds for up to wait_time seconds. Aborts the
-        test if still none of the created endpoints have responded once
-        wait_time has elapsed.
+        every poll_interval seconds for up to wait_time seconds.
+
+        Returns:
+            True while at least one created endpoint is still responding.
+            False if none of them have responded once wait_time has elapsed —
+            the caller decides whether that skips just this coordinate or
+            aborts the run (see _handle_round_failure).
         """
         csv_file = os.path.join(self.path, "endpoint_status_changes.csv")
         created_endp = self.generic_endps_profile.created_endp
@@ -1052,9 +1069,9 @@ class ZoomAutomation(Realm):
         if not endpoint_data:
             logger.error(
                 f"No data received for any of the created endpoints after waiting "
-                f"{wait_time} seconds. Aborting test."
+                f"{wait_time} seconds."
             )
-            exit(1)
+            return False
 
         for gen_endp, generic_endpoint in endpoint_data.items():
             current_status = generic_endpoint["endpoint"].get("status", "")
@@ -1081,6 +1098,8 @@ class ZoomAutomation(Realm):
                 )
 
             self.endpoint_last_status[gen_endp] = current_status
+
+        return True
 
     def wait_for_flask(self, url="http://127.0.0.1:5000/get_latest_stats", timeout=10):
         """Wait until the Flask server is up, but exit if it takes longer than `timeout` seconds."""
@@ -1430,7 +1449,7 @@ class ZoomAutomation(Realm):
         Returns:
             True if the endpoint was created and started.
             False if creation failed — the caller decides whether that aborts
-            the run or just skips this coordinate (see _handle_host_failure).
+            the run or just skips this coordinate (see _handle_round_failure).
         """
         # Reset per round so start_cx()/stop_cx()/cleanup() only ever act on
         # this coordinate's CXs/endpoints, instead of re-processing every
@@ -1478,15 +1497,33 @@ class ZoomAutomation(Realm):
         logger.debug(f"checking real sta os type {self.real_sta_os_type}")
         return True
 
-    def _handle_host_failure(self, reason):
-        """Decide whether a host-device failure aborts the run or skips a point.
+    def _record_round_issue(self, bucket):
+        """Note the current coordinate in `bucket`, once.
 
-        Centralises the abort-vs-skip rule so endpoint-creation failures and
-        readiness failures are treated identically.
+        With rotations on a coordinate is visited at several angles, so the
+        same coordinate can fail repeatedly. These buckets answer "which
+        locations are missing data", so one entry per coordinate is what the
+        report wants — the per-angle detail stays in the log.
+        """
+        if self.current_cord not in bucket:
+            bucket.append(self.current_cord)
+
+    def _handle_round_failure(self, reason, record_in=None):
+        """Decide whether a mid-run failure aborts the run or skips a point.
+
+        Centralises the abort-vs-skip rule so endpoint-creation failures,
+        readiness failures, and endpoints disappearing mid-round are all
+        treated identically.
 
         Args:
             reason: what failed, phrased so it reads before "on the very first
                 round ..." / "for ...".
+            record_in: the list this round's coordinate is recorded in.
+                Defaults to host_failure_coords. The endpoint-loss path passes
+                its own list instead, so "we never got a reading here" stays
+                separable from a host fault when the report is built. Neither
+                touches failed_coords, which is reserved for the robot failing
+                to reach the coordinate at all.
 
         Returns:
             The value run() should return — False to abort the whole robo test,
@@ -1503,7 +1540,9 @@ class ZoomAutomation(Realm):
             else:
                 where = f"coordinate {self.current_cord}"
 
-            self.failed_coords.append(self.current_cord)
+            self._record_round_issue(
+                self.host_failure_coords if record_in is None else record_in
+            )
             if not self.host_ever_ready:
                 logger.error(
                     f"{reason} on the very first round ({where}) — this points to "
@@ -1675,11 +1714,11 @@ class ZoomAutomation(Realm):
 
     def run(self):
         if not self.create_host():
-            return self._handle_host_failure(
+            return self._handle_round_failure(
                 "Host device generic endpoint creation failed"
             )
         if not self.wait_for_host_ready():
-            return self._handle_host_failure("Host device failed to become ready")
+            return self._handle_round_failure("Host device failed to become ready")
         self.host_ever_ready = True
         self.create_participants()
         if not self.wait_for_test_start():
@@ -1688,7 +1727,7 @@ class ZoomAutomation(Realm):
                     f"Unable to get the start signal from the host device for coordinate {self.current_cord} — "
                     "skipping this coordinate and continuing with the next one."
                 )
-                self.failed_coords.append(self.current_cord)
+                self._record_round_issue(self.host_failure_coords)
                 return True
             else:
                 logger.error(
@@ -1771,12 +1810,12 @@ class ZoomAutomation(Realm):
                         self.stop_signal = False
                         self.participants_joined = 0
                         if not self.create_host():
-                            return self._handle_host_failure(
+                            return self._handle_round_failure(
                                 "Host device generic endpoint creation failed after "
                                 "battery pause"
                             )
                         if not self.wait_for_host_ready():
-                            return self._handle_host_failure(
+                            return self._handle_round_failure(
                                 "Host device failed to restart after battery pause"
                             )
                         self.create_participants()
@@ -1785,9 +1824,23 @@ class ZoomAutomation(Realm):
                                 f"Unable to get the start signal from the host device after the battery pause "
                                 f"for coordinate {self.current_cord} — skipping this round."
                             )
-                            self.failed_coords.append(self.current_cord)
+                            self._record_round_issue(self.host_failure_coords)
                             return True
-                self.monitor_endpoint_status_changes()
+                if not self.monitor_endpoint_status_changes():
+                    # None of this round's endpoints answered — they may have
+                    # been deleted, or the manager may just be unreachable, and
+                    # the poll can't tell those apart. Either way tear the round
+                    # down so the next coordinate starts clean; the normal
+                    # teardown below is skipped by the early return.
+                    if self.do_robo:
+                        self.generic_endps_profile.stop_cx()
+                        self.cleanup_generic_endpoints()
+                        self.start_time = None
+                        self.end_time = None
+                    return self._handle_round_failure(
+                        "None of the generic endpoints could be read",
+                        record_in=self.endpoint_loss_coords,
+                    )
                 logger.info("Monitoring the Test")
                 time.sleep(5)
         if self.do_robo:
@@ -4730,11 +4783,17 @@ class ZoomAutomation(Realm):
                 for angle in self.angles_list:
                     self.robo_obj.wait_for_battery()
                     rotated = self.robo_obj.rotate_angle(angle_degree=angle)
-                    if rotated:
-                        self.current_angle = angle
-                    else:
-                        logger.error(f"Failed to Rotate the Angle {self.current_angle}")
-                        sys.exit()
+                    if not rotated:
+                        # One unreachable angle is a per-angle problem, the
+                        # same shape as an unreachable coordinate — skip it
+                        # rather than taking down every angle still to come.
+                        logger.error(
+                            f"Failed to rotate to angle {angle} at coordinate "
+                            f"{coordinate} — skipping this angle and trying the next one."
+                        )
+                        self.failed_angles.setdefault(coordinate, []).append(angle)
+                        continue
+                    self.current_angle = angle
                     if not self.run():
                         logger.error(
                             "Stopping robo test early — host device issue detected on the first coordinate."

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -726,7 +726,7 @@ class ZoomAutomation(Realm):
             self.end_time = self.start_time + timedelta(minutes=self.duration)
         return [self.start_time, self.end_time]
 
-    def check_gen_cx(self, stall_timeout=300):
+    def check_gen_cx(self, stall_timeout=600):
         """Return True once every generic endpoint is idle (Stopped/WAITING/NO-CX),
         or once a stuck endpoint has been non-idle for longer than stall_timeout
         seconds — in which case we stop waiting on it instead of hanging forever."""
@@ -1199,7 +1199,7 @@ class ZoomAutomation(Realm):
         logger.debug(f"checking real sta list {self.real_sta_list}")
         logger.debug(f"checking real sta os type {self.real_sta_os_type}")
 
-    def wait_for_host_ready(self, timeout=300):
+    def wait_for_host_ready(self, timeout=600):
         """Wait for the host device to confirm login.
 
         Returns:
@@ -1210,24 +1210,25 @@ class ZoomAutomation(Realm):
         """
         deadline = time.time() + timeout
         while not self.login_completed:
+            host_endp = self.generic_endps_profile.created_endp[0]
             if time.time() >= deadline:
                 logger.error(
-                    f"Timed out after {timeout}s waiting for host device to log in."
+                    f"Timed out after {timeout}s waiting for host device ({host_endp}) to log in."
                 )
                 self.generic_endps_profile.cleanup()
                 return False
             try:
-                generic_endpoint = self.json_get(
-                    f"/generic/{self.generic_endps_profile.created_endp[0]}"
-                )
+                generic_endpoint = self.json_get(f"/generic/{host_endp}")
                 endp_status = generic_endpoint["endpoint"]["status"]
                 if endp_status == "Stopped":
-                    logger.error("Failed to Start the Host Device")
+                    logger.error(f"Failed to start the host device ({host_endp}).")
                     self.generic_endps_profile.cleanup()
                     return False
                 time.sleep(5)
             except Exception as e:
-                logger.error(f"Error while checking login_completed status: {e}")
+                logger.error(
+                    f"Error while checking login_completed status for host device ({host_endp}): {e}"
+                )
                 time.sleep(5)
 
         self.meet_link = f"https://us04web.zoom.us/j/{self.remote_login_url}?pwd={self.remote_login_passwd}"
@@ -1388,7 +1389,7 @@ class ZoomAutomation(Realm):
 
             try:
                 logger.info(
-                    f"Band-Steering Test coordinates to be visited: {self.bs_coord_result}"
+                    f"Band-Steering Test coordinates to be visited ({len(self.bs_coord_result)} total): {self.bs_coord_result}"
                 )
 
                 if not self.bs_coord_result:
@@ -1415,9 +1416,10 @@ class ZoomAutomation(Realm):
                     else:
                         self.failed_coords.append(coordinate)
                     if aborted:
-                        logger.error(f"Failed to reach the {coordinate}")
-                        self.failed_coords.append(coordinate)
-                        sys.exit()
+                        logger.error(
+                            f"Failed to reach coordinate {coordinate} — skipping it and trying the next coordinate."
+                        )
+                        continue
 
                 logger.info(
                     "All coordinates completed — stopping Band-Steering Test"
@@ -4279,6 +4281,9 @@ class ZoomAutomation(Realm):
             logger.error(f"Error updating running_status.json: {e}")
 
     def run_robo_test(self):
+        logger.info(
+            f"Robo test coordinates to be visited ({len(self.coordinates_list)} total): {self.coordinates_list}"
+        )
         for coordinate in self.coordinates_list:
             self.robo_obj.wait_for_battery()
             matched, aborted = self.robo_obj.move_to_coordinate(coord=coordinate)
@@ -4288,9 +4293,10 @@ class ZoomAutomation(Realm):
             else:
                 self.failed_coords.append(coordinate)
             if aborted:
-                logger.error(f"Failed to Reach the coordinate {self.current_cord}")
-                self.failed_coords.append(coordinate)
-                sys.exit()
+                logger.error(
+                    f"Failed to reach coordinate {coordinate} — skipping it and trying the next coordinate."
+                )
+                continue
             if self.rotations_enabled:
                 for angle in self.angles_list:
                     self.robo_obj.wait_for_battery()

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -285,6 +285,7 @@ class ZoomAutomation(Realm):
             )
         self.successful_coords = []
         self.failed_coords = []
+        self.host_ever_ready = False
         self.is_csv_available = False
         self.wait_at_point = int(wait_at_point)
         self.resource_ip = resource_ip
@@ -404,12 +405,14 @@ class ZoomAutomation(Realm):
 
         @self.app.route("/get_participants_joined", methods=["GET"])
         def get_participants_joined():
+            logger.info(f"/get_participants_joined GET -> participants joined: {self.participants_joined}")
             return jsonify({"participants": self.participants_joined})
 
         @self.app.route("/set_participants_joined", methods=["POST"])
         def set_participants_joined():
             data = request.json
             self.participants_joined = data.get("participants_joined", None)
+            logger.info(f"/set_participants_joined POST -> participants joined: {self.participants_joined}")
             return jsonify(
                 {
                     "message": f"Updated participants joined status to {self.participants_joined}"
@@ -418,6 +421,7 @@ class ZoomAutomation(Realm):
 
         @self.app.route("/get_participants_req", methods=["GET"])
         def get_participants_req():
+            logger.info(f"/get_participants_req GET -> participants required: {self.participants_req}")
             return jsonify({"participants": self.participants_req})
 
         @self.app.route("/test_started", methods=["GET", "POST"])
@@ -624,6 +628,8 @@ class ZoomAutomation(Realm):
                 filename = data.get("filename", "csvdata.csv")
                 self.csv_file_name = f"received_{filename}"
                 rows = data.get("rows", [])
+                logger.info(f"/upload_csv POST: received filename={filename}")
+                logger.debug(f"/upload_csv POST: received rows={rows}")
                 if not rows:
                     return (
                         jsonify({"status": "error", "message": "No rows received"}),
@@ -720,25 +726,47 @@ class ZoomAutomation(Realm):
             self.end_time = self.start_time + timedelta(minutes=self.duration)
         return [self.start_time, self.end_time]
 
-    def check_gen_cx(self):
+    def check_gen_cx(self, stall_timeout=300):
+        """Return True once every generic endpoint is idle (Stopped/WAITING/NO-CX),
+        or once a stuck endpoint has been non-idle for longer than stall_timeout
+        seconds — in which case we stop waiting on it instead of hanging forever."""
+        if not hasattr(self, "_gen_cx_stall_since"):
+            self._gen_cx_stall_since = {}
+
+        now = time.time()
+        ready = True
+        generic_endpoint = None
+
         try:
 
-            for gen_endp in self.generic_endps_profile.created_endp:
+            for gen_endp in set(self.generic_endps_profile.created_endp):
                 generic_endpoint = self.json_get(f"/generic/{gen_endp}")
 
                 if not generic_endpoint or "endpoint" not in generic_endpoint:
                     logger.info(f"Error fetching endpoint data for {gen_endp}")
-                    return False
+                    endp_status = None  # unreachable/deleted endpoint
+                else:
+                    endp_status = generic_endpoint["endpoint"].get("status", "")
 
-                endp_status = generic_endpoint["endpoint"].get("status", "")
+                if endp_status in ["Stopped", "WAITING", "NO-CX", "FTM_WAIT"]:
+                    self._gen_cx_stall_since.pop(gen_endp, None)
+                    continue
 
-                if endp_status not in ["Stopped", "WAITING", "NO-CX", "FTM_WAIT"]:
-                    return False
-
-            return True
+                # Covers BOTH "stuck at a non-idle status" AND "can't be fetched/deleted"
+                stall_start = self._gen_cx_stall_since.setdefault(gen_endp, now)
+                stalled_for = now - stall_start
+                if stalled_for >= stall_timeout:
+                    logger.warning(
+                        f"{gen_endp} unresolved (status={endp_status!r}) for "
+                        f"{stalled_for:.0f}s (limit {stall_timeout}s) — giving up waiting on it."
+                    )
+                    continue
+                ready = False
+            return ready
         except Exception as e:
             logger.error(f"Error in check_gen_cx function {e}", exc_info=True)
             logger.info(f"generic endpoint data {generic_endpoint}")
+            return False
 
     def monitor_endpoint_status_changes(self, wait_time=40, poll_interval=5):
         """
@@ -760,9 +788,12 @@ class ZoomAutomation(Realm):
         endpoint_data = {}
         while True:
             for gen_endp in created_endp:
-                generic_endpoint = self.json_get(f"/generic/{gen_endp}")
-                if generic_endpoint and "endpoint" in generic_endpoint:
-                    endpoint_data[gen_endp] = generic_endpoint
+                try:
+                    generic_endpoint = self.json_get(f"/generic/{gen_endp}")
+                    if generic_endpoint and "endpoint" in generic_endpoint:
+                        endpoint_data[gen_endp] = generic_endpoint
+                except Exception as e:
+                    logger.error(f"Error fetching endpoint {gen_endp} status: {e}")
 
             if endpoint_data or (time.time() - start_time) >= wait_time:
                 break
@@ -854,6 +885,7 @@ class ZoomAutomation(Realm):
             gen_name_a = "%s-%s" % ("zoom", "_".join(port_name.split(".")))
             endp_tpls.append((shelf, resource, name, gen_name_a))
 
+        logger.debug(f"create_android: endp_tpls={endp_tpls}")
         for endp_tpl in endp_tpls:
             shelf = endp_tpl[0]
             resource = endp_tpl[1]
@@ -1126,6 +1158,12 @@ class ZoomAutomation(Realm):
                 logger.error(f"Error deleting file {file_path}: {e}")
 
     def create_host(self):
+        # Reset per round so start_cx()/stop_cx()/cleanup() only ever act on
+        # this coordinate's CXs/endpoints, instead of re-processing every
+        # stale entry from every previous coordinate.
+        self.generic_endps_profile.created_cx = []
+        self.generic_endps_profile.created_endp = []
+
         if self.generic_endps_profile.create(
             ports=[self.real_sta_list[0]],
             real_client_os_types=[self.real_sta_os_type[0]],
@@ -1161,8 +1199,23 @@ class ZoomAutomation(Realm):
         logger.debug(f"checking real sta list {self.real_sta_list}")
         logger.debug(f"checking real sta os type {self.real_sta_os_type}")
 
-    def wait_for_host_ready(self):
+    def wait_for_host_ready(self, timeout=300):
+        """Wait for the host device to confirm login.
+
+        Returns:
+            True once login is confirmed.
+            False if the host device stops before logging in, or if login
+            isn't confirmed within `timeout` seconds (default 5 minutes) —
+            instead of hanging forever or killing the whole process.
+        """
+        deadline = time.time() + timeout
         while not self.login_completed:
+            if time.time() >= deadline:
+                logger.error(
+                    f"Timed out after {timeout}s waiting for host device to log in."
+                )
+                self.generic_endps_profile.cleanup()
+                return False
             try:
                 generic_endpoint = self.json_get(
                     f"/generic/{self.generic_endps_profile.created_endp[0]}"
@@ -1171,7 +1224,7 @@ class ZoomAutomation(Realm):
                 if endp_status == "Stopped":
                     logger.error("Failed to Start the Host Device")
                     self.generic_endps_profile.cleanup()
-                    sys.exit(1)
+                    return False
                 time.sleep(5)
             except Exception as e:
                 logger.error(f"Error while checking login_completed status: {e}")
@@ -1190,8 +1243,13 @@ class ZoomAutomation(Realm):
             logger.error(f"Failed to save meet link file: {e}")
 
         self.login_completed = False
+        return True
 
     def create_participants(self):
+        logger.info(
+            f"Creating participants — ports={self.lanforge_port_list}, "
+            f"hostnames={self.real_sta_hostname}, serials={self.serial_list}"
+        )
         for i in range(1, len(self.real_sta_os_type)):
             if self.real_sta_os_type[i] == "android":
                 status, created_cx, created_endp = self.create_android(
@@ -1201,6 +1259,7 @@ class ZoomAutomation(Realm):
                 )
                 self.generic_endps_profile.created_endp.extend(created_endp)
                 self.generic_endps_profile.created_cx.extend(created_cx)
+                logger.debug(f"create_participants: created_cx now={self.generic_endps_profile.created_cx}")
                 cmd = (
                     f"su - lanforge -c "
                     f"\"cd /home/lanforge && "
@@ -1251,10 +1310,24 @@ class ZoomAutomation(Realm):
             )
             logger.info(f"Sending running state to.. {cx_name}")
 
-    def wait_for_test_start(self):
-        # Wait for the test to be started
+    def wait_for_test_start(self, timeout=180):
+        """Wait for the test-started signal.
+
+        Returns:
+            True once the test has started.
+            False if it isn't signaled within `timeout` seconds (default 3
+            minutes) — instead of hanging forever.
+        """
+        deadline = time.time() + timeout
         count = 0
         while not self.test_start:
+            if time.time() >= deadline:
+                logger.error(
+                    f"Unable to get the start signal from the host device within {timeout}s. "
+                    "Giving up and cleaning up this round's CXs."
+                )
+                self.generic_endps_profile.cleanup()
+                return False
             logger.info("WAITING FOR THE TEST TO BE STARTED")
             time.sleep(5)
             count += 1
@@ -1273,12 +1346,42 @@ class ZoomAutomation(Realm):
                 self.current_cord = self.from_cord
         self.set_start_time()
         logger.info("TEST WILL BE STARTING")
+        return True
 
     def run(self):
         self.create_host()
-        self.wait_for_host_ready()
+        if not self.wait_for_host_ready():
+            if self.do_robo:
+                self.failed_coords.append(self.current_cord)
+                if not self.host_ever_ready:
+                    logger.error(
+                        f"Host device failed to become ready on the very first coordinate ({self.current_cord}) — "
+                        "this points to a host device problem rather than a location issue. "
+                        "Aborting the robo test instead of trying the remaining coordinates."
+                    )
+                    return False
+                logger.error(
+                    f"Host device failed to become ready for coordinate {self.current_cord} — skipping this coordinate and continuing with the next one."
+                )
+                return True
+            else:
+                logger.error("Host device never became ready. Aborting test.")
+                sys.exit(1)
+        self.host_ever_ready = True
         self.create_participants()
-        self.wait_for_test_start()
+        if not self.wait_for_test_start():
+            if self.do_robo:
+                logger.error(
+                    f"Unable to get the start signal from the host device for coordinate {self.current_cord} — "
+                    "skipping this coordinate and continuing with the next one."
+                )
+                self.failed_coords.append(self.current_cord)
+                return True
+            else:
+                logger.error(
+                    "Unable to get the start signal from the host device — aborting test."
+                )
+                sys.exit(1)
 
         if self.do_bs:
             time.sleep(60)
@@ -1354,9 +1457,20 @@ class ZoomAutomation(Realm):
                         self.stop_signal = False
                         self.participants_joined = 0
                         self.create_host()
-                        self.wait_for_host_ready()
+                        if not self.wait_for_host_ready():
+                            logger.error(
+                                f"Host device failed to restart after battery pause for coordinate {self.current_cord} — skipping this round."
+                            )
+                            self.failed_coords.append(self.current_cord)
+                            return True
                         self.create_participants()
-                        self.wait_for_test_start()
+                        if not self.wait_for_test_start():
+                            logger.error(
+                                f"Unable to get the start signal from the host device after the battery pause "
+                                f"for coordinate {self.current_cord} — skipping this round."
+                            )
+                            self.failed_coords.append(self.current_cord)
+                            return True
                 self.monitor_endpoint_status_changes()
                 logger.info("Monitoring the Test")
                 time.sleep(5)
@@ -1365,6 +1479,7 @@ class ZoomAutomation(Realm):
             self.generic_endps_profile.cleanup()
             self.start_time = None
             self.end_time = None
+            return True
 
     def select_real_devices(self, real_device_obj, real_sta_list=None):
         final_device_list = []
@@ -1541,6 +1656,8 @@ class ZoomAutomation(Realm):
                 lf_stats_map[sta]["bssid"] = data.get(
                     "ap", "-"
                 )  # 'ap' is usually BSSID
+
+        logger.debug(f"get_signal_and_channel_data_dict: lf_stats_map={lf_stats_map}")
 
         return lf_stats_map
 
@@ -4183,11 +4300,19 @@ class ZoomAutomation(Realm):
                     else:
                         logger.error(f"Failed to Rotate the Angle {self.current_angle}")
                         sys.exit()
-                    self.run()
+                    if not self.run():
+                        logger.error(
+                            "Stopping robo test early — host device issue detected on the first coordinate."
+                        )
+                        return
                     self.participants_joined = 0
 
             else:
-                self.run()
+                if not self.run():
+                    logger.error(
+                        "Stopping robo test early — host device issue detected on the first coordinate."
+                    )
+                    return
                 self.participants_joined = 0
 
 
@@ -4771,9 +4896,9 @@ def main():
                                 + " "
                                 + device["hostname"]
                             )
-                    print("Available Devices For Testing")
+                    logger.info("Available Devices For Testing")
                     for device in device_list:
-                        print(device)
+                        logger.info(device)
                     zm_host = input("Enter Host Resource for the Test : ")
                     zm_host = zm_host.strip()
                     args.resources = input("Enter client Resources to run the test :")

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -100,46 +100,31 @@ DeviceConfig = importlib.import_module("py-scripts.DeviceConfig")
 lf_base_interop_profile = importlib.import_module("py-scripts.lf_base_interop_profile")
 RealDevice = lf_base_interop_profile.RealDevice
 
-# Set up logging
 flask_server_logger = logging.getLogger(__name__)
 flask_server_log = logging.getLogger("werkzeug")
 flask_server_log.setLevel(logging.ERROR)
 
-# Everything this test writes is anchored here rather than to the working
-# directory, so results land in the same predictable place no matter which
-# directory the test was launched from.
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))  # everything is anchored here, not the cwd
 
 LOG_FILE = os.path.join(SCRIPT_DIR, "lf_interop_zoom.log")
 
-# Terminal and file get the same line. filename/lineno matter because the other
-# modules (DeviceConfig, lf_base_robo, gen_cxprofile, LFRequest) log through the
-# root logger into here too, and that is what tells them apart. The log file is
-# opened in append mode deliberately — a re-run must not destroy the log of the
-# run that just failed.
-#
-# force=True is required: DeviceConfig calls logging.basicConfig() when it is
-# imported above, and without force our call here would be a silent no-op and
-# the run log would never be written.
-LOG_FORMAT = "%(asctime)s - %(levelname)-8s - %(message)s (%(filename)s:%(lineno)s)"
+LOG_FORMAT = "%(asctime)s - %(levelname)-8s - %(message)s (%(filename)s:%(lineno)s)"  # filename/lineno tell apart the modules logging through root
 
 logging.basicConfig(
     level=logging.INFO,
     format=LOG_FORMAT,
     handlers=[
         logging.StreamHandler(sys.stdout),
-        logging.FileHandler(LOG_FILE, mode="a"),
+        logging.FileHandler(LOG_FILE, mode="a"),  # append: a re-run must not destroy the failed run's log
     ],
-    force=True,
+    force=True,  # DeviceConfig ran basicConfig() on import; without this ours is a no-op
 )
 
 logger = logging.getLogger(__name__)
 
 robo_base_class = importlib.import_module("py-scripts.lf_base_robo")
 
-# Directories on the real client stations where the Zoom automation scripts
-# (zoom.bat, ctzoom.bash) are deployed.
-WINDOWS_ZOOM_DIR = r".\local\real_application_test\zoom_automation"
+WINDOWS_ZOOM_DIR = r".\local\real_application_test\zoom_automation"  # zoom.bat/ctzoom.bash live on the client Laptops
 LINUX_ZOOM_DIR = "./local/real_application_test/zoom_automation"
 MACOS_ZOOM_DIR = "./local/real_application_test/zoom_automation"
 
@@ -224,11 +209,7 @@ class ZoomAutomation(Realm):
         self.stop_signal = False
         self.download_csv = False
         self.csv_file_name = "csvdata.csv"
-        # Next to the script, not in the working directory: a run launched from
-        # /home/lanforge and one launched from the script's own folder now put
-        # their results in the same place. Overridden with --report_dir when the
-        # web UI drives the test.
-        self.path = os.path.join(SCRIPT_DIR, "zoom_test_results")
+        self.path = os.path.join(SCRIPT_DIR, "zoom_test_results")  # not the cwd; --report_dir overrides
         os.makedirs(self.path, exist_ok=True)
 
         self.device_names = []
@@ -268,7 +249,6 @@ class ZoomAutomation(Realm):
         self.selected_groups = list(selected_groups or [])
         self.selected_profiles = list(selected_profiles or [])
         self.duration = duration
-        # Single container for raw Zoom QoS and summarized report data.
         self.zoom_stats_data = {"raw_qos": [], "summary": {}}
         self.env_file = env_file
 
@@ -302,21 +282,11 @@ class ZoomAutomation(Realm):
             logger.info(
                 f"User mentioned coordinates list: {self.robo_obj.coordinate_list}"
             )
-        # Robot navigation only — whether the robot physically reached the
-        # coordinate. Everything that goes wrong *after* arrival belongs in one
-        # of the buckets below, so "the robot couldn't get there" is never
-        # confused with "the round there produced no data".
-        self.successful_coords = []
-        self.failed_coords = []
-        # Angles the robot could not rotate to, {coordinate: [angles]}.
-        self.failed_angles = {}
-        # Rounds abandoned because the host device failed or never signalled
-        # the start of the test.
-        self.host_failure_coords = []
-        # Rounds abandoned because none of the round's generic endpoints could
-        # be read — they may have been deleted, or the manager may have been
-        # unreachable; the poll can't tell those apart.
-        self.endpoint_loss_coords = []
+        self.successful_coords = []  # robot reached the coordinate
+        self.failed_coords = []  # robot never got there
+        self.failed_angles = {}  # {coordinate: [angles]} it could not rotate to
+        self.host_failure_coords = []  # host device failed or never signalled start
+        self.endpoint_loss_coords = []  # no endpoint answered: deleted or unreachable
         self.host_ever_ready = False
         self.is_csv_available = False
         self.wait_at_point = int(wait_at_point)
@@ -335,7 +305,6 @@ class ZoomAutomation(Realm):
 
         try:
             if current_os in ["Linux", "Darwin"]:
-                # Find PID on Linux/Mac using lsof
                 command = f"lsof -t -i:{port}"
                 try:
                     output = subprocess.check_output(command, shell=True, text=True)
@@ -364,10 +333,6 @@ class ZoomAutomation(Realm):
             logger.info(f"No ping_logs directory found at {source_dir}")
             return
 
-        # report_path_date_time is only created once a report has been built,
-        # so it can be missing here — this runs from main()'s finally block,
-        # which is reached however the run ended. Crashing would replace the
-        # real error with an AttributeError and skip the cleanup below it.
         report_dir = getattr(self, "report_path_date_time", None)
         if not report_dir:
             logger.warning(f"No report folder for this run; ping logs stay at {source_dir}")
@@ -376,7 +341,6 @@ class ZoomAutomation(Realm):
         destination_dir = os.path.join(report_dir, "ping_logs")
         os.makedirs(report_dir, exist_ok=True)
 
-        # If destination exists, merge files and remove source
         if os.path.exists(destination_dir):
             for file_name in os.listdir(source_dir):
                 src_file = os.path.join(source_dir, file_name)
@@ -395,9 +359,7 @@ class ZoomAutomation(Realm):
             logger.info(f"No zoom_client_logs directory found at {source_dir}")
             return
 
-        # Missing whenever the run aborted before a report was built — see the
-        # note in move_ping_logs().
-        report_dir = getattr(self, "report_path_date_time", None)
+        report_dir = getattr(self, "report_path_date_time", None)  # see move_ping_logs()
         if not report_dir:
             logger.warning(f"No report folder for this run; client logs stay at {source_dir}")
             return
@@ -405,7 +367,6 @@ class ZoomAutomation(Realm):
         destination_dir = os.path.join(report_dir, "zoom_client_logs")
         os.makedirs(report_dir, exist_ok=True)
 
-        # If destination exists, merge files and remove source
         if os.path.exists(destination_dir):
             for file_name in os.listdir(source_dir):
                 src_file = os.path.join(source_dir, file_name)
@@ -436,9 +397,7 @@ class ZoomAutomation(Realm):
 
         report_dir = getattr(self, "report_path_date_time", None)
         if not report_dir or not os.path.isdir(report_dir):
-            # Aborted before a report was built. The log stays where it is —
-            # it is the only record of what went wrong.
-            logger.info(f"No report folder for this run; run log stays at {LOG_FILE}")
+            logger.info(f"No report folder for this run; run log stays at {LOG_FILE}")  # the only record of what went wrong
             return
 
         source = os.path.abspath(LOG_FILE)
@@ -447,10 +406,7 @@ class ZoomAutomation(Realm):
 
         destination = os.path.join(report_dir, os.path.basename(source))
 
-        # Release the file before moving it: on a cross-filesystem move shutil
-        # copies and deletes, and a handler still holding the old descriptor
-        # would keep writing into the deleted inode.
-        root = logging.getLogger()
+        root = logging.getLogger()  # release the file first: a cross-fs move leaves the handler on a deleted inode
         for handler in root.handlers[:]:
             if getattr(handler, "baseFilename", None) == source:
                 root.removeHandler(handler)
@@ -631,7 +587,6 @@ class ZoomAutomation(Realm):
                             else:
                                 stats["rotations_enabled"] = False
 
-                        # --- CSV FILE PATH GENERATION ---
                         if self.do_robo:
                             if self.rotations_enabled:
                                 csv_name = f"{hostname}_{self.current_cord}_{self.current_angle}.csv"
@@ -642,7 +597,6 @@ class ZoomAutomation(Realm):
 
                         csv_file = os.path.join(self.path, csv_name)
 
-                        # --- WRITING DATA TO CSV ---
                         file_exists = (
                             os.path.isfile(csv_file) and os.path.getsize(csv_file) > 0
                         )
@@ -711,7 +665,6 @@ class ZoomAutomation(Realm):
 
         @self.app.route("/get_latest_stats", methods=["GET"])
         def get_latest_stats():
-            # Return the latest data for all hostnames
             return jsonify(self._get_summary_zoom_stats()), 200
 
         @self.app.route("/stop_zoom", methods=["GET"])
@@ -721,7 +674,6 @@ class ZoomAutomation(Realm):
             """
             logger.info("Stopping the test through web UI")
             self.stop_signal = True  # Signal to stop the application
-            # Respond to the client
             response = jsonify({"message": "Stopping Zoom Test"})
             response.status_code = 200
             # Trigger shutdown in a separate thread to avoid blocking
@@ -744,12 +696,7 @@ class ZoomAutomation(Realm):
                         400,
                     )
 
-                # basename() because the name comes off the network: without it
-                # a client could steer this write out of self.path with a
-                # filename like "../../x.csv". Same treatment as the hostname
-                # in /upload_log below. It also collapses a path-only value to
-                # "", which is rejected here rather than silently renamed.
-                filename = os.path.basename((data.get("filename") or "").strip())
+                filename = os.path.basename((data.get("filename") or "").strip())  # basename blocks "../../x.csv" traversal; name comes off the network
                 if not filename:
                     logger.error("/upload_csv POST: missing or invalid filename")
                     return (
@@ -1258,10 +1205,8 @@ class ZoomAutomation(Realm):
             ".".join(item.split(".")[:2]) for item in self.real_sta_list
         ]
 
-        # Step 1: Retrieve information about all resources
         response = self.json_get_with_retry("/resource/all")
 
-        # Step 2: Match user-specified resources with available resources sequentially
         if self.user_resources:
             try:
                 resources = response["resources"]
@@ -1311,22 +1256,16 @@ class ZoomAutomation(Realm):
         self.link_rate_list = []
         self.ssid_list = []
 
-        # Step 3: Retrieve port information
         response_port = self.json_get_with_retry("/port/all")
 
-        # Step 4: Match ports associated with retrieved resources in the order of ports_list
         try:
             for port_entry in self.ports_list:
-                # Extract the eid and ctrl-ip from the current ports_list entry
                 expected_eid = port_entry["eid"]
 
-                # Iterate over the port interfaces to find a matching port
                 for interface in response_port["interfaces"]:
                     for port, _port_data in interface.items():
-                        # Extract the first two segments of the port identifier to match with expected_eid
                         result = ".".join(port.split(".")[:2])
 
-                        # Check if the result matches the current expected eid from ports_list
                         if result == expected_eid:
                             self.gen_ports_list.append(port.split(".")[-1])
                             break
@@ -1335,16 +1274,12 @@ class ZoomAutomation(Realm):
                     break
 
             for port_entry in self.ports_list:
-                # Extract the eid and ctrl-ip from the current ports_list entry
                 expected_eid = port_entry["eid"]
 
-                # Iterate over the port interfaces to find a matching port
                 for interface in response_port["interfaces"]:
                     for port, port_data in interface.items():
-                        # Extract the first two segments of the port identifier to match with expected_eid
                         result = ".".join(port.split(".")[:2])
 
-                        # Check if the result matches the current expected eid from ports_list
                         if result == expected_eid and port_data["parent dev"] == "wiphy0":
                             self.mac_list.append(port_data["mac"])
                             self.rssi_list.append(port_data["signal"])
@@ -1383,7 +1318,6 @@ class ZoomAutomation(Realm):
                     self.lanforge_port_list.append("")
                 else:
                     user_found = False
-                    # 1. Handle Single Device (Flat Dictionary)
                     if isinstance(interop_mobile_data, dict):
                         if interop_mobile_data["user-name"] == user:
                             # Extract details from 'name' (e.g., '1.1.3200f8664a91a5e9')
@@ -1452,10 +1386,7 @@ class ZoomAutomation(Realm):
             False if creation failed — the caller decides whether that aborts
             the run or just skips this coordinate (see _handle_round_failure).
         """
-        # Reset per round so start_cx()/stop_cx()/cleanup() only ever act on
-        # this coordinate's CXs/endpoints, instead of re-processing every
-        # stale entry from every previous coordinate.
-        self.generic_endps_profile.created_cx = []
+        self.generic_endps_profile.created_cx = []  # reset per round so cleanup() only touches this coordinate's CXs
         self.generic_endps_profile.created_endp = []
 
         self.pre_cleanup_stale_endpoint(self.real_sta_list[0])
@@ -1532,9 +1463,7 @@ class ZoomAutomation(Realm):
             run has no next round, so it exits non-zero instead.
         """
         if self.do_robo:
-            # With rotations on, the same coordinate is visited at several
-            # angles — naming only the coordinate wouldn't say which round.
-            if self.rotations_enabled:
+            if self.rotations_enabled:  # coordinate alone would not identify the round
                 where = (
                     f"coordinate {self.current_cord} at angle {self.current_angle}"
                 )
@@ -1595,7 +1524,6 @@ class ZoomAutomation(Realm):
         self.meet_link = f"https://us04web.zoom.us/j/{self.remote_login_url}?pwd={self.remote_login_passwd}"
         logger.info(f"Meet link for android devices: {self.meet_link}")
 
-        # Save meet link in a text file under self.path
         try:
             meet_link_file = os.path.join(self.path, "meet_link.txt")
             with open(meet_link_file, "w") as f:
@@ -1828,12 +1756,7 @@ class ZoomAutomation(Realm):
                             self._record_round_issue(self.host_failure_coords)
                             return True
                 if not self.monitor_endpoint_status_changes():
-                    # None of this round's endpoints answered — they may have
-                    # been deleted, or the manager may just be unreachable, and
-                    # the poll can't tell those apart. Either way tear the round
-                    # down so the next coordinate starts clean; the normal
-                    # teardown below is skipped by the early return.
-                    if self.do_robo:
+                    if self.do_robo:  # no endpoint answered (deleted, or manager unreachable); early return skips the normal teardown
                         self.generic_endps_profile.stop_cx()
                         self.cleanup_generic_endpoints()
                         self.start_time = None
@@ -1876,7 +1799,6 @@ class ZoomAutomation(Realm):
         9. Returns the sorted list of selected real station names.
 
         """
-        # Query and retrieve all user-defined real stations if `real_sta_list` is not provided
         if real_sta_list is None:
             self.real_sta_list, _, _ = real_device_obj.query_user()
         else:
@@ -1897,7 +1819,6 @@ class ZoomAutomation(Realm):
                     ) in (
                         interface_dict.items()
                     ):  # Iterate through items of each interface dictionary
-                        # Check conditions for adding the device
                         key_parts = key.split(".")
                         extracted_key = ".".join(key_parts[:2])
                         if (
@@ -1916,11 +1837,9 @@ class ZoomAutomation(Realm):
 
             self.real_sta_list = final_device_list
 
-        # Log an error and exit if no real stations are selected for testing
         if len(self.real_sta_list) == 0:
             logger.error("There are no real devices in this testbed. Aborting test")
             exit(0)
-        # Filter out iOS devices from the real_sta_list before proceeding
         self.real_sta_list = self.filter_ios_devices(self.real_sta_list)
 
         # Rebuild a clean, ordered and unique station list (avoid mutating while iterating)
@@ -1971,12 +1890,10 @@ class ZoomAutomation(Realm):
             elif value["ostype"] == "android":
                 self.android = self.android + 1
 
-        # Create mapping: { 'Hostname': 'Station_ID' }
         self.hostname_to_station_map = dict(
             zip(self.real_sta_hostname, self.real_sta_list)
         )
 
-        # Return the sorted list of selected real station names
         return self.real_sta_list
 
     def get_signal_and_channel_data_dict(self):
@@ -1988,7 +1905,6 @@ class ZoomAutomation(Realm):
         interfaces_dict = dict()
 
         try:
-            # Get raw data from LANforge API
             response = self.json_get_with_retry_no_exit("/ports/all/")
             if response:
                 port_data = response["interfaces"]
@@ -2007,7 +1923,6 @@ class ZoomAutomation(Realm):
             logger.error(f"Error fetching port data: {e}", exc_info=True)
             return {}
 
-        # Loop through your managed stations (e.g., sta001, sta002)
         for sta in self.real_sta_list:
             # Default values if station is missing
             lf_stats_map[sta] = {
@@ -2022,14 +1937,12 @@ class ZoomAutomation(Realm):
             if sta in interfaces_dict:
                 data = interfaces_dict[sta]
 
-                # --- Signal Parsing ---
                 sig = data.get("signal", "-")
                 if "dBm" in str(sig):
                     lf_stats_map[sta]["signal"] = sig.split(" ")[0]
                 else:
                     lf_stats_map[sta]["signal"] = sig
 
-                # --- Other Fields ---
                 lf_stats_map[sta]["channel"] = data.get("channel", "-")
                 lf_stats_map[sta]["mode"] = data.get("mode", "-")
                 lf_stats_map[sta]["tx_rate"] = data.get("tx-rate", "-")
@@ -2152,7 +2065,6 @@ class ZoomAutomation(Realm):
 
     def get_live_data(self):
         try:
-            # retrieving with past meetings
             token = self.get_access_token(
                 self.account_id, self.client_id, self.client_secret
             )
@@ -2172,7 +2084,6 @@ class ZoomAutomation(Realm):
             )
 
     def get_final_qos_data(self):
-        # 1. Check Credentials (using instance variables)
         if not all([self.account_id, self.client_id, self.client_secret]):
             logger.error("Exiting test due to missing credentials.")
             raise ValueError(
@@ -2182,7 +2093,6 @@ class ZoomAutomation(Realm):
         meeting_id = self.remote_login_url
         logger.info(f"Meeting ID: {meeting_id}")
 
-        # 2. Get Token & Wait for Data Indexing
         token = self.get_access_token(
             self.account_id, self.client_id, self.client_secret
         )
@@ -2190,15 +2100,12 @@ class ZoomAutomation(Realm):
             logger.error("Unable to obtain Zoom access token. Aborting QoS data fetch.")
             return
 
-        # Zoom QoS data is typically available ~20 seconds after meeting end.
-        # We wait 150 seconds to be safe and simplify the logic.
-        wait_time = 150
+        wait_time = 150  # QoS data appears ~20s after meeting end; 150 is the safe margin
         logger.info(
             f"Waiting {wait_time} seconds for Zoom servers to index past meeting QoS data..."
         )
         time.sleep(wait_time)
 
-        # 3. Fetch Data (Try 'Past' first, fallback to 'Live')
         try:
             logger.info("Attempting to fetch 'past' meeting data...")
             past_qos_data = self.get_participants_qos(meeting_id, token, "past")
@@ -2216,11 +2123,9 @@ class ZoomAutomation(Realm):
             except Exception as e_live:
                 logger.error(f"Failed to fetch both past and live data: {e_live}")
 
-        # 4. Summarize and Save JSON
         raw_qos_data = self._get_raw_zoom_stats()
         summary_data = self.summarize_audio_video(raw_qos_data)
 
-        # Construct JSON filename
         if self.do_robo:
             json_name = (
                 f"{meeting_id}_{self.current_cord}_{self.current_angle}_qos.json"
@@ -2230,12 +2135,10 @@ class ZoomAutomation(Realm):
 
         self.save_json(raw_qos_data, json_name)
 
-        # 5. Write to CSV (Integrated Logic)
         if self.do_robo or self.do_bs or self.api_stats_collection:
             if summary_data:
                 logger.info("Writing final QoS data to CSV...")
 
-                # Fetch Wifi Data if needed
                 lf_wifi_data = {}
                 if self.do_bs:
                     try:
@@ -2248,7 +2151,6 @@ class ZoomAutomation(Realm):
                     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                     stats["timestamp"] = timestamp
 
-                    # Add Robot/BS specific data
                     if self.do_bs:
                         x, y, _, _ = self.robo_obj.get_robot_pose()
                         stats["X"] = x
@@ -2271,7 +2173,6 @@ class ZoomAutomation(Realm):
                                 }
                             )
 
-                    # Add Coordinate/Angle data
                     if self.do_robo or self.do_bs:
                         stats["current_cord"] = self.current_cord
                         if self.rotations_enabled:
@@ -2280,7 +2181,6 @@ class ZoomAutomation(Realm):
                         else:
                             stats["rotations_enabled"] = False
 
-                    # Generate CSV Filename
                     if self.do_robo:
                         if self.rotations_enabled:
                             csv_name = f"{final_filename}_{self.current_cord}_{self.current_angle}.csv"
@@ -2291,7 +2191,6 @@ class ZoomAutomation(Realm):
 
                     csv_file = os.path.join(self.path, csv_name)
 
-                    # Write to File
                     try:
                         file_exists = (
                             os.path.isfile(csv_file) and os.path.getsize(csv_file) > 0
@@ -2353,11 +2252,7 @@ class ZoomAutomation(Realm):
         try:
             return float(value.split()[0].replace("%", ""))
         except Exception as e:
-            # Every expected empty/graded/avg-max form is handled above, so an
-            # unparseable value here is genuinely unrecognised. It becomes a
-            # blank cell in the report — log the raw value so that blank can be
-            # traced back to its input.
-            logger.debug(f"Could not parse stat value {value!r} as a number: {e}")
+            logger.debug(f"Could not parse stat value {value!r} as a number: {e}")  # every known form is handled above; log the raw value so the blank cell is traceable
             return None
 
     def _clean_zoom_participant_name(self, participant_name):
@@ -2466,7 +2361,6 @@ class ZoomAutomation(Realm):
         return normalized_summary
 
     def summarize_csv_audio_video(self, csv_path):
-        # Step 1: Find the correct header line
         with open(csv_path, "r", encoding="utf-8-sig") as f:
             lines = f.readlines()
 
@@ -2477,7 +2371,6 @@ class ZoomAutomation(Realm):
             if pd.notna(host_value):
                 csv_host_name = self._clean_zoom_participant_name(host_value)
 
-        # Step 2: Find the line index where real participant data header starts
         header_line_idx = None
         for i, line in enumerate(lines):
             if line.strip().startswith("Participant,"):
@@ -2489,7 +2382,6 @@ class ZoomAutomation(Realm):
                 "Could not find the participant metrics section in the CSV."
             )
 
-        # Step 3: Read only the participant section
         df = pd.read_csv(csv_path, skiprows=header_line_idx, encoding="utf-8-sig")
         df.columns = df.columns.str.strip()
 
@@ -2606,7 +2498,6 @@ class ZoomAutomation(Realm):
                         if val is not None:
                             temp_values[m][f].append(val)
 
-            # calculate avg and max
             for m in metrics:
                 for f in fields:
                     vals = temp_values[m][f]
@@ -2629,7 +2520,6 @@ class ZoomAutomation(Realm):
         - True if the 'generic' tab exists (response is not None).
         - False if the 'generic' tab does not exist (response is None).
         """
-        # Make a JSON GET request to check the existence of the 'generic' tab
         response = self.json_get("generic")
         # Check if the response is None (indicating the tab does not exist)
         if response is None:
@@ -2638,24 +2528,19 @@ class ZoomAutomation(Realm):
             return True
 
     def move_files(self, source_file, dest_dir):
-        # Ensure the source file exists
         if not os.path.isfile(source_file):
             logging.error(f"Source file '{source_file}' does not exist or is not a regular file.")
             return
 
-        # Ensure the destination directory exists
         if not os.path.exists(dest_dir):
             logging.error(f"Destination directory '{dest_dir}' does not exist.")
             return
 
         try:
-            # Extract the filename from the source file path
             filename = os.path.basename(source_file)
 
-            # Construct the destination file path
             dest_file = os.path.join(dest_dir, filename)
 
-            # Move the file
             shutil.move(source_file, dest_file)
 
             logging.info(f"Successfully moved '{source_file}' to '{dest_file}'.")
@@ -2694,11 +2579,7 @@ class ZoomAutomation(Realm):
                     f"(got {self.testname!r}) and --report_dir match what the "
                     f"web UI created."
                 )
-                # sys.exit rather than an exception: this is a configuration
-                # problem, not a test failure, and it keeps the output to the
-                # one line above instead of a traceback. SystemExit still runs
-                # main()'s finally block, so endpoints are cleaned up.
-                sys.exit(1)
+                sys.exit(1)  # config problem, not a test failure: no traceback, and finally still cleans up
             logger.info(f"Waiting for the running json file to be created: {file_path}")
             time.sleep(1)
 
@@ -2712,9 +2593,7 @@ class ZoomAutomation(Realm):
             with open(file_path, "w") as file:
                 json.dump(data, file, indent=4)
         except (OSError, ValueError) as e:
-            # ValueError covers json.JSONDecodeError — a truncated or
-            # half-written file must not take the whole test down.
-            logger.error(f"Could not update the web UI running json {file_path}: {e}")
+            logger.error(f"Could not update the web UI running json {file_path}: {e}")  # ValueError covers JSONDecodeError; a truncated file must not kill the test
             return False
 
         return True
@@ -2761,10 +2640,8 @@ class ZoomAutomation(Realm):
 
             }])
         elif len(self.selected_groups) > 0 and len(self.selected_profiles) > 0:
-            # Map each group with a profile
             gp_pairs = zip(self.selected_groups, self.selected_profiles)
 
-            # Create a string by joining the mapped pairs
             gp_map = ", ".join(f"{group} -> {profile}" for group, profile in gp_pairs)
 
             test_parameters = pd.DataFrame([{
@@ -3149,7 +3026,6 @@ class ZoomAutomation(Realm):
                     for client in accepted_clients
                 ]
             }
-            # If both groups and profiles are selected, generate separate audio results tables per group; otherwise show a single combined results table.
             if self.selected_groups and self.selected_profiles:
                 for group in self.selected_groups:
                     group_specific_audio_test_results = self.get_test_results_data(audio_test_results_dict, group)
@@ -3280,7 +3156,6 @@ class ZoomAutomation(Realm):
                     for client in accepted_clients
                 ]
             }
-            # If both groups and profiles are selected, generate separate video results tables per group; otherwise show a single combined results table.
             if self.selected_groups and self.selected_profiles:
                 for group in self.selected_groups:
                     group_specific_video_test_results = self.get_test_results_data(video_test_results_dict, group)
@@ -3508,7 +3383,6 @@ class ZoomAutomation(Realm):
 
             logger.info(f"Bandsteering report dir: {report_dir}")
 
-            # Search for CSV files in self.path
             csv_files = glob.glob(os.path.join(report_dir, "*.csv"))
             logger.info(f"Bandsteering CSV files found: {csv_files}")
 
@@ -3557,14 +3431,12 @@ class ZoomAutomation(Realm):
 
                 device_name = os.path.basename(csv_file_path).replace(".csv", "")
 
-                # Clean columns
                 df["BSSID"] = df["BSSID"].fillna("NA").astype(str)
                 df["TimeStamp"] = df["TimeStamp"].fillna("NA").astype(str)
                 df["From_Coord"] = df["From_Coord"].fillna("NA").astype(str)
                 df["To_Coord"] = df["To_Coord"].fillna("NA").astype(str)
                 df["Channel"] = df["Channel"].fillna("NA").astype(str)
 
-                # Filter only configured BSSIDs (if provided)
                 if allowed_bssids:
                     df = df[df["BSSID"].isin(allowed_bssids)]
 
@@ -3589,7 +3461,6 @@ class ZoomAutomation(Realm):
 
                 skip_table = not mask.any()
 
-                # Count BSSID switches
                 if skip_table:
                     # Ensure all expected BSSIDs show zero
                     bssid_counts = {bssid: 0 for bssid in self.bssids}
@@ -3664,7 +3535,6 @@ class ZoomAutomation(Realm):
                 report.set_table_dataframe(table_df)
                 report.build_table()
 
-            # Handle Charging Timestamps (Check if robo_obj exists first)
             if (
                 hasattr(self, "robo_obj")
                 and hasattr(self.robo_obj, "charging_timestamps")
@@ -3679,7 +3549,6 @@ class ZoomAutomation(Realm):
                         "charging_completion_timestamp",
                     ],
                 )
-                # Add S.No column
                 df.insert(0, "S.No", range(1, len(df) + 1))
                 report.set_table_dataframe(df)
                 report.build_table()
@@ -3689,10 +3558,7 @@ class ZoomAutomation(Realm):
                     _obj="Robot did not go to charge during this test",
                 )
                 report.build_objective()
-        except Exception as e:
-            # This handler wraps the whole function, so the failure could be
-            # anywhere from CSV discovery to graph building — the traceback is
-            # what narrows it down.
+        except Exception as e:  # wraps the whole function; exc_info is what narrows the failure down
             logger.error(
                 f"Failed to build the band-steering report section: {e}",
                 exc_info=True,
@@ -3704,7 +3570,6 @@ class ZoomAutomation(Realm):
         """
         live_view_dir = os.path.join(self.path, "live_view_images")
 
-        # Define the specific filenames for Floor 1
         video_img_name = f"zoom_video_{self.testname}_floor1.png"
         audio_img_name = f"zoom_audio_{self.testname}_floor1.png"
 
@@ -3714,7 +3579,6 @@ class ZoomAutomation(Realm):
         timeout = 90  # seconds
         start_time = time.time()
 
-        # 1. Wait for the Video image (Primary trigger)
         while not (os.path.exists(video_path) and os.path.exists(audio_path)):
             if time.time() - start_time > timeout:
                 logger.error(f"Timeout: {video_img_name} not found within 60 seconds.")
@@ -3731,10 +3595,8 @@ class ZoomAutomation(Realm):
         else:
             logger.warning(f"Audio heatmap image not found: {audio_path}")
 
-        # 2. Build the HTML Report Content
         html_content = ""
 
-        # Add Video Map (if found)
         if os.path.exists(video_path):
             html_content += (
                 '<div style="page-break-before: always;"></div>'
@@ -3742,7 +3604,6 @@ class ZoomAutomation(Realm):
                 f'<div style="text-align:center;"><img src="file://{video_path}" style="width:1200px; height:800px;"></img></div>'
             )
 
-        # Add Audio Map (if found)
         if os.path.exists(audio_path):
             html_content += (
                 '<div style="page-break-before: always;"></div>'
@@ -3750,7 +3611,6 @@ class ZoomAutomation(Realm):
                 f'<div style="text-align:center;"><img src="file://{audio_path}" style="width:1200px; height:800px;"></img></div>'
             )
 
-        # 3. Inject into Report
         if html_content:
             self.report.set_custom_html(html_content)
 
@@ -3958,7 +3818,6 @@ class ZoomAutomation(Realm):
             )
             self.report.build_text_simple()
 
-            # audio bitrate graph
             self.report.set_graph_title("a. Audio Bitrate (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -3996,7 +3855,6 @@ class ZoomAutomation(Realm):
             self.report.move_graph_image()
             self.report.build_graph()
 
-            # audio latency graph
             self.report.set_graph_title("b. Audio Latency (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4033,7 +3891,6 @@ class ZoomAutomation(Realm):
             self.report.move_graph_image()
             self.report.build_graph()
 
-            # audio jitter graph
             self.report.set_graph_title("c. Audio Jitter (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4070,7 +3927,6 @@ class ZoomAutomation(Realm):
             self.report.move_graph_image()
             self.report.build_graph()
 
-            # audio packet loss graph
             self.report.set_graph_title("d. Audio Packet Loss (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4198,7 +4054,6 @@ class ZoomAutomation(Realm):
             )
             self.report.build_text_simple()
 
-            # video bitrate graph
             self.report.set_graph_title("a. Video Bitrate (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4235,7 +4090,6 @@ class ZoomAutomation(Realm):
             self.report.move_graph_image()
             self.report.build_graph()
 
-            # video latency graph
             self.report.set_graph_title("b. Video Latency (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4272,7 +4126,6 @@ class ZoomAutomation(Realm):
             self.report.move_graph_image()
             self.report.build_graph()
 
-            # video jitter graph
             self.report.set_graph_title("c. Video Jitter (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4309,7 +4162,6 @@ class ZoomAutomation(Realm):
             self.report.move_graph_image()
             self.report.build_graph()
 
-            # video packet loss graph
             self.report.set_graph_title("d. Video Packet Loss (Recevied/Sent)")
             self.report.build_graph_title()
             x_data_set = [
@@ -4460,7 +4312,6 @@ class ZoomAutomation(Realm):
         """
         Main function to generate report from API data.
         """
-        # --- Initialize Report ---
         self.report = lf_report(
             _output_pdf="zoom_call_report.pdf",
             _output_html="zoom_call_report.html",
@@ -4468,15 +4319,10 @@ class ZoomAutomation(Realm):
             _path=self.path,
         )
         report_path_date_time = self.report.get_path_date_time()
-        # Recorded on self like the other two report generators do: the cleanup
-        # in main()'s finally block reads it to place the client logs and the
-        # run log, and this is the only generator that runs for
-        # --do_robo --api_stats_collection.
-        self.report_path_date_time = report_path_date_time
+        self.report_path_date_time = report_path_date_time  # main()'s finally reads this to place the client and run logs
         self.report.set_title("Zoom Call Automated Report")
         self.report.build_banner()
 
-        # --- Objective Section ---
         self.report.set_table_title("Objective:")
         self.report.build_table_title()
         self.report.set_text(
@@ -4487,7 +4333,6 @@ class ZoomAutomation(Realm):
         )
         self.report.build_text_simple()
 
-        # --- Test Parameters Table ---
         self.report.set_table_title("Test Parameters:")
         self.report.build_table_title()
 
@@ -4512,7 +4357,6 @@ class ZoomAutomation(Realm):
             "Mode": "Robo Motion" if self.do_robo else "Static",
         }
 
-        # Add conditional fields
         if self.config:
             param_data["Configured Devices"] = self.hostname_os_combination
             param_data["SSID"] = self.ssid
@@ -4526,13 +4370,11 @@ class ZoomAutomation(Realm):
         self.report.set_table_dataframe(pd.DataFrame([param_data]))
         self.report.build_table()
 
-        # ROBO MODE: Iterate through Coords/Angles and generate device graphs for each
         self._generate_robo_per_location_report()
 
         if self.do_webui:
             self.add_live_view_images_to_report()
 
-        # --- Finalize Report ---
         self.report.build_custom()
         self.report.write_html()
         self.report.write_pdf(_page_size="Legal", _orientation="Landscape")
@@ -4546,14 +4388,12 @@ class ZoomAutomation(Realm):
         coords = self.coordinates_list if self.coordinates_list else ["0,0,0"]
 
         for coord in coords:
-            # Determine angles loop
             if self.rotations_enabled and self.angles_list:
                 angles_loop = self.angles_list
             else:
                 angles_loop = [self.current_angle]
 
             for angle in angles_loop:
-                # 1. Heading for this Location
                 if self.rotations_enabled:
                     heading = f"Audio and Video graphs at coordinate {coord} and angle {angle}"
                 else:
@@ -4561,7 +4401,6 @@ class ZoomAutomation(Realm):
                 self.report.set_table_title(heading)
                 self.report.build_table_title()
 
-                # 2. Load Data
                 json_pattern = f"*_{coord}_{angle}_qos.json"
                 file_path = os.path.join(self.path, "zoom_api_responses", json_pattern)
                 found_files = glob.glob(file_path)
@@ -4581,7 +4420,6 @@ class ZoomAutomation(Realm):
                     self.report.build_text_simple()
                     continue
 
-                # 3. Generate Audio Graphs (Device on Y-Axis)
                 if self.audio:
                     suffix = f"_{coord}_{angle}"
                     self._build_metric_graph(
@@ -4602,7 +4440,6 @@ class ZoomAutomation(Realm):
                     )
                     self._build_results_table(device_data, "audio")
 
-                # 4. Generate Video Graphs (Device on Y-Axis)
                 if self.video:
                     suffix = f"_{coord}_{angle}"
                     self._build_metric_graph(
@@ -4623,7 +4460,6 @@ class ZoomAutomation(Realm):
                     )
                     self._build_results_table(device_data, "video")
 
-                # Add a separator between coordinates
                 self.report.set_custom_html("<hr>")
                 self.report.build_custom()
 
@@ -4700,7 +4536,6 @@ class ZoomAutomation(Realm):
         """
         Helper to move CSVs, and Robo JSONs to the report folder.
         """
-        # 1. Move Client CSV files
         if self.do_robo:
             for coord in self.coordinates_list:
                 if self.rotations_enabled:
@@ -4718,13 +4553,11 @@ class ZoomAutomation(Realm):
                         if os.path.exists(csv_path):
                             self.move_files(csv_path, report_path_date_time)
 
-        # 2. Move Robo JSONs (Wildcard search for Multi-Location files)
         if self.do_robo:
             pattern = os.path.join(self.path, "zoom_api_responses", "*_qos.json")
             for f in glob.glob(pattern):
                 self.move_files(f, report_path_date_time)
 
-        # 3. Move the endpoint status change log
         self.move_files(
             os.path.join(self.path, "endpoint_status_changes.csv"), report_path_date_time
         )
@@ -4736,25 +4569,20 @@ class ZoomAutomation(Realm):
         try:
             json_path = os.path.join(self.path, "running_status.json")
 
-            # 1. Load existing data or create new dict
             data = {}
             if os.path.exists(json_path):
                 with open(json_path, "r") as f:
                     try:
                         data = json.load(f)
-                    except json.JSONDecodeError as e:
-                        # Existing contents are discarded — say so, otherwise
-                        # the keys that were in this file vanish with no trace.
+                    except json.JSONDecodeError as e:  # warn loudly: the keys already in this file are about to vanish
                         logger.warning(
                             f"{json_path} is not valid JSON ({e}); its existing "
                             "contents are being discarded and the file rewritten."
                         )
                         data = {}
 
-            # 2. Update status
             data["status"] = "Completed"
 
-            # 3. Write back to file
             with open(json_path, "w") as f:
                 json.dump(data, f, indent=4)
 
@@ -4784,10 +4612,7 @@ class ZoomAutomation(Realm):
                 for angle in self.angles_list:
                     self.robo_obj.wait_for_battery()
                     rotated = self.robo_obj.rotate_angle(angle_degree=angle)
-                    if not rotated:
-                        # One unreachable angle is a per-angle problem, the
-                        # same shape as an unreachable coordinate — skip it
-                        # rather than taking down every angle still to come.
+                    if not rotated:  # per-angle skip, same shape as an unreachable coordinate
                         logger.error(
                             f"Failed to rotate to angle {angle} at coordinate "
                             f"{coordinate} — skipping this angle and trying the next one."
@@ -4812,10 +4637,7 @@ class ZoomAutomation(Realm):
 
 
 def main():
-    # Bound up front so the finally block below can always test it. It stays
-    # None whenever we leave the try before the test object is built — --help,
-    # a bad argument, a validation exit — and there is nothing to clean up.
-    zoom_automation = None
+    zoom_automation = None  # bound up front so the finally block below can always test it
 
     try:
         parser = argparse.ArgumentParser(
@@ -5216,10 +5038,7 @@ def main():
             )
             exit(0)
 
-        # Zoom API credentials, resolved before anything else is set up: without
-        # them an --api_stats_collection run cannot produce its report, so there
-        # is no point reaching LANforge or starting the Flask server first.
-        account_id = client_id = client_secret = None
+        account_id = client_id = client_secret = None  # resolved first: no point reaching LANforge without them
         if args.api_stats_collection:
             if args.env_file:
                 if not os.path.exists(args.env_file):
@@ -5284,9 +5103,7 @@ def main():
             linux_dir=args.linux_dir,
             mac_dir=args.mac_dir,
         )
-        # Already resolved and validated above; None unless this is an
-        # --api_stats_collection run.
-        zoom_automation.account_id = account_id
+        zoom_automation.account_id = account_id  # None unless this is an --api_stats_collection run
         zoom_automation.client_id = client_id
         zoom_automation.client_secret = client_secret
 
@@ -5355,9 +5172,7 @@ def main():
                             elif j in all_res.keys():
                                 eid_list.append(all_res[j])
             if args.zoom_host in eid_list:
-                # Remove the existing instance of args.zoom_host from the list
                 eid_list.remove(args.zoom_host)
-                # Insert args.zoom_host at the beginning of the list
                 eid_list.insert(0, args.zoom_host)
 
             args.resources = ",".join(id for id in eid_list)
@@ -5406,7 +5221,6 @@ def main():
                         )
                     args.resources = ",".join(id for id in dev_list)
             else:
-                # If no resources provided, prompt user to select devices manually
                 if args.config:
                     all_devices = config_obj.get_all_devices()
                     device_list = []
@@ -5452,7 +5266,6 @@ def main():
                 )
                 for item in get_data:
                     item = item.strip()
-                    # Find and append the matching lap to result_list
                     matching_laps = [lap for lap in laptops if lap.startswith(item)]
                     result_list.extend(matching_laps)
                 if not result_list:
@@ -5513,12 +5326,7 @@ def main():
     except Exception as e:
         logger.error(f"AN ERROR OCCURED WHILE RUNNING TEST {e}")
         traceback.print_exc()
-    finally:
-        # Covers --help too: argparse exits inside parse_args(), long before
-        # the object is built. Deliberately an if rather than an early return —
-        # a return here would discard the exception on its way out, including
-        # the SystemExit carrying the exit code, turning a failed run into a
-        # silent success.
+    finally:  # covers --help; an if not a return, which would swallow SystemExit
         if zoom_automation is not None:
             zoom_automation.stop_signal = True
             logger.info("Waiting for Browser Cleanup in Laptops")
@@ -5536,9 +5344,7 @@ def main():
             # zoom_automation.move_ping_logs()
             zoom_automation.move_log_folder()
             logger.info("Done.")
-            # Last thing in the run — everything above is now in the log that
-            # travels with the report.
-            zoom_automation.move_run_log_to_report()
+            zoom_automation.move_run_log_to_report()  # last: everything above is now in the log that travels with the report
 
 
 if __name__ == "__main__":

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -348,6 +348,28 @@ class ZoomAutomation(Realm):
             shutil.move(source_dir, destination_dir)
             logger.info(f"Moved ping logs folder to {destination_dir}")
 
+    def move_log_folder(self):
+        source_dir = os.path.join(self.path, "zoom_laptop_client_logs")
+        if not os.path.isdir(source_dir):
+            logger.info(f"No zoom_laptop_client_logs directory found at {source_dir}")
+            return
+
+        destination_dir = os.path.join(self.report_path_date_time, "zoom_laptop_client_logs")
+        os.makedirs(self.report_path_date_time, exist_ok=True)
+
+        # If destination exists, merge files and remove source
+        if os.path.exists(destination_dir):
+            for file_name in os.listdir(source_dir):
+                src_file = os.path.join(source_dir, file_name)
+                dst_file = os.path.join(destination_dir, file_name)
+                if os.path.isfile(src_file):
+                    shutil.move(src_file, dst_file)
+            shutil.rmtree(source_dir, ignore_errors=True)
+            logger.info(f"Merged client logs into {destination_dir}")
+        else:
+            shutil.move(source_dir, destination_dir)
+            logger.info(f"Moved client logs folder to {destination_dir}")
+
     def handle_flask_server(self):
         self.stop_previous_flask_server()
         time.sleep(5)  # Ensure the port is released before starting the server
@@ -696,6 +718,38 @@ class ZoomAutomation(Realm):
                     200,
                 )
             except Exception as e:
+                return jsonify({"status": "error", "message": str(e)}), 500
+
+        @self.app.route("/upload_log", methods=["POST"])
+        def upload_log():
+            try:
+                data = request.json
+                hostname = data.get("hostname")
+                log_content = data.get("log")
+
+                if not hostname or log_content is None:
+                    return jsonify({"status": "error", "message": "Missing hostname or log"}), 400
+
+                log_dir = os.path.join(self.path, "zoom_laptop_client_logs")
+                os.makedirs(log_dir, exist_ok=True)
+
+                # Force a safe filename to avoid path traversal from client-supplied hostname
+                hostname = os.path.basename(hostname.strip())
+                if self.do_robo:
+                    if self.rotations_enabled:
+                        log_name = f"{hostname}_{self.current_cord}_{self.current_angle}.log"
+                    else:
+                        log_name = f"{hostname}_{self.current_cord}.log"
+                else:
+                    log_name = f"{hostname}.log"
+                save_path = os.path.join(log_dir, log_name)
+                with open(save_path, "w", errors="replace") as f:
+                    f.write(log_content)
+
+                logger.info(f"Log file uploaded from {hostname}")
+                return jsonify({"status": "success", "message": "Log file uploaded"}), 200
+            except Exception as e:
+                logger.error(f"Error uploading log file: {e}")
                 return jsonify({"status": "error", "message": str(e)}), 500
 
         try:
@@ -5032,6 +5086,7 @@ def main():
             time.sleep(5)
             zoom_automation.generic_endps_profile.cleanup()
             # zoom_automation.move_ping_logs()
+            zoom_automation.move_log_folder()
             logger.info("Done.")
 
 

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -768,7 +768,7 @@ class ZoomAutomation(Realm):
             self.generate_report_from_data()
         elif self.api_stats_collection:
             self.generate_report_from_api()
-        self.generic_endps_profile.cleanup()
+        self.cleanup_generic_endpoints()
         logger.info("Initiating graceful shutdown...")
         os._exit(0)
 
@@ -779,6 +779,96 @@ class ZoomAutomation(Realm):
         else:
             self.end_time = self.start_time + timedelta(minutes=self.duration)
         return [self.start_time, self.end_time]
+
+    def generic_endpoint_exists(self, endp_name):
+        """True if LANforge currently has a generic endpoint by this name."""
+        response = self.json_get(f"/generic/{endp_name}")
+        return bool(response and "endpoint" in response)
+
+    def predict_endpoint_names(self, port_name):
+        """
+        Reproduce GenCXProfile.create()'s naming convention without actually
+        creating anything, so we can check LANforge for a stale endpoint/CX
+        left over from a prior run that crashed before cleanup ran.
+
+        create() is always called here with real_client_os_types set, in
+        which case it builds gen_name_a from the port name UNMODIFIED (dots
+        and all) rather than just its final EID segment — see the first
+        loop in GenCXProfile.create() (gen_cxprofile.py), where
+        `name = port_name` when real_client_os_types is truthy, and that
+        `name` (not a later split() reassignment used only for the POST
+        body's "port" field) is what gen_name_a/cx_name are built from.
+
+        Example: port_name="1.400.wlan0", name_prefix="zoom" ->
+        ("zoom-1.400.wlan0", "CX_zoom-1.400.wlan0")
+        """
+        prefix = self.generic_endps_profile.name_prefix
+        return f"{prefix}-{port_name}", f"CX_{prefix}-{port_name}"
+
+    def predict_android_endpoint_names(self, port_name):
+        """
+        Reproduce create_android()'s naming convention — distinct from
+        GenCXProfile.create()'s: it keeps the full port EID (underscore-
+        joined) rather than just the final segment, and prefixes the CX
+        name with "generic" instead of "zoom".
+
+        Example: port_name="1.13.wlan0" ->
+        ("zoom-1_13_wlan0", "CX_generic-zoom-1_13_wlan0")
+        """
+        gen_name = "zoom-%s" % "_".join(port_name.split("."))
+        cx_name = "CX_generic-%s" % gen_name
+        return gen_name, cx_name
+
+    def pre_cleanup_stale_names(self, gen_name, cx_name):
+        """
+        Remove any endpoint/CX by these names that's still on LANforge from
+        a previous run — e.g. one that crashed before its own cleanup ran.
+
+        CX existence can't be queried directly: /cx/{name} only looks in
+        the L3 table, and generic-type CXs live elsewhere — LANforge
+        returns an empty/warning response for a generic CX regardless of
+        whether it exists, so a truthiness/membership check against it is
+        always False. Instead, infer CX presence from the endpoint: this
+        codebase always creates them as a 1:1 pair, and LANforge itself
+        refuses to rm_endp an endpoint that's still owned by a CX — so if
+        the endpoint exists, its CX must too, and has to go first.
+        """
+        if self.generic_endpoint_exists(gen_name):
+            logger.info(f"Removing stale CX {cx_name} left over from a previous run.")
+            self.json_post("cli-json/rm_cx", {"test_mgr": "default_tm", "cx_name": cx_name})
+            logger.info(f"Removing stale generic endpoint {gen_name} left over from a previous run.")
+            self.json_post("cli-json/rm_endp", {"endp_name": gen_name})
+
+    def pre_cleanup_stale_endpoint(self, port_name):
+        """Before creating a real-device generic endpoint for port_name."""
+        gen_name, cx_name = self.predict_endpoint_names(port_name)
+        self.pre_cleanup_stale_names(gen_name, cx_name)
+
+    def pre_cleanup_stale_android_endpoint(self, port_name):
+        """Before creating an Android generic endpoint for port_name."""
+        gen_name, cx_name = self.predict_android_endpoint_names(port_name)
+        self.pre_cleanup_stale_names(gen_name, cx_name)
+
+    def cleanup_generic_endpoints(self):
+        """
+        Like generic_endps_profile.cleanup(), but only deletes the endpoint
+        if LANforge still actually reports it as present.
+
+        CX existence can't be queried directly for generic-type CXs (see
+        pre_cleanup_stale_names()'s docstring), so — since these are our
+        own tracked created_cx names, known to have been created — rm_cx
+        is attempted unconditionally for each one, same as the original
+        cleanup(). This must run before the endpoint loop: LANforge
+        refuses to rm_endp an endpoint still owned by its CX.
+        """
+        for cx_name in self.generic_endps_profile.created_cx:
+            self.json_post("cli-json/rm_cx", {"test_mgr": "default_tm", "cx_name": cx_name})
+
+        for endp_name in self.generic_endps_profile.created_endp:
+            if self.generic_endpoint_exists(endp_name):
+                self.json_post("cli-json/rm_endp", {"endp_name": endp_name})
+            else:
+                logger.debug(f"Generic endpoint {endp_name} no longer exists on LANforge — skipping delete.")
 
     def check_gen_cx(self, stall_timeout=600):
         """Return True once every generic endpoint is idle (Stopped/WAITING/NO-CX),
@@ -1239,6 +1329,7 @@ class ZoomAutomation(Realm):
         self.generic_endps_profile.created_cx = []
         self.generic_endps_profile.created_endp = []
 
+        self.pre_cleanup_stale_endpoint(self.real_sta_list[0])
         if self.generic_endps_profile.create(
             ports=[self.real_sta_list[0]],
             real_client_os_types=[self.real_sta_os_type[0]],
@@ -1290,14 +1381,14 @@ class ZoomAutomation(Realm):
                 logger.error(
                     f"Timed out after {timeout}s waiting for host device ({host_endp}) to log in."
                 )
-                self.generic_endps_profile.cleanup()
+                self.cleanup_generic_endpoints()
                 return False
             try:
                 generic_endpoint = self.json_get(f"/generic/{host_endp}")
                 endp_status = generic_endpoint["endpoint"]["status"]
                 if endp_status == "Stopped":
                     logger.error(f"Failed to start the host device ({host_endp}).")
-                    self.generic_endps_profile.cleanup()
+                    self.cleanup_generic_endpoints()
                     return False
                 time.sleep(5)
             except Exception as e:
@@ -1328,6 +1419,7 @@ class ZoomAutomation(Realm):
         )
         for i in range(1, len(self.real_sta_os_type)):
             if self.real_sta_os_type[i] == "android":
+                self.pre_cleanup_stale_android_endpoint(self.real_sta_list[i])
                 status, created_cx, created_endp = self.create_android(
                     lanforge_res=self.lanforge_port_list[i],
                     ports=[self.real_sta_list[i]],
@@ -1351,6 +1443,7 @@ class ZoomAutomation(Realm):
                 )
 
             else:
+                self.pre_cleanup_stale_endpoint(self.real_sta_list[i])
                 self.generic_endps_profile.create(
                     ports=[self.real_sta_list[i]],
                     real_client_os_types=[self.real_sta_os_type[i]],
@@ -1402,7 +1495,7 @@ class ZoomAutomation(Realm):
                     f"Unable to get the start signal from the host device within {timeout}s. "
                     "Giving up and cleaning up this round's CXs."
                 )
-                self.generic_endps_profile.cleanup()
+                self.cleanup_generic_endpoints()
                 return False
             logger.info("WAITING FOR THE TEST TO BE STARTED")
             time.sleep(5)
@@ -1526,7 +1619,7 @@ class ZoomAutomation(Realm):
                     if pause:
                         self.stop_signal = True
                         self.generic_endps_profile.stop_cx()
-                        self.generic_endps_profile.cleanup()
+                        self.cleanup_generic_endpoints()
                         self.delete_current_csv_files()
                         self.start_time = None
                         self.end_time = None
@@ -1553,7 +1646,7 @@ class ZoomAutomation(Realm):
                 time.sleep(5)
         if self.do_robo:
             self.generic_endps_profile.stop_cx()
-            self.generic_endps_profile.cleanup()
+            self.cleanup_generic_endpoints()
             self.start_time = None
             self.end_time = None
             return True
@@ -5127,7 +5220,7 @@ def main():
             elif args.api_stats_collection:
                 zoom_automation.generate_report_from_api()
             time.sleep(5)
-            zoom_automation.generic_endps_profile.cleanup()
+            zoom_automation.cleanup_generic_endpoints()
             # zoom_automation.move_ping_logs()
             zoom_automation.move_log_folder()
             logger.info("Done.")

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -389,9 +389,9 @@ class ZoomAutomation(Realm):
             logger.info(f"Moved ping logs folder to {destination_dir}")
 
     def move_log_folder(self):
-        source_dir = os.path.join(self.path, "zoom_laptop_client_logs")
+        source_dir = os.path.join(self.path, "zoom_client_logs")
         if not os.path.isdir(source_dir):
-            logger.info(f"No zoom_laptop_client_logs directory found at {source_dir}")
+            logger.info(f"No zoom_client_logs directory found at {source_dir}")
             return
 
         # Missing whenever the run aborted before a report was built — see the
@@ -401,7 +401,7 @@ class ZoomAutomation(Realm):
             logger.warning(f"No report folder for this run; client logs stay at {source_dir}")
             return
 
-        destination_dir = os.path.join(report_dir, "zoom_laptop_client_logs")
+        destination_dir = os.path.join(report_dir, "zoom_client_logs")
         os.makedirs(report_dir, exist_ok=True)
 
         # If destination exists, merge files and remove source
@@ -845,7 +845,7 @@ class ZoomAutomation(Realm):
                 if not hostname or log_content is None:
                     return jsonify({"status": "error", "message": "Missing hostname or log"}), 400
 
-                log_dir = os.path.join(self.path, "zoom_laptop_client_logs")
+                log_dir = os.path.join(self.path, "zoom_client_logs")
                 os.makedirs(log_dir, exist_ok=True)
 
                 # Force a safe filename to avoid path traversal from client-supplied hostname

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -293,9 +293,7 @@ class ZoomAutomation(Realm):
         self.resource_ip = resource_ip
 
     def stop_previous_flask_server(self):
-        """
-        Forcefully kills any process currently listening on port 5000 (Linux/Darwin only).
-        """
+        """Kill any process listening on port 5000 (Linux/Darwin only)."""
         port = 5000
         logger.info(
             f"Checking for processes using port {port} to forcefully kill them..."
@@ -380,17 +378,10 @@ class ZoomAutomation(Realm):
             logger.info(f"Moved client logs folder to {destination_dir}")
 
     def move_run_log_to_report(self):
-        """Move this run's own log file into the report folder. CLI runs only.
+        """Move this run's log file into the report folder. CLI runs only.
 
-        Skipped under --do_webUI: there the report directory is handed to us by
-        the web UI (--report_dir), so the log is left at its fixed path next to
-        the script rather than relocated into a directory the UI owns.
-
-        The log file is opened in append mode, so moving it out is also what
-        gives the next CLI run an empty one — each report folder ends up
-        holding the log of the run that produced it. Anything logged after this
-        point belongs to the same run, so the handler is re-attached at the new
-        path instead of just being closed.
+        Skipped under --do_webUI, where the report directory belongs to the web
+        UI. The logging handler is re-attached at the new path.
         """
         if self.do_webui:
             return
@@ -669,9 +660,7 @@ class ZoomAutomation(Realm):
 
         @self.app.route("/stop_zoom", methods=["GET"])
         def stop_zoom():
-            """
-            Endpoint to stop the Zoom test and trigger a graceful application shutdown.
-            """
+            """Stop the Zoom test and shut the application down."""
             logger.info("Stopping the test through web UI")
             self.stop_signal = True  # Signal to stop the application
             response = jsonify({"message": "Stopping Zoom Test"})
@@ -824,9 +813,7 @@ class ZoomAutomation(Realm):
             sys.exit(0)
 
     def shutdown(self):
-        """
-        Gracefully shut down the application.
-        """
+        """Shut the application down gracefully."""
         if self.do_robo and self.api_stats_collection:
             self.generate_report_from_data()
         elif self.api_stats_collection:
@@ -844,57 +831,34 @@ class ZoomAutomation(Realm):
         return [self.start_time, self.end_time]
 
     def generic_endpoint_exists(self, endp_name):
-        """True if LANforge currently has a generic endpoint by this name."""
+        """Return True if LANforge has a generic endpoint by this name."""
         response = self.json_get(f"/generic/{endp_name}")
         return bool(response and "endpoint" in response)
 
     def predict_endpoint_names(self, port_name):
-        """
-        Reproduce GenCXProfile.create()'s naming convention without actually
-        creating anything, so we can check LANforge for a stale endpoint/CX
-        left over from a prior run that crashed before cleanup ran.
+        """Return the generic endpoint and CX names for a port.
 
-        create() is always called here with real_client_os_types set, in
-        which case it builds gen_name_a from the port name UNMODIFIED (dots
-        and all) rather than just its final EID segment — see the first
-        loop in GenCXProfile.create() (gen_cxprofile.py), where
-        `name = port_name` when real_client_os_types is truthy, and that
-        `name` (not a later split() reassignment used only for the POST
-        body's "port" field) is what gen_name_a/cx_name are built from.
-
-        Example: port_name="1.400.wlan0", name_prefix="zoom" ->
-        ("zoom-1.400.wlan0", "CX_zoom-1.400.wlan0")
+        Both are built from the configured name prefix: port "1.400.wlan0" with
+        prefix "zoom" gives ("zoom-1.400.wlan0", "CX_zoom-1.400.wlan0").
         """
         prefix = self.generic_endps_profile.name_prefix
         return f"{prefix}-{port_name}", f"CX_{prefix}-{port_name}"
 
     def predict_android_endpoint_names(self, port_name):
-        """
-        Reproduce create_android()'s naming convention — distinct from
-        GenCXProfile.create()'s: it keeps the full port EID (underscore-
-        joined) rather than just the final segment, and prefixes the CX
-        name with "generic" instead of "zoom".
+        """Return the generic endpoint and CX names for an Android port.
 
-        Example: port_name="1.13.wlan0" ->
-        ("zoom-1_13_wlan0", "CX_generic-zoom-1_13_wlan0")
+        The port EID is underscore-joined: "1.13.wlan0" gives
+        ("zoom-1_13_wlan0", "CX_generic-zoom-1_13_wlan0").
         """
         gen_name = "zoom-%s" % "_".join(port_name.split("."))
         cx_name = "CX_generic-%s" % gen_name
         return gen_name, cx_name
 
     def pre_cleanup_stale_names(self, gen_name, cx_name):
-        """
-        Remove any endpoint/CX by these names that's still on LANforge from
-        a previous run — e.g. one that crashed before its own cleanup ran.
+        """Delete the named CX and generic endpoint from LANforge.
 
-        CX existence can't be queried directly: /cx/{name} only looks in
-        the L3 table, and generic-type CXs live elsewhere — LANforge
-        returns an empty/warning response for a generic CX regardless of
-        whether it exists, so a truthiness/membership check against it is
-        always False. Instead, infer CX presence from the endpoint: this
-        codebase always creates them as a 1:1 pair, and LANforge itself
-        refuses to rm_endp an endpoint that's still owned by a CX — so if
-        the endpoint exists, its CX must too, and has to go first.
+        Does nothing if the endpoint is not present. The CX goes first, since
+        LANforge refuses to delete an endpoint its CX still owns.
         """
         if self.generic_endpoint_exists(gen_name):
             logger.info(f"Removing stale CX {cx_name} left over from a previous run.")
@@ -913,16 +877,10 @@ class ZoomAutomation(Realm):
         self.pre_cleanup_stale_names(gen_name, cx_name)
 
     def cleanup_generic_endpoints(self):
-        """
-        Like generic_endps_profile.cleanup(), but only deletes the endpoint
-        if LANforge still actually reports it as present.
+        """Delete every CX and generic endpoint this run created.
 
-        CX existence can't be queried directly for generic-type CXs (see
-        pre_cleanup_stale_names()'s docstring), so — since these are our
-        own tracked created_cx names, known to have been created — rm_cx
-        is attempted unconditionally for each one, same as the original
-        cleanup(). This must run before the endpoint loop: LANforge
-        refuses to rm_endp an endpoint still owned by its CX.
+        Each CX is removed first, then the endpoints LANforge still reports;
+        endpoints already gone are skipped.
         """
         for cx_name in self.generic_endps_profile.created_cx:
             self.json_post("cli-json/rm_cx", {"test_mgr": "default_tm", "cx_name": cx_name})
@@ -934,9 +892,11 @@ class ZoomAutomation(Realm):
                 logger.debug(f"Generic endpoint {endp_name} no longer exists on LANforge — skipping delete.")
 
     def check_gen_cx(self, stall_timeout=600):
-        """Return True once every generic endpoint is idle (Stopped/WAITING/NO-CX),
-        or once a stuck endpoint has been non-idle for longer than stall_timeout
-        seconds — in which case we stop waiting on it instead of hanging forever."""
+        """Return True once every generic endpoint is idle.
+
+        Idle means Stopped, WAITING or NO-CX — or non-idle for longer than
+        stall_timeout seconds, so a stuck endpoint stops being waited on.
+        """
         if not hasattr(self, "_gen_cx_stall_since"):
             self._gen_cx_stall_since = {}
 
@@ -976,21 +936,11 @@ class ZoomAutomation(Realm):
             return False
 
     def monitor_endpoint_status_changes(self, wait_time=40, poll_interval=5):
-        """
-        Checks the current status of every generic endpoint and, only the
-        first time an endpoint's status changes, logs a message and appends
-        a row (timestamp, endpoint_name, status) to
-        endpoint_status_changes.csv. Repeated polls of an unchanged status
-        are not logged or written again.
+        """Log and record each generic endpoint's first status change.
 
-        If every created endpoint is missing from the response, retries
-        every poll_interval seconds for up to wait_time seconds.
-
-        Returns:
-            True while at least one created endpoint is still responding.
-            False if none of them have responded once wait_time has elapsed —
-            the caller decides whether that skips just this coordinate or
-            aborts the run (see _handle_round_failure).
+        Rows are appended to endpoint_status_changes.csv; unchanged statuses are
+        ignored. Returns True while any endpoint still responds, False once none
+        have answered for wait_time seconds.
         """
         csv_file = os.path.join(self.path, "endpoint_status_changes.csv")
         created_endp = self.generic_endps_profile.created_endp
@@ -1153,10 +1103,10 @@ class ZoomAutomation(Realm):
         return True, created_cx, created_endp
 
     def json_get_with_retry(self, url, wait_time=40, poll_interval=5):
-        """
-        Calls self.json_get(url), retrying every poll_interval seconds for up
-        to wait_time seconds if LANforge returns no response. Aborts the test
-        if it still hasn't responded once wait_time has elapsed.
+        """Call self.json_get(url), retrying until LANforge responds.
+
+        Retries every poll_interval seconds for up to wait_time seconds, then
+        aborts the test.
         """
         start_time = time.time()
         response = self.json_get(url)
@@ -1175,10 +1125,10 @@ class ZoomAutomation(Realm):
         return response
 
     def json_get_with_retry_no_exit(self, url, wait_time=40, poll_interval=5):
-        """
-        Same as json_get_with_retry(), but for callers where the fetched data
-        is best-effort/non-critical: returns None instead of aborting the
-        test if LANforge still hasn't responded once wait_time has elapsed.
+        """GET `url` from LANforge, retrying until it responds.
+
+        Retries every poll_interval seconds for up to wait_time seconds.
+        Returns the decoded response, or None if there was still none.
         """
         start_time = time.time()
         response = self.json_get(url)
@@ -1379,12 +1329,10 @@ class ZoomAutomation(Realm):
                 logger.error(f"Error deleting file {file_path}: {e}")
 
     def create_host(self):
-        """Create and start the host device's generic endpoint.
+        """Create the host device's generic endpoint and set its Zoom command.
 
-        Returns:
-            True if the endpoint was created and started.
-            False if creation failed — the caller decides whether that aborts
-            the run or just skips this coordinate (see _handle_round_failure).
+        The command sent depends on the host's OS. Returns True once the
+        endpoint is created and started, False if creation failed.
         """
         self.generic_endps_profile.created_cx = []  # reset per round so cleanup() only touches this coordinate's CXs
         self.generic_endps_profile.created_endp = []
@@ -1430,37 +1378,16 @@ class ZoomAutomation(Realm):
         return True
 
     def _record_round_issue(self, bucket):
-        """Note the current coordinate in `bucket`, once.
-
-        With rotations on a coordinate is visited at several angles, so the
-        same coordinate can fail repeatedly. These buckets answer "which
-        locations are missing data", so one entry per coordinate is what the
-        report wants — the per-angle detail stays in the log.
-        """
+        """Append the current coordinate to `bucket` if it is not already there."""
         if self.current_cord not in bucket:
             bucket.append(self.current_cord)
 
     def _handle_round_failure(self, reason, record_in=None):
-        """Decide whether a mid-run failure aborts the run or skips a point.
+        """Log a round failure and report whether the run should continue.
 
-        Centralises the abort-vs-skip rule so endpoint-creation failures,
-        readiness failures, and endpoints disappearing mid-round are all
-        treated identically.
-
-        Args:
-            reason: what failed, phrased so it reads before "on the very first
-                round ..." / "for ...".
-            record_in: the list this round's coordinate is recorded in.
-                Defaults to host_failure_coords. The endpoint-loss path passes
-                its own list instead, so "we never got a reading here" stays
-                separable from a host fault when the report is built. Neither
-                touches failed_coords, which is reserved for the robot failing
-                to reach the coordinate at all.
-
-        Returns:
-            The value run() should return — False to abort the whole robo test,
-            True to skip this round and carry on with the next one. A non-robo
-            run has no next round, so it exits non-zero instead.
+        Records the current coordinate in `record_in`, defaulting to
+        host_failure_coords. Returns False if the host was never ready, True to
+        carry on. A non-robo run exits with status 1 instead of returning.
         """
         if self.do_robo:
             if self.rotations_enabled:  # coordinate alone would not identify the round
@@ -1492,11 +1419,8 @@ class ZoomAutomation(Realm):
     def wait_for_host_ready(self, timeout=600):
         """Wait for the host device to confirm login.
 
-        Returns:
-            True once login is confirmed.
-            False if the host device stops before logging in, or if login
-            isn't confirmed within `timeout` seconds (default 5 minutes) —
-            instead of hanging forever or killing the whole process.
+        Returns True once confirmed, False if the host stops first or `timeout`
+        seconds pass.
         """
         deadline = time.time() + timeout
         while not self.login_completed:
@@ -1606,10 +1530,8 @@ class ZoomAutomation(Realm):
     def wait_for_test_start(self, timeout=180):
         """Wait for the test-started signal.
 
-        Returns:
-            True once the test has started.
-            False if it isn't signaled within `timeout` seconds (default 3
-            minutes) — instead of hanging forever.
+        Returns True once the test has started, False if it is not signalled
+        within `timeout` seconds.
         """
         deadline = time.time() + timeout
         count = 0
@@ -1897,8 +1819,8 @@ class ZoomAutomation(Realm):
         return self.real_sta_list
 
     def get_signal_and_channel_data_dict(self):
-        """
-        Returns a dictionary of LANforge stats keyed by station name.
+        """Return LANforge stats keyed by station name.
+
         Example: {'sta001': {'lf_signal': -55, 'lf_channel': 36, ...}}
         """
         lf_stats_map = {}
@@ -1987,17 +1909,9 @@ class ZoomAutomation(Realm):
     ):
         """Fetch every page of participant QoS for a meeting.
 
-        Two separate bounds, because there are two ways this can hang:
-
-        request_timeout caps each individual HTTP call, so an unresponsive
-        Zoom endpoint cannot block forever. This matters most for the "live"
-        fetch, which runs inside the /upload_stats request — a stalled socket
-        there holds a Flask worker thread and the client waiting on it.
-
-        timeout caps the whole pagination walk. The loop otherwise ends only
-        when Zoom stops handing back a next_page_token; a repeating token
-        would page indefinitely. On expiry the pages collected so far are
-        kept rather than discarded.
+        `request_timeout` caps each HTTP call and `timeout` the whole pagination
+        walk; on expiry the pages already collected are kept. Returns the
+        participant records, or [] if none could be fetched.
         """
         url = f"https://api.zoom.us/v2/metrics/meetings/{meeting_id}/participants/qos"
         headers = {"Authorization": f"Bearer {access_token}"}
@@ -2218,15 +2132,10 @@ class ZoomAutomation(Realm):
             return None
 
     def parse_zoom_value(self, value):
-        """
-        Convert Zoom string metrics into a float.
-        Handles cases like:
-        - "123 kbps"
-        - "21 ms"
-        - "5.6 %"
-        - "21 ms/40 ms"
-        - "Good(4.41)"
-        - "-" or empty values
+        """Convert a Zoom string metric to a float.
+
+        Handles "123 kbps", "21 ms/40 ms", "Good(4.41)", "-" and empty values.
+        Returns None when the value cannot be parsed.
         """
         if not value or str(value).strip() in ["-", ""]:
             return None
@@ -2454,14 +2363,10 @@ class ZoomAutomation(Realm):
         return self._match_summary_data_to_hostnames(summary, host_device_key)
 
     def summarize_audio_video(self, json_data):
-        """
-        Summarize per-device audio and video stats: avg/max of bitrate, jitter, latency, packet loss.
+        """Summarize per-device audio and video stats from Zoom participant JSON.
 
-        Args:
-            json_data (list): Zoom JSON as list of participants.
-
-        Returns:
-            dict: {device_name: {metric_field_avg/max: value, ...}}
+        Returns {device_name: {metric_avg/max: value}} covering bitrate, jitter,
+        latency and packet loss.
         """
         if not json_data:
             summary_data = self._get_summary_zoom_stats()
@@ -2513,12 +2418,9 @@ class ZoomAutomation(Realm):
         return self._match_summary_data_to_hostnames(summary, host_device_key)
 
     def check_tab_exists(self):
-        """
-        Checks if the 'generic' tab exists by making a JSON GET request.
+        """Check whether the 'generic' tab exists.
 
-        Returns:
-        - True if the 'generic' tab exists (response is not None).
-        - False if the 'generic' tab does not exist (response is None).
+        Returns True if it does, False otherwise.
         """
         response = self.json_get("generic")
         # Check if the response is None (indicating the tab does not exist)
@@ -2548,19 +2450,11 @@ class ZoomAutomation(Realm):
             logging.error(f"Failed to move '{source_file}' to '{dest_dir}': {e}")
 
     def updating_webui_runningjson(self, obj, timeout=60):
-        """Merge obj into the web UI's running json for this test.
+        """Merge `obj` into the web UI's running json for this test.
 
-        Returns True when the file was updated, False when it existed but could
-        not be read or written — that only costs the web UI a status update, so
-        it is logged and the test carries on.
-
-        A missing file is different and ends the run. The web UI creates it
-        before launching the script, so if it has not appeared within timeout
-        seconds it is not coming, and every later status update would fail the
-        same way — the web UI would show a test that never reports progress or
-        completion. The usual cause is a name that can never match: --testname
-        left unset makes this look for "<ip>_None_running.json". The message
-        names the exact path so that is obvious at a glance.
+        Returns True when written, False when the file exists but could not be
+        read or written. A file still missing after `timeout` seconds ends the
+        run — usually --testname was left unset, so the name can never match.
         """
         file_path = os.path.join(
             self.path,
@@ -3188,26 +3082,10 @@ class ZoomAutomation(Realm):
         )
 
     def change_port_to_ip(self, upstream_port):
-        """
-        Convert a given port name to its corresponding IP address if it's not already an IP.
+        """Resolve a LANforge port name such as "1.1.eth1" to its IP address.
 
-        This function checks whether the provided `upstream_port` is a valid IPv4 address.
-        If it's not, it attempts to extract the IP address of the port by resolving it
-        via the internal `name_to_eid()` method and then querying the IP using `json_get()`.
-
-        Args:
-            upstream_port (str): The name or IP of the upstream port. This could be a
-                                 LANforge port name like '1.1.eth1' or an IP address.
-
-        Returns:
-            str: The resolved IP address if the port name was converted successfully,
-                otherwise returns the original input if it was already an IP or
-                if resolution fails.
-
-        Logs:
-            - A warning if the port is not Ethernet or IP resolution fails.
-            - Info logs for the resolved or passed IP.
-
+        Returns the resolved IP, or the input unchanged if it was already an IP
+        or could not be resolved.
         """
         if upstream_port.count('.') != 3:
             target_port_list = self.name_to_eid(upstream_port)
@@ -3236,43 +3114,10 @@ class ZoomAutomation(Realm):
         return upstream_port
 
     def get_test_results_data(self, test_results, group):
-        """
-        Filters the overall test results to include only the data belonging to a specific group.
+        """Return `test_results` with only the rows for devices in `group`.
 
-        This function maps hostnames to their respective groups using the configuration object
-        (`self.configobj.get_groups_devices`). It then filters the input `test_results` dictionary
-        so that only entries corresponding to devices in the specified `group` are retained.
-
-        Args:
-            test_results (dict): A dictionary containing lists of test result values for all devices.
-                Example:
-                    {
-                        "Hostname": ["Device1", "Device2"],
-                        "RSSI": [-45, -50],
-                        "Link Rate": [300, 150],
-                        ...
-                    }
-            group (str): The name of the group whose test result data needs to be extracted.
-
-        Returns:
-            dict: A dictionary in the same structure as `test_results`, but filtered to include
-            only entries for hostnames that belong to the given `group`.
-
-        Example:
-            >>> test_results = {
-            ...     "Hostname": ["D1", "D2", "D3"],
-            ...     "RSSI": [-40, -50, -55]
-            ... }
-            >>> self.get_test_results_data(test_results, "GroupA")
-            {
-                "Hostname": ["D1", "D3"],
-                "RSSI": [-40, -55]
-            }
-
-        Notes:
-            - Relies on `self.configobj.get_groups_devices()` to retrieve the mapping of
-            groups to device hostnames.
-            - Returns an empty dictionary if no hostnames from the group are found.
+        Rows are matched on the "Device Name" column. Every original key is
+        kept, holding an empty list when no device matches.
         """
         groups_devices_map = self.config_obj.get_groups_devices(data=self.selected_groups, groupdevmap=True)
         group_hostnames = groups_devices_map.get(group, [])
@@ -3289,34 +3134,11 @@ class ZoomAutomation(Realm):
         return group_test_results
 
     def filter_ios_devices(self, device_list):
-        """
-        Filters out iOS devices from the given device list based on hardware and software identifiers.
+        """Drop iOS devices from a list or comma-separated string of device ids.
 
-        This method accepts a list or comma-separated string of device identifiers and removes
-        devices identified as iOS (Apple) based on their hardware version, app ID, and kernel info
-        fetched via the `/resource/{shelf}/{resource}` API endpoint.
-
-        Supported input formats for each device:
-        - "shelf.resource"
-        - "shelf.resource.port"
-        - "resource" (assumes shelf = 1)
-
-        iOS devices are identified if:
-        - 'Apple' is found in the hardware version, and
-        - `app-id` is not empty and is either non-zero or the kernel is empty
-
-        Args:
-            device_list (Union[list[str], str]): A list or comma-separated string of devices to be filtered.
-
-        Returns:
-            Union[list[int], str]: A list of valid (non-iOS) device IDs as integers,
-                                or a comma-separated string if the input was a string.
-
-        Logs:
-            - Warnings for invalid formats or missing device data.
-            - Info when an iOS device is skipped.
-            - Exceptions if errors occur during processing.
-
+        Accepts "shelf.resource", "shelf.resource.port" or "resource". Returns
+        the non-iOS ids in the form the input used: a list of ints, or a
+        comma-separated string if a string was passed.
         """
         modified_device_list = device_list
         if isinstance(device_list, str):
@@ -3565,9 +3387,7 @@ class ZoomAutomation(Realm):
             )
 
     def add_live_view_images_to_report(self):
-        """
-        Waits for and adds the Video and Audio heatmap images for Floor 1.
-        """
+        """Wait for the Floor 1 video and audio heatmaps, then add them."""
         live_view_dir = os.path.join(self.path, "live_view_images")
 
         video_img_name = f"zoom_video_{self.testname}_floor1.png"
@@ -4309,9 +4129,7 @@ class ZoomAutomation(Realm):
         )
 
     def generate_report_from_data(self):
-        """
-        Main function to generate report from API data.
-        """
+        """Generate the report from collected API data."""
         self.report = lf_report(
             _output_pdf="zoom_call_report.pdf",
             _output_html="zoom_call_report.html",
@@ -4381,9 +4199,9 @@ class ZoomAutomation(Realm):
         self._move_report_files(report_path_date_time)
 
     def _generate_robo_per_location_report(self):
-        """
-        Iterates through every coordinate and angle, loads the specific JSON,
-        and generates Device-Specific Bar Graphs (Device Name on Y-Axis).
+        """Generate per-device bar graphs for every coordinate and angle.
+
+        Loads each round's JSON and plots device names on the Y-axis.
         """
         coords = self.coordinates_list if self.coordinates_list else ["0,0,0"]
 
@@ -4466,9 +4284,7 @@ class ZoomAutomation(Realm):
     def _build_metric_graph(
         self, media_type, metric_name, unit, data, input_key, output_key, suffix=""
     ):
-        """
-        Helper to build standard horizontal bar graphs with Device Names on Y-Axis.
-        """
+        """Build a horizontal bar graph with device names on the Y-axis."""
         self.report.set_graph_title(f"{media_type} {metric_name} (Sent/Received)")
         self.report.build_graph_title()
 
@@ -4497,7 +4313,7 @@ class ZoomAutomation(Realm):
         self.report.build_graph()
 
     def _build_results_table(self, data, media_type):
-        """Helper for Summary Table"""
+        """Build the summary results table."""
 
         def fmt_val(client, key):
             val = data.get(client, {}).get(key)
@@ -4533,9 +4349,7 @@ class ZoomAutomation(Realm):
         self.report.html += self.report.dataframe_html
 
     def _move_report_files(self, report_path_date_time):
-        """
-        Helper to move CSVs, and Robo JSONs to the report folder.
-        """
+        """Move CSVs and robo JSONs into the report folder."""
         if self.do_robo:
             for coord in self.coordinates_list:
                 if self.rotations_enabled:
@@ -4563,9 +4377,7 @@ class ZoomAutomation(Realm):
         )
 
     def stop_webui(self):
-        """
-        Updates the running_status.json file to mark the test as Completed.
-        """
+        """Mark the test Completed in running_status.json."""
         try:
             json_path = os.path.join(self.path, "running_status.json")
 

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -104,11 +104,12 @@ flask_server_logger = logging.getLogger(__name__)
 flask_server_log = logging.getLogger("werkzeug")
 flask_server_log.setLevel(logging.ERROR)
 
-# Run log, kept next to this script so it lands in a predictable place
-# regardless of which directory the test was launched from.
-LOG_FILE = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "lf_interop_zoom.log"
-)
+# Everything this test writes is anchored here rather than to the working
+# directory, so results land in the same predictable place no matter which
+# directory the test was launched from.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+LOG_FILE = os.path.join(SCRIPT_DIR, "lf_interop_zoom.log")
 
 # Terminal and file get the same line. filename/lineno matter because the other
 # modules (DeviceConfig, lf_base_robo, gen_cxprofile, LFRequest) log through the
@@ -222,9 +223,12 @@ class ZoomAutomation(Realm):
         self.stop_signal = False
         self.download_csv = False
         self.csv_file_name = "csvdata.csv"
-        self.path = os.path.join(os.getcwd(), "zoom_test_results")
-        if not os.path.exists(self.path):
-            os.makedirs(self.path)
+        # Next to the script, not in the working directory: a run launched from
+        # /home/lanforge and one launched from the script's own folder now put
+        # their results in the same place. Overridden with --report_dir when the
+        # web UI drives the test.
+        self.path = os.path.join(SCRIPT_DIR, "zoom_test_results")
+        os.makedirs(self.path, exist_ok=True)
 
         self.device_names = []
         self.hostname_os_combination = None
@@ -726,7 +730,20 @@ class ZoomAutomation(Realm):
                         400,
                     )
 
-                filename = data.get("filename", "csvdata.csv")
+                # basename() because the name comes off the network: without it
+                # a client could steer this write out of self.path with a
+                # filename like "../../x.csv". Same treatment as the hostname
+                # in /upload_log below. It also collapses a path-only value to
+                # "", which is rejected here rather than silently renamed.
+                filename = os.path.basename((data.get("filename") or "").strip())
+                if not filename:
+                    logger.error("/upload_csv POST: missing or invalid filename")
+                    return (
+                        jsonify(
+                            {"status": "error", "message": "Missing or invalid filename"}
+                        ),
+                        400,
+                    )
                 self.csv_file_name = f"received_{filename}"
                 rows = data.get("rows", [])
                 logger.info(f"/upload_csv POST: received filename={filename}")
@@ -737,7 +754,7 @@ class ZoomAutomation(Realm):
                         400,
                     )
 
-                filepath = f"received_{filename}"
+                filepath = os.path.join(self.path, self.csv_file_name)
                 logger.info(
                     f"Data Received from Zoom dashboard is stored at: {filepath}"
                 )
@@ -2041,8 +2058,9 @@ class ZoomAutomation(Realm):
         return []
 
     def save_json(self, data, filename):
-        os.makedirs("zoom_api_responses", exist_ok=True)
-        path = os.path.join("zoom_api_responses", filename)
+        api_dir = os.path.join(self.path, "zoom_api_responses")
+        os.makedirs(api_dir, exist_ok=True)
+        path = os.path.join(api_dir, filename)
         with open(path, "w") as f:
             json.dump(data, f, indent=2)
 
@@ -3742,8 +3760,9 @@ class ZoomAutomation(Realm):
         else:
             csv_device_data = {}
             try:
-                if not os.path.exists(os.path.join(os.getcwd(), self.csv_file_name)):
-                    logger.error(f"File not found: {self.csv_file_name}")
+                csv_path = os.path.join(self.path, self.csv_file_name)
+                if not os.path.exists(csv_path):
+                    logger.error(f"File not found: {csv_path}")
                     self.report.set_table_title("Test Devices:")
                     self.report.build_table_title()
                     device_details = pd.DataFrame(
@@ -3759,7 +3778,7 @@ class ZoomAutomation(Realm):
                         }
                     )
                 else:
-                    csv_device_data = self.summarize_csv_audio_video(self.csv_file_name)
+                    csv_device_data = self.summarize_csv_audio_video(csv_path)
                     device_data = csv_device_data
                     self.report.set_table_title("Test Devices:")
                     self.report.build_table_title()
@@ -4291,18 +4310,18 @@ class ZoomAutomation(Realm):
             self.move_files(file_to_move_path, self.report_path_date_time)
         if self.download_csv:
             self.move_files(
-                os.path.join(os.getcwd(), self.csv_file_name),
+                os.path.join(self.path, self.csv_file_name),
                 self.report_path_date_time,
             )
         self.move_files(
             os.path.join(
-                os.getcwd(), "zoom_api_responses", f"{self.remote_login_url}_qos.json"
+                self.path, "zoom_api_responses", f"{self.remote_login_url}_qos.json"
             ),
             self.report_path_date_time,
         )
         self.move_files(
             os.path.join(
-                os.getcwd(),
+                self.path,
                 "zoom_api_responses",
                 f"{self.remote_login_url}_raw_qos.json",
             ),
@@ -4419,7 +4438,7 @@ class ZoomAutomation(Realm):
 
                 # 2. Load Data
                 json_pattern = f"*_{coord}_{angle}_qos.json"
-                file_path = os.path.join("zoom_api_responses", json_pattern)
+                file_path = os.path.join(self.path, "zoom_api_responses", json_pattern)
                 found_files = glob.glob(file_path)
                 device_data = {}
                 if found_files:
@@ -4576,7 +4595,7 @@ class ZoomAutomation(Realm):
 
         # 2. Move Robo JSONs (Wildcard search for Multi-Location files)
         if self.do_robo:
-            pattern = os.path.join(os.getcwd(), "zoom_api_responses", "*_qos.json")
+            pattern = os.path.join(self.path, "zoom_api_responses", "*_qos.json")
             for f in glob.glob(pattern):
                 self.move_files(f, report_path_date_time)
 

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -2009,25 +2009,56 @@ class ZoomAutomation(Realm):
             )
             return None
 
-    def get_participants_qos(self, meeting_id, access_token, test_type="past"):
+    def get_participants_qos(
+        self,
+        meeting_id,
+        access_token,
+        test_type="past",
+        timeout=300,
+        request_timeout=30,
+    ):
+        """Fetch every page of participant QoS for a meeting.
+
+        Two separate bounds, because there are two ways this can hang:
+
+        request_timeout caps each individual HTTP call, so an unresponsive
+        Zoom endpoint cannot block forever. This matters most for the "live"
+        fetch, which runs inside the /upload_stats request — a stalled socket
+        there holds a Flask worker thread and the client waiting on it.
+
+        timeout caps the whole pagination walk. The loop otherwise ends only
+        when Zoom stops handing back a next_page_token; a repeating token
+        would page indefinitely. On expiry the pages collected so far are
+        kept rather than discarded.
+        """
         url = f"https://api.zoom.us/v2/metrics/meetings/{meeting_id}/participants/qos"
         headers = {"Authorization": f"Bearer {access_token}"}
         params = {"type": test_type}
         all_participants = []
         next_page_token = None
+        deadline = time.time() + timeout
 
         try:
             while True:
                 if next_page_token:
                     params["next_page_token"] = next_page_token
 
-                response = requests.get(url, headers=headers, params=params)
+                response = requests.get(
+                    url, headers=headers, params=params, timeout=request_timeout
+                )
                 if response.status_code == 200:
                     data = response.json()
                     participants = data.get("participants", [])
                     all_participants.extend(participants)
                     next_page_token = data.get("next_page_token")
                     if not next_page_token:
+                        break
+                    if time.time() >= deadline:
+                        logger.warning(
+                            f"Stopped paging {test_type} participant QoS after "
+                            f"{timeout}s with {len(all_participants)} participants "
+                            "collected; keeping what was fetched so far."
+                        )
                         break
                 else:
                     raise Exception(
@@ -2576,23 +2607,62 @@ class ZoomAutomation(Realm):
         except Exception as e:
             logging.error(f"Failed to move '{source_file}' to '{dest_dir}': {e}")
 
-    def updating_webui_runningjson(self, obj):
-        data = {}
-        file_path = self.path + "/../../Running_instances/{}_{}_running.json".format(self.mgr_ip, self.testname)
+    def updating_webui_runningjson(self, obj, timeout=60):
+        """Merge obj into the web UI's running json for this test.
 
-        # Wait until the file exists
+        Returns True when the file was updated, False when it existed but could
+        not be read or written — that only costs the web UI a status update, so
+        it is logged and the test carries on.
+
+        A missing file is different and ends the run. The web UI creates it
+        before launching the script, so if it has not appeared within timeout
+        seconds it is not coming, and every later status update would fail the
+        same way — the web UI would show a test that never reports progress or
+        completion. The usual cause is a name that can never match: --testname
+        left unset makes this look for "<ip>_None_running.json". The message
+        names the exact path so that is obvious at a glance.
+        """
+        file_path = os.path.join(
+            self.path,
+            "..",
+            "..",
+            "Running_instances",
+            f"{self.mgr_ip}_{self.testname}_running.json",
+        )
+
+        deadline = time.time() + timeout
         while not os.path.exists(file_path):
-            logging.info("Waiting for the running json file to be created")
+            if time.time() >= deadline:
+                logger.error(
+                    f"Aborting the test: the web UI running json never appeared "
+                    f"at {file_path} after {timeout}s. Check that --testname "
+                    f"(got {self.testname!r}) and --report_dir match what the "
+                    f"web UI created."
+                )
+                # sys.exit rather than an exception: this is a configuration
+                # problem, not a test failure, and it keeps the output to the
+                # one line above instead of a traceback. SystemExit still runs
+                # main()'s finally block, so endpoints are cleaned up.
+                sys.exit(1)
+            logger.info(f"Waiting for the running json file to be created: {file_path}")
             time.sleep(1)
-        logging.info("Running Json file found")
-        with open(file_path, 'r') as file:
-            data = json.load(file)
 
-        for key in obj:
-            data[key] = obj[key]
+        try:
+            with open(file_path, "r") as file:
+                data = json.load(file)
 
-        with open(file_path, 'w') as file:
-            json.dump(data, file, indent=4)
+            for key in obj:
+                data[key] = obj[key]
+
+            with open(file_path, "w") as file:
+                json.dump(data, file, indent=4)
+        except (OSError, ValueError) as e:
+            # ValueError covers json.JSONDecodeError — a truncated or
+            # half-written file must not take the whole test down.
+            logger.error(f"Could not update the web UI running json {file_path}: {e}")
+            return False
+
+        return True
 
     def generate_report(self):
         report = lf_report(_output_pdf='zoom_call_report.pdf',
@@ -5085,6 +5155,29 @@ def main():
             )
             exit(0)
 
+        # Zoom API credentials, resolved before anything else is set up: without
+        # them an --api_stats_collection run cannot produce its report, so there
+        # is no point reaching LANforge or starting the Flask server first.
+        account_id = client_id = client_secret = None
+        if args.api_stats_collection:
+            if args.env_file:
+                if not os.path.exists(args.env_file):
+                    logger.error(f".env file '{args.env_file}' not found")
+                    sys.exit(1)
+                load_dotenv(args.env_file)
+                logger.info(f"Loaded environment variables from {args.env_file}")
+
+            account_id = args.account_id or os.environ.get("ACCOUNT_ID")
+            client_id = args.client_id or os.environ.get("CLIENT_ID")
+            client_secret = args.client_secret or os.environ.get("CLIENT_SECRET")
+
+            if not all([account_id, client_id, client_secret]):
+                logger.error(
+                    "Missing Zoom credentials: pass --account_id/--client_id/"
+                    "--client_secret or set ACCOUNT_ID/CLIENT_ID/CLIENT_SECRET"
+                )
+                sys.exit(1)
+
         rotations_enabled = False
         bssids = []
         if args.do_robo or args.do_bs or args.do_roam:
@@ -5130,6 +5223,12 @@ def main():
             linux_dir=args.linux_dir,
             mac_dir=args.mac_dir,
         )
+        # Already resolved and validated above; None unless this is an
+        # --api_stats_collection run.
+        zoom_automation.account_id = account_id
+        zoom_automation.client_id = client_id
+        zoom_automation.client_secret = client_secret
+
         if args.download_csv:
             zoom_automation.download_csv = True
         args.upstream_port = zoom_automation.change_port_to_ip(args.upstream_port)
@@ -5341,34 +5440,6 @@ def main():
         zoom_automation.get_resource_data()
         zoom_automation.get_ports_data()
         zoom_automation.get_interop_data()
-
-        if args.api_stats_collection:
-            # load environment file if specified
-            if args.env_file:
-                if os.path.exists(args.env_file):
-                    load_dotenv(args.env_file)
-                    logger.info(f"Loaded environment variables from {args.env_file}")
-                else:
-                    raise FileNotFoundError(f".env file '{args.env_file}' not found")
-
-            # Fetching zoom credentials for account
-            zoom_automation.account_id = args.account_id or os.environ.get("ACCOUNT_ID")
-            zoom_automation.client_id = args.client_id or os.environ.get("CLIENT_ID")
-            zoom_automation.client_secret = args.client_secret or os.environ.get(
-                "CLIENT_SECRET"
-            )
-
-            if not all(
-                [
-                    zoom_automation.account_id,
-                    zoom_automation.client_id,
-                    zoom_automation.client_secret,
-                ]
-            ):
-                logger.info("Exiting test.")
-                raise ValueError(
-                    "Missing Zoom credentials (account_id, client_id, client_secret)"
-                )
 
         if args.do_robo:
             zoom_automation.run_robo_test()

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -1015,6 +1015,27 @@ class ZoomAutomation(Realm):
 
         return response
 
+    def json_get_with_retry_no_exit(self, url, wait_time=40, poll_interval=5):
+        """
+        Same as json_get_with_retry(), but for callers where the fetched data
+        is best-effort/non-critical: returns None instead of aborting the
+        test if LANforge still hasn't responded once wait_time has elapsed.
+        """
+        start_time = time.time()
+        response = self.json_get(url)
+        while response is None and (time.time() - start_time) < wait_time:
+            logger.warning(f"GET {url} returned no response from LANforge; retrying...")
+            time.sleep(poll_interval)
+            response = self.json_get(url)
+
+        if response is None:
+            logger.error(
+                f"GET {url} returned no response from LANforge after waiting "
+                f"{wait_time} seconds. Continuing without this data."
+            )
+
+        return response
+
     def get_resource_data(self):
         self.ports_list = []
         self.user_list = []
@@ -1675,11 +1696,22 @@ class ZoomAutomation(Realm):
 
         try:
             # Get raw data from LANforge API
-            port_data = self.json_get("/ports/all/")["interfaces"]
-            for port in port_data:
-                interfaces_dict.update(port)
+            response = self.json_get_with_retry_no_exit("/ports/all/")
+            if response:
+                port_data = response["interfaces"]
+                for port in port_data:
+                    interfaces_dict.update(port)
+            else:
+                return {}
+        except KeyError as e:
+            logger.error(
+                f"/ports/all/ response is not in the expected format, missing key {e}. "
+                "Data received:\n%s",
+                json.dumps(response, indent=2, default=str),
+            )
+            return {}
         except Exception as e:
-            logger.error(f"Error fetching port data: {e}")
+            logger.error(f"Error fetching port data: {e}", exc_info=True)
             return {}
 
         # Loop through your managed stations (e.g., sta001, sta002)
@@ -2940,8 +2972,19 @@ class ZoomAutomation(Realm):
             try:
                 target_port_ip = response['interface']['ip']
                 upstream_port = target_port_ip
+            except KeyError as e:
+                logging.error(
+                    f"/port/{shelf}/{resource}/{port} response is not in the expected format, missing key {e}. "
+                    "Data received:\n%s",
+                    json.dumps(response, indent=2, default=str),
+                )
+                exit(1)
             except Exception as e:
-                logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}. Exception: {e}')
+                logging.error(
+                    f"Unexpected error while parsing /port/{shelf}/{resource}/{port} response: {e}",
+                    exc_info=True,
+                )
+                exit(1)
             logging.info(f"Upstream port IP {upstream_port}")
         else:
             logging.info(f"Upstream port IP {upstream_port}")

--- a/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/lf_interop_zoom.py
@@ -104,20 +104,34 @@ flask_server_logger = logging.getLogger(__name__)
 flask_server_log = logging.getLogger("werkzeug")
 flask_server_log.setLevel(logging.ERROR)
 
-# 1. Configure the logging system
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("lf_interop_zoom.log", mode="w"),  # Writes to file
-        logging.StreamHandler(sys.stdout),  # Writes to terminal
-    ],
+# Run log, kept next to this script so it lands in a predictable place
+# regardless of which directory the test was launched from.
+LOG_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "lf_interop_zoom.log"
 )
 
-# 2. Create the logger instance
-logger = logging.getLogger(__name__)
+# Terminal and file get the same line. filename/lineno matter because the other
+# modules (DeviceConfig, lf_base_robo, gen_cxprofile, LFRequest) log through the
+# root logger into here too, and that is what tells them apart. The log file is
+# opened in append mode deliberately — a re-run must not destroy the log of the
+# run that just failed.
+#
+# force=True is required: DeviceConfig calls logging.basicConfig() when it is
+# imported above, and without force our call here would be a silent no-op and
+# the run log would never be written.
+LOG_FORMAT = "%(asctime)s - %(levelname)-8s - %(message)s (%(filename)s:%(lineno)s)"
 
-lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
+logging.basicConfig(
+    level=logging.INFO,
+    format=LOG_FORMAT,
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler(LOG_FILE, mode="a"),
+    ],
+    force=True,
+)
+
+logger = logging.getLogger(__name__)
 
 robo_base_class = importlib.import_module("py-scripts.lf_base_robo")
 
@@ -332,8 +346,17 @@ class ZoomAutomation(Realm):
             logger.info(f"No ping_logs directory found at {source_dir}")
             return
 
-        destination_dir = os.path.join(self.report_path_date_time, "ping_logs")
-        os.makedirs(self.report_path_date_time, exist_ok=True)
+        # report_path_date_time is only created once a report has been built,
+        # so it can be missing here — this runs from main()'s finally block,
+        # which is reached however the run ended. Crashing would replace the
+        # real error with an AttributeError and skip the cleanup below it.
+        report_dir = getattr(self, "report_path_date_time", None)
+        if not report_dir:
+            logger.warning(f"No report folder for this run; ping logs stay at {source_dir}")
+            return
+
+        destination_dir = os.path.join(report_dir, "ping_logs")
+        os.makedirs(report_dir, exist_ok=True)
 
         # If destination exists, merge files and remove source
         if os.path.exists(destination_dir):
@@ -354,8 +377,15 @@ class ZoomAutomation(Realm):
             logger.info(f"No zoom_laptop_client_logs directory found at {source_dir}")
             return
 
-        destination_dir = os.path.join(self.report_path_date_time, "zoom_laptop_client_logs")
-        os.makedirs(self.report_path_date_time, exist_ok=True)
+        # Missing whenever the run aborted before a report was built — see the
+        # note in move_ping_logs().
+        report_dir = getattr(self, "report_path_date_time", None)
+        if not report_dir:
+            logger.warning(f"No report folder for this run; client logs stay at {source_dir}")
+            return
+
+        destination_dir = os.path.join(report_dir, "zoom_laptop_client_logs")
+        os.makedirs(report_dir, exist_ok=True)
 
         # If destination exists, merge files and remove source
         if os.path.exists(destination_dir):
@@ -369,6 +399,55 @@ class ZoomAutomation(Realm):
         else:
             shutil.move(source_dir, destination_dir)
             logger.info(f"Moved client logs folder to {destination_dir}")
+
+    def move_run_log_to_report(self):
+        """Move this run's own log file into the report folder. CLI runs only.
+
+        Skipped under --do_webUI: there the report directory is handed to us by
+        the web UI (--report_dir), so the log is left at its fixed path next to
+        the script rather than relocated into a directory the UI owns.
+
+        The log file is opened in append mode, so moving it out is also what
+        gives the next CLI run an empty one — each report folder ends up
+        holding the log of the run that produced it. Anything logged after this
+        point belongs to the same run, so the handler is re-attached at the new
+        path instead of just being closed.
+        """
+        if self.do_webui:
+            return
+
+        report_dir = getattr(self, "report_path_date_time", None)
+        if not report_dir or not os.path.isdir(report_dir):
+            # Aborted before a report was built. The log stays where it is —
+            # it is the only record of what went wrong.
+            logger.info(f"No report folder for this run; run log stays at {LOG_FILE}")
+            return
+
+        source = os.path.abspath(LOG_FILE)
+        if not os.path.isfile(source):
+            return
+
+        destination = os.path.join(report_dir, os.path.basename(source))
+
+        # Release the file before moving it: on a cross-filesystem move shutil
+        # copies and deletes, and a handler still holding the old descriptor
+        # would keep writing into the deleted inode.
+        root = logging.getLogger()
+        for handler in root.handlers[:]:
+            if getattr(handler, "baseFilename", None) == source:
+                root.removeHandler(handler)
+                handler.close()
+
+        try:
+            shutil.move(source, destination)
+        except Exception as e:
+            logger.error(f"Could not move run log to {destination}: {e}", exc_info=True)
+            destination = source  # re-attach where the log actually still is
+
+        handler = logging.FileHandler(destination, mode="a")
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        root.addHandler(handler)
+        logger.info(f"Run log: {destination}")
 
     def handle_flask_server(self):
         self.stop_previous_flask_server()
@@ -680,6 +759,11 @@ class ZoomAutomation(Realm):
                 )
 
             except Exception as e:
+                logger.error(
+                    f"/upload_csv POST failed: {e}. The Zoom dashboard CSV for this "
+                    "round was not saved.",
+                    exc_info=True,
+                )
                 return jsonify({"status": "error", "message": str(e)}), 500
 
         @self.app.route("/upload_ping_log", methods=["POST"])
@@ -718,6 +802,7 @@ class ZoomAutomation(Realm):
                     200,
                 )
             except Exception as e:
+                logger.error(f"/upload_ping_log POST failed: {e}", exc_info=True)
                 return jsonify({"status": "error", "message": str(e)}), 500
 
         @self.app.route("/upload_log", methods=["POST"])
@@ -1323,6 +1408,13 @@ class ZoomAutomation(Realm):
                 logger.error(f"Error deleting file {file_path}: {e}")
 
     def create_host(self):
+        """Create and start the host device's generic endpoint.
+
+        Returns:
+            True if the endpoint was created and started.
+            False if creation failed — the caller decides whether that aborts
+            the run or just skips this coordinate (see _handle_host_failure).
+        """
         # Reset per round so start_cx()/stop_cx()/cleanup() only ever act on
         # this coordinate's CXs/endpoints, instead of re-processing every
         # stale entry from every previous coordinate.
@@ -1336,8 +1428,11 @@ class ZoomAutomation(Realm):
         ):
             logger.info("Real client generic endpoint creation completed.")
         else:
-            logger.error("Real client generic endpoint creation failed.")
-            exit(0)
+            logger.error(
+                f"Generic endpoint creation failed for the host device "
+                f"{self.real_sta_list[0]} (os={self.real_sta_os_type[0]})."
+            )
+            return False
 
         if self.real_sta_os_type[0] == "windows":
             cmd = fr'"{self.window_dir}\zoom.bat" --ip {self.upstream_port} host'
@@ -1364,6 +1459,49 @@ class ZoomAutomation(Realm):
 
         logger.debug(f"checking real sta list {self.real_sta_list}")
         logger.debug(f"checking real sta os type {self.real_sta_os_type}")
+        return True
+
+    def _handle_host_failure(self, reason):
+        """Decide whether a host-device failure aborts the run or skips a point.
+
+        Centralises the abort-vs-skip rule so endpoint-creation failures and
+        readiness failures are treated identically.
+
+        Args:
+            reason: what failed, phrased so it reads before "on the very first
+                round ..." / "for ...".
+
+        Returns:
+            The value run() should return — False to abort the whole robo test,
+            True to skip this round and carry on with the next one. A non-robo
+            run has no next round, so it exits non-zero instead.
+        """
+        if self.do_robo:
+            # With rotations on, the same coordinate is visited at several
+            # angles — naming only the coordinate wouldn't say which round.
+            if self.rotations_enabled:
+                where = (
+                    f"coordinate {self.current_cord} at angle {self.current_angle}"
+                )
+            else:
+                where = f"coordinate {self.current_cord}"
+
+            self.failed_coords.append(self.current_cord)
+            if not self.host_ever_ready:
+                logger.error(
+                    f"{reason} on the very first round ({where}) — this points to "
+                    "a host device problem rather than a location issue. Aborting "
+                    "the robo test instead of trying the remaining coordinates."
+                )
+                return False
+            logger.error(
+                f"{reason} for {where} — skipping this round and continuing with "
+                "the next one."
+            )
+            return True
+
+        logger.error(f"{reason}. Aborting test.")
+        sys.exit(1)
 
     def wait_for_host_ready(self, timeout=600):
         """Wait for the host device to confirm login.
@@ -1518,24 +1656,12 @@ class ZoomAutomation(Realm):
         return True
 
     def run(self):
-        self.create_host()
+        if not self.create_host():
+            return self._handle_host_failure(
+                "Host device generic endpoint creation failed"
+            )
         if not self.wait_for_host_ready():
-            if self.do_robo:
-                self.failed_coords.append(self.current_cord)
-                if not self.host_ever_ready:
-                    logger.error(
-                        f"Host device failed to become ready on the very first coordinate ({self.current_cord}) — "
-                        "this points to a host device problem rather than a location issue. "
-                        "Aborting the robo test instead of trying the remaining coordinates."
-                    )
-                    return False
-                logger.error(
-                    f"Host device failed to become ready for coordinate {self.current_cord} — skipping this coordinate and continuing with the next one."
-                )
-                return True
-            else:
-                logger.error("Host device never became ready. Aborting test.")
-                sys.exit(1)
+            return self._handle_host_failure("Host device failed to become ready")
         self.host_ever_ready = True
         self.create_participants()
         if not self.wait_for_test_start():
@@ -1626,13 +1752,15 @@ class ZoomAutomation(Realm):
                         time.sleep(20)
                         self.stop_signal = False
                         self.participants_joined = 0
-                        self.create_host()
-                        if not self.wait_for_host_ready():
-                            logger.error(
-                                f"Host device failed to restart after battery pause for coordinate {self.current_cord} — skipping this round."
+                        if not self.create_host():
+                            return self._handle_host_failure(
+                                "Host device generic endpoint creation failed after "
+                                "battery pause"
                             )
-                            self.failed_coords.append(self.current_cord)
-                            return True
+                        if not self.wait_for_host_ready():
+                            return self._handle_host_failure(
+                                "Host device failed to restart after battery pause"
+                            )
                         self.create_participants()
                         if not self.wait_for_test_start():
                             logger.error(
@@ -2120,7 +2248,12 @@ class ZoomAutomation(Realm):
         # General case: "123 kbps", "45 ms", "6.7 %"
         try:
             return float(value.split()[0].replace("%", ""))
-        except Exception:
+        except Exception as e:
+            # Every expected empty/graded/avg-max form is handled above, so an
+            # unparseable value here is genuinely unrecognised. It becomes a
+            # blank cell in the report — log the raw value so that blank can be
+            # traced back to its input.
+            logger.debug(f"Could not parse stat value {value!r} as a number: {e}")
             return None
 
     def _clean_zoom_participant_name(self, participant_name):
@@ -3414,8 +3547,13 @@ class ZoomAutomation(Realm):
                 )
                 report.build_objective()
         except Exception as e:
-            logger.error(f"Exeception Occured {e}")
-            logger.error("Error Occured ", exc_info=True)
+            # This handler wraps the whole function, so the failure could be
+            # anywhere from CSV discovery to graph building — the traceback is
+            # what narrows it down.
+            logger.error(
+                f"Failed to build the band-steering report section: {e}",
+                exc_info=True,
+            )
 
     def add_live_view_images_to_report(self):
         """
@@ -4186,6 +4324,11 @@ class ZoomAutomation(Realm):
             _path=self.path,
         )
         report_path_date_time = self.report.get_path_date_time()
+        # Recorded on self like the other two report generators do: the cleanup
+        # in main()'s finally block reads it to place the client logs and the
+        # run log, and this is the only generator that runs for
+        # --do_robo --api_stats_collection.
+        self.report_path_date_time = report_path_date_time
         self.report.set_title("Zoom Call Automated Report")
         self.report.build_banner()
 
@@ -4455,7 +4598,13 @@ class ZoomAutomation(Realm):
                 with open(json_path, "r") as f:
                     try:
                         data = json.load(f)
-                    except json.JSONDecodeError:
+                    except json.JSONDecodeError as e:
+                        # Existing contents are discarded — say so, otherwise
+                        # the keys that were in this file vanish with no trace.
+                        logger.warning(
+                            f"{json_path} is not valid JSON ({e}); its existing "
+                            "contents are being discarded and the file rewritten."
+                        )
                         data = {}
 
             # 2. Update status
@@ -4513,6 +4662,11 @@ class ZoomAutomation(Realm):
 
 
 def main():
+    # Bound up front so the finally block below can always test it. It stays
+    # None whenever we leave the try before the test object is built — --help,
+    # a bad argument, a validation exit — and there is nothing to clean up.
+    zoom_automation = None
+
     try:
         parser = argparse.ArgumentParser(
             prog=__file__,
@@ -4585,7 +4739,11 @@ def main():
             help="Time set to wait for the CSV files",
         )
         parser.add_argument("--log_level", help="Level of the logs to be dispalyed")
-        parser.add_argument("--lf_logger_config_json", help="lf_logger config json")
+        parser.add_argument(
+            "--lf_logger_config_json",
+            help="Accepted for backwards compatibility but ignored; this test "
+            "logs to stdout and to lf_interop_zoom.log next to the script",
+        )
         parser.add_argument("--resources", help="resources participated in the test")
         parser.add_argument(
             "--do_webUI",
@@ -4850,15 +5008,13 @@ def main():
 
         args = parser.parse_args()
 
-        # set the logger level to debug
-        logger_config = lf_logger_config.lf_logger_config()
-
         if args.log_level:
-            logger_config.set_level(level=args.log_level)
+            logging.getLogger().setLevel(args.log_level.upper())
 
-        if args.lf_logger_config_json:
-            logger_config.lf_logger_config_json = args.lf_logger_config_json
-            logger_config.load_lf_logger_config()
+        logger.info("=" * 70)
+        logger.info("Zoom test run starting — log file: %s", LOG_FILE)
+        logger.info("Command: %s", " ".join(sys.argv))
+        logger.info("=" * 70)
 
         if (
             args.expected_passfail_value is not None
@@ -5207,7 +5363,12 @@ def main():
         logger.error(f"AN ERROR OCCURED WHILE RUNNING TEST {e}")
         traceback.print_exc()
     finally:
-        if not ("--help" in sys.argv or "-h" in sys.argv):
+        # Covers --help too: argparse exits inside parse_args(), long before
+        # the object is built. Deliberately an if rather than an early return —
+        # a return here would discard the exception on its way out, including
+        # the SystemExit carrying the exit code, turning a failed run into a
+        # silent success.
+        if zoom_automation is not None:
             zoom_automation.stop_signal = True
             logger.info("Waiting for Browser Cleanup in Laptops")
             time.sleep(10)
@@ -5224,6 +5385,9 @@ def main():
             # zoom_automation.move_ping_logs()
             zoom_automation.move_log_folder()
             logger.info("Done.")
+            # Last thing in the run — everything above is now in the log that
+            # travels with the report.
+            zoom_automation.move_run_log_to_report()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reliability work on the Zoom interop test. Before this branch, the test could
hang indefinitely, exit part-way through a robo run leaving coordinates
unvisited, or crash during teardown — and in one case exit 0 while failing.

Three themes:

- **Bound every unbounded wait**, so a stalled device or API surfaces as a
  logged failure rather than a hang.
- **Skip the failed round instead of ending the run**, so one bad coordinate,
  angle, or host no longer discards the rest of the test.
- **Fix the generic CX/endpoint lifecycle**, so rounds stop colliding with
  leftovers from prior ones.

Plus supporting changes to logging, output paths, and client log collection.

## Changes

### Hangs and unbounded waits
- `check_gen_cx()`: track how long each generic endpoint has been stuck and give
  up after `stall_timeout` instead of blocking forever
- `wait_for_host_ready()` / `wait_for_test_start()`: 600s and 3-minute bounds;
  both return True/False rather than hanging or calling `sys.exit()`
- `updating_webui_runningjson()`: waited with no deadline at all, logging once a
  second forever. The usual cause was never a slow web UI but an unset
  `--testname` making the filename unmatchable, so it now gives up after 60s and
  names the path and the `--testname` it was given
- `get_participants_qos()`: `requests` has no default timeout, so a stalled
  socket blocked forever — worse in the "live" fetch, which runs inside
  `/upload_stats` and pins a Flask worker. Each call now uses a 30s timeout, and
  the pagination walk is capped at 300s, since the loop otherwise ended only when
  Zoom stopped returning a `next_page_token` and a repeating token pages forever

### Failed rounds no longer end the run
- `monitor_endpoint_status_changes()` called `exit(1)` when no endpoint answered,
  killing the process mid-run. It now returns False, and the caller routes that
  through the abort-vs-skip rule. The check only ever proved no endpoint could be
  read — deletion and an unreachable manager look identical — so the wording no
  longer claims deletion, and teardown runs either way
- A failed rotation called a bare `sys.exit()`, ending a test with coordinates
  still to visit *and* terminating with status 0 — a failure reporting success.
  The angle is now recorded and skipped, and the log names the angle that failed
- Band-steering no longer `sys.exit()`s on an unreachable coordinate, matching
  `run_robo_test`'s existing behavior
- `_handle_host_failure` renamed `_handle_round_failure`, since it no longer
  handles only host-device failures

### Endpoint and CX lifecycle
- A generic CX's existence can't be checked with `GET /cx/{name}` — that endpoint
  only searches the L3 table and returns empty for a gen_generic CX either way,
  so every `rm_cx` was silently skipped, LANforge then refused to delete the
  endpoint its CX still owned, and the next round's `add_cx` collided. Infer the
  CX from its endpoint via `GET /generic/{name}` instead
- Pre-clean before `create_host()`/`create_participants()` to drop endpoints left
  by a run that died before its own cleanup
- `create_host()` resets `created_cx`/`created_endp` per coordinate, so
  start/stop/cleanup act only on the current round

### Paths, logging, client logs
- `self.path` and `LOG_FILE` derive from the script's directory rather than
  `os.getcwd()`. This matters because `lf_multi_traffic.py` calls `os.chdir()`,
  so a cwd-relative path could be written in one place and looked for in another
- The dashboard CSV and `zoom_api_responses` JSONs now live under `self.path`,
  which also means they follow `--report_dir` in web UI runs
- `/upload_csv` took its output filename straight from client JSON; now passed
  through `os.path.basename()`, matching `/upload_log`
- `android_zoom.py` resolved from `SCRIPT_DIR` instead of a hardcoded checkout path
- Logging configured in one place via a single `logging.basicConfig(force=True)`
  — needed because DeviceConfig calls `basicConfig()` at import time
- Fix three ways `main()`'s `finally` block could crash
- New `/upload_log` route so clients push automation logs to the host, namespaced
  by coordinate so robo rounds don't overwrite each other, archived into the
  report as `zoom_client_logs.`
- `android_zoom.py`: fail fast when Zoom is missing; write logs relative to the
  script dir; push the run log to the host on exit

## Testing

Per-commit verified CLIs are in the individual commit messages. Additionally
exercised end-to-end against three real clients — 1.134 (Windows), 1.179
(macOS), 1.233 (Windows) — in all three modes:

- **plain**: report generated, `endpoint_status_changes.csv` written, zero
  leftover endpoints or CXs
- **robo** (`P1, CHARGE`): CHARGE's host endpoint went `Stopped`; the round was
  skipped rather than aborting, and P1's data survived into the report
- **band-steering** (2 cycles): `['CHARGE','P1','CHARGE','P1']`, all visited,
  clean teardown

All three were launched from a directory outside the repo to confirm the
cwd-anchoring change. `/upload_log` and `/upload_csv` were probed with
path-traversal payloads (contained; malformed names rejected 400), and the
pagination cap was driven with a stub returning a repeating `next_page_token`.
