### PR TITLE
teams_android.py: Fix Android log path and participant tracking

### DIFF
--- a/py-scripts/real_application_tests/teams_automation/teams_android.py
+++ b/py-scripts/real_application_tests/teams_automation/teams_android.py
@@ -36,7 +36,9 @@ class TeamsAndroid:
         self.base_url = f"http://{self.upstream_port}:5005"
         self.participant_name = participant_name
 
-        os.makedirs(f"{os.getcwd()}/ms_teams_mobile_logs", exist_ok=True)
+        # Store mobile logs in a fixed location relative to this script, independent of the current working directory.
+        mobile_log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ms_teams_mobile_logs",)
+        os.makedirs(mobile_log_dir, exist_ok=True)
 
         # Configure the logging system
         logging.basicConfig(
@@ -44,7 +46,7 @@ class TeamsAndroid:
             format="%(asctime)s - %(levelname)s - %(message)s",
             handlers=[
                 logging.FileHandler(
-                    f"{os.getcwd()}/ms_teams_mobile_logs/{self.participant_name}.log",
+                    os.path.join(mobile_log_dir, f"{self.participant_name}.log"),
                     mode="w",
                 ),  # Writes to file
                 logging.StreamHandler(sys.stdout),  # Writes to terminal
@@ -280,7 +282,8 @@ class TeamsAndroid:
 
         endpoint_url = f"{self.base_url}/set_participants_joined"
         try:
-            response = requests.get(endpoint_url, timeout=5)
+            # Include the participant name so the server can identify which device joined the call.
+            response = requests.get(endpoint_url, params={"device": self.participant_name}, timeout=5)
             if response.status_code == 200:
                 self.logger.info("Device participation status updated successfully.")
             else:


### PR DESCRIPTION
- Stores Android logs relative to the script location and includes the participant name in join-status callbacks for device-specific tracking.

**Test logs:**
``` 
1785913103.064954 INFO Upstream port IP 192.168.245.233 lf_interop_teams.py 384
1785913103.119855 INFO Selected Real Devices: ['1.109.wlan0', '1.113.wlan0', '1.153.en0', '1.156.wlan0', '1.18.wlan0'] lf_interop_teams.py 2263
1785913103.130436 INFO Running Json file found lf_interop_teams.py 311
1785913103.131680 INFO Checking for processes using port 5005 to forcefully kill them... lf_interop_teams.py 1071
1785913103.197612 INFO No process found using port 5005 on Linux. lf_interop_teams.py 1091
1785913103.197817 INFO Port 5005 is clear, ready to start Flask server. lf_interop_teams.py 1092
* Serving Flask app 'lf_interop_teams'
* Debug mode: on
1785913109.219085 INFO Flask server is up and running! lf_interop_teams.py 346
1785913111.395941 INFO {'alias': 'CX_teams-1.109.wlan0',
'test_mgr': 'default_tm',
'tx_endp': 'teams-1.109.wlan0'} gen_cxprofile.py 454
1785913112.187478 INFO Real client generic endpoint creation completed. lf_interop_teams.py 490
1785913112.230582 INFO Starting CXs: ['CX_teams-1.109.wlan0'] gen_cxprofile.py 129
1785913112.230856 INFO Created-Endp: ['teams-1.109.wlan0'] gen_cxprofile.py 130
1785913200.970562 INFO Meeting Link Updated: https://teams.microsoft.com/meet/483935294718547?p=wbyVKIHZwCKDg9FE5Z lf_interop_teams.py 2417
1785913207.416936 INFO Host login is complete and CX endpoint 'teams-1.109.wlan0' is available. Proceeding with participant creation. lf_interop_teams.py 595
1785913209.598022 INFO {'alias': 'CX_teams-1.113.wlan0',
'test_mgr': 'default_tm',
'tx_endp': 'teams-1.113.wlan0'} gen_cxprofile.py 454
1785913212.437949 INFO {'alias': 'CX_teams-1.153.en0',
'test_mgr': 'default_tm',
'tx_endp': 'teams-1.153.en0'} gen_cxprofile.py 454
1785913215.249314 INFO {'alias': 'CX_teams-1.156.wlan0',
'test_mgr': 'default_tm',
'tx_endp': 'teams-1.156.wlan0'} gen_cxprofile.py 454
1785913217.457702 INFO sending running state to.. CX_teams-1.113.wlan0 lf_interop_teams.py 828
1785913217.541815 INFO sending running state to.. CX_teams-1.153.en0 lf_interop_teams.py 828
1785913217.666896 INFO sending running state to.. CX_teams-1.156.wlan0 lf_interop_teams.py 828
1785913217.710294 INFO sending running state to.. CX_generic-teams-1_18_wlan0 lf_interop_teams.py 828
1785913217.730327 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913222.741169 INFO Endpoint 'teams-1.156.wlan0' status changed to 'Run'. lf_interop_teams.py 1830
1785913222.759012 INFO Endpoint 'teams-1.113.wlan0' status changed to 'Run'. lf_interop_teams.py 1830
1785913222.765051 INFO Endpoint 'teams-1_18_wlan0' status changed to 'Run'. lf_interop_teams.py 1830
1785913222.765421 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913227.783456 INFO Endpoint 'teams-1.153.en0' status changed to 'Stopped'. lf_interop_teams.py 1830
1785913227.792364 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913232.819627 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913237.838644 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913242.854271 INFO Endpoint 'teams-1_18_wlan0' status changed to 'Stopped'. lf_interop_teams.py 1830
1785913242.854496 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913247.874957 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913252.904467 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913257.996883 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913263.018807 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913268.038619 INFO Waiting for all participants to join the call. Joined: 1, Expected: 5 lf_interop_teams.py 1204
1785913273.055612 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913278.067239 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913283.083986 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913288.103307 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913293.125824 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913298.162722 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913303.251696 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913308.288717 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913313.318050 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913318.335989 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913323.355721 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913328.378601 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913333.395103 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913338.419776 INFO Waiting for all participants to join the call. Joined: 3, Expected: 5 lf_interop_teams.py 1204
1785913343.426698 WARNING Proceeding with the test with the participants that have joined. Joined: 3, Expected: 5 lf_interop_teams.py 1210
1785913343.427055 WARNING Devices that did not join the call: ['lanforges-Air.ctinb.candelatech', 'kvm-slave-build-s-system-071096'] lf_interop_teams.py 1218
1785913343.427473 INFO TEST WILL BE STARTING lf_interop_teams.py 1233
1785913554.742866 INFO Log file uploaded from user-HP-ProBook-445R-G6 and saved as user-HP-ProBook-445R-G6.log lf_interop_teams.py 2723
1785913557.352551 INFO Log file uploaded from DESKTOP-0P0OM22 and saved as DESKTOP-0P0OM22.log lf_interop_teams.py 2723
1785913560.211183 INFO Endpoint 'teams-1.109.wlan0' status changed to 'Stopped'. lf_interop_teams.py 1830
1785913560.444192 INFO Log file uploaded from DESKTOP-F0HLI17 and saved as DESKTOP-F0HLI17.log lf_interop_teams.py 2723
1785913565.227134 INFO Endpoint 'teams-1.156.wlan0' status changed to 'Stopped'. lf_interop_teams.py 1830
1785913565.245349 INFO Endpoint 'teams-1.113.wlan0' status changed to 'Stopped'. lf_interop_teams.py 1830
1785913565.252147 INFO Monitoring Duration: 3m 41s lf_interop_teams.py 837
1785913585.271669 INFO Creating average data for all devices lf_interop_teams.py 2820
1785913585.313666 INFO Avg data saved to /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/teams_call_avg_data.csv lf_interop_teams.py 2847
1785913585.314203 INFO Updated running_status.json with status Completed at /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/running_status.json lf_interop_teams.py 2883
1785913585.314390 INFO path set: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10 lf_report.py 85
1785913585.314641 INFO path_date_time /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report lf_report.py 239
1785913585.314828 INFO report path : /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report lf_report.py 248
1785913585.921829 INFO graph_src_file: Audio_RTT_(ms).png lf_report.py 212
1785913585.921990 INFO graph_dst_file: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/Audio_RTT_(ms).png lf_report.py 213
1785913586.205469 INFO graph_src_file: Received_Audio_Jitter_(ms).png lf_report.py 212
1785913586.205650 INFO graph_dst_file: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/Received_Audio_Jitter_(ms).png lf_report.py 213
1785913586.503576 INFO graph_src_file: Sent_Audio_Bitrate_(Kbps).png lf_report.py 212
1785913586.503779 INFO graph_dst_file: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/Sent_Audio_Bitrate_(Kbps).png lf_report.py 213
1785913586.945010 INFO graph_src_file: Sent_Video_Bitrate_(Mbps).png lf_report.py 212
1785913586.945247 INFO graph_dst_file: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/Sent_Video_Bitrate_(Mbps).png lf_report.py 213
1785913587.392608 INFO graph_src_file: Received_Video_Bitrate_(Mbps).png lf_report.py 212
1785913587.392896 INFO graph_dst_file: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/Received_Video_Bitrate_(Mbps).png lf_report.py 213
1785913587.799878 INFO graph_src_file: Sent_Video_Packets.png lf_report.py 212
1785913587.800075 INFO graph_dst_file: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/Sent_Video_Packets.png lf_report.py 213
1785913587.816669 INFO write_output_html: /home/lanforge/Desktop/Nikhita/UI/interop-webGUI/results/teams_10/2026-08-05-12-36-25_teams_call_report/teams_call_report.html lf_report.py 368
1785913588.903318 INFO Waiting for Browser Cleanup at Client Side lf_interop_teams.py 3169