### PR TITLE
Added Logging and Enhancements in test_l3

### DIFF
--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1910,12 +1910,7 @@ class L3VariableTime(Realm):
         for endp_name in endpoint:
             logger.debug("endpoint: {}".format(endp_name))
             for item, endp_value in endp_name.items():
-                # multicast does not support use existing: or self.use_existing_station_lists:
                 if item in our_endps:
-                    # endps.append(endp_value) need to see how to affect
-                    # NOTE: during each monitor period the rates are added to get the totals
-                    # this is done so that if there is an issue the rate information will be in
-                    # the csv for the individual polling period
                     logger.debug(
                         "multicast endpoint: {item} value:\n".format(item=item))
                     logger.debug(endp_value)
@@ -1925,21 +1920,16 @@ class L3VariableTime(Realm):
                                 'Expected integer response for rx rate, received non-numeric string instead. Replacing with 0')
                             value = 0
                         if value_name == 'rx rate':
-                            # This hack breaks for mcast or if someone names endpoints weirdly.
-                            # logger.info("item: ", item, " rx-bps: ", value_rx_bps)
                             if "-mrx-" in item:
                                 total_dl += int(value)
                             else:
                                 total_ul += int(value)
                         if value_name == 'rx rate ll':
-                            # This hack breaks for mcast or if someone
-                            # names endpoints weirdly.
                             if "-mrx-" in item:
                                 total_dl_ll += int(value)
                             else:
                                 total_ul_ll += int(value)
 
-                        # TODO need a way to report rates
         # Unicast endpoints
         for e in self.cx_profile.created_endp.keys():
             our_endps[e] = e
@@ -1967,8 +1957,6 @@ class L3VariableTime(Realm):
                                 logging.debug(
                                     'Expected integer response for rx rate, received non-numeric string instead. Replacing with 0')
                                 value = 0
-                            # This hack breaks for mcast or if someone names endpoints weirdly.
-                            # logger.info("item: ", item, " rx-bps: ", value_rx_bps)
                             if item.endswith("-A"):
                                 total_dl += int(value)
                             elif item.endswith("-B"):
@@ -1978,8 +1966,6 @@ class L3VariableTime(Realm):
                                 logging.debug(
                                     'Expected integer response for rx rate ll, received non-numeric string instead. Replacing with 0')
                                 value = 0
-                            # This hack breaks for mcast or if someone
-                            # names endpoints weirdly.
                             if item.endswith("-A"):
                                 total_dl_ll += int(value)
                             elif item.endswith("-B"):
@@ -7861,6 +7847,7 @@ class L3VariableTime(Realm):
                 report.build_custom()
 
     def append_cx_data(self, is_cx, name, state):
+        """Append an endpoint/CX state change to client_issue_csv_name."""
         file_exists = os.path.isfile(self.client_issue_csv_name)
 
         with open(self.client_issue_csv_name, "a", newline="") as file:
@@ -7879,6 +7866,7 @@ class L3VariableTime(Realm):
             ])
 
     def check_endpoint_availability(self, expected_endps, present_endps, endp_list):
+        """Log endpoint missing/not-running/recovered transitions and update the tracking sets."""
         for endp_name in expected_endps:
             if endp_name not in present_endps.keys():
                 if endp_name not in self.missing_endp_logged:
@@ -7909,6 +7897,7 @@ class L3VariableTime(Realm):
                 self.not_running_endp_logged.discard(endp_name)
 
     def is_test_stopped_by_webgui(self):
+        """Check the webgui running-instance file to see if the user stopped the test."""
         if not self.dowebgui:
             return False
         running_file = f"{self.result_dir}/../../Running_instances/{self.ip}_{self.test_name}_running.json"
@@ -7931,6 +7920,7 @@ class L3VariableTime(Realm):
         return False
 
     def monitor_endp_availability(self, expected_endps, return_endpoint_data=False, duration=40, interval=5):
+        """Retry for up to duration seconds until at least one expected endpoint is present and running."""
         start_time = time.time()
         end_time = start_time + duration
         no_of_attempts = duration // interval
@@ -7951,9 +7941,6 @@ class L3VariableTime(Realm):
                     f"Requested URL: '{endp_url}'\n"
                     f"Response: {endp_list}")
                 endp_list = {}
-                # time.sleep(interval)
-                # start_time = time.time()
-                # continue
             endpoint = endp_list.get('endpoint', [])
             if isinstance(endpoint, dict):
                 endpoint = [{endpoint['name']: endpoint}]
@@ -7995,6 +7982,7 @@ class L3VariableTime(Realm):
         return [] if return_endpoint_data else False
 
     def check_cx_availability(self, expected_cxs, present_cxs, cx_list):
+        """Log CX missing/not-running/recovered transitions and update the tracking sets."""
         for cx_name in expected_cxs:
             if cx_name not in present_cxs.keys():
                 if cx_name not in self.missing_cx_logged:
@@ -8025,6 +8013,7 @@ class L3VariableTime(Realm):
                 self.not_running_cx_logged.discard(cx_name)
 
     def monitor_cx_availability(self, expected_cxs, duration=40, interval=5):
+        """Retry for up to duration seconds until at least one expected cross-connect is present and running."""
         start_time = time.time()
         end_time = start_time + duration
         no_of_attempts = duration // interval
@@ -8068,6 +8057,7 @@ class L3VariableTime(Realm):
         return False
 
     def format_duration(self, td):
+        """Convert a timedelta into a readable duration string, e.g. "1 hour 5 minutes"."""
         total_seconds = int(td.total_seconds())
 
         days, remainder = divmod(total_seconds, 86400)

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -981,6 +981,7 @@ class L3VariableTime(Realm):
                                                   "client_issue.csv")
         self.need_endps_stopped = False
         self.actual_test_duration_display = None
+        self.bandsteering_start_time = None
         self.csv_started = False
         self.epoch_time = int(time.time())
         self.debug = debug
@@ -2447,8 +2448,12 @@ class L3VariableTime(Realm):
             logger.info("Exiting test")
             exit(1)
         self.robot_obj.do_bandsteering = True
-        ul, dl, ul_pdu_str, dl_pdu_str, atten_val, ul_pdu, dl_pdu, passes, expected_passes, coordinate, rotation = self.start()
-        logger.info("Starting CXs")
+        available, ul, dl, ul_pdu_str, dl_pdu_str, atten_val, ul_pdu, dl_pdu, passes, expected_passes, coordinate, rotation = self.start()
+        if not available:
+            logger.warning("Endpoint data not available, so not going to monitor and skipping band steering test.")
+            return 0
+        # the bandsteering_start_time is used to calculate the actual test duration as we call the monitor multiple times unlike others
+        self.bandsteering_start_time = datetime.datetime.now()
         for coordinate in cycle_coords:
             if test_stopped_by_user:
                 break
@@ -2457,14 +2462,22 @@ class L3VariableTime(Realm):
             # If test is stopped by user during battery wait
             if test_stopped_by_user:
                 break
+            if self.need_endps_stopped:
+                logger.info("Required endpoints stopped, exiting band steering test ...")
+                self.actual_test_duration_display = self.format_duration(datetime.datetime.now() - self.bandsteering_start_time)
+                break
             robo_moved, abort, test_data = self.robot_obj.move_to_coordinate(coordinate, monitor_function=lambda: self.monitor(ul, dl, ul_pdu_str, dl_pdu_str, atten_val, coordinate, rotation))
+            if robo_moved:
+                logger.info("Reached the coordinate {}".format(coordinate))
             # If robot failed to reach the coordinate
             if abort:
                 break
+            if self.need_endps_stopped:
+                logger.info("Required endpoints stopped, exiting band steering test ...")
+                self.actual_test_duration_display = self.format_duration(datetime.datetime.now() - self.bandsteering_start_time)
+                break
             if not robo_moved:
                 continue
-            if robo_moved:
-                logger.info("Reached the coordinate {}".format(coordinate))
         self.process_port_interval_statistics(self.total_dl_bps, self.total_ul_bps, self.total_dl_ll_bps, self.total_ul_ll_bps,
                                               ul, dl, ul_pdu_str, dl_pdu_str, ul_pdu, dl_pdu, atten_val, passes, expected_passes)
         # total_dl_bps,total_ul_bps,total_dl_ll

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1472,6 +1472,7 @@ class L3VariableTime(Realm):
                 json.dump({}, file)
 
             # self.robot_obj.robo_ip = f"{self.robo_ip}" # Fake Server Testing
+            self.robot_obj.ip = self.ip
             self.robot_obj.nav_data_path = nav_data
             self.robot_obj.result_directory = os.path.dirname(nav_data)
             self.robot_obj.runtime_dir = self.result_dir

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -2945,11 +2945,14 @@ class L3VariableTime(Realm):
                     passes = 0
                     expected_passes = 0
                     logger.info("Getting initial values.")
-                    self.__get_rx_values()
+                    available = self.__get_rx_values()[0]
                     self.overall = []
                     # monitor stats
                     if self.do_bandsteering:
-                        return ul, dl, ul_pdu_str, dl_pdu_str, atten_val, ul_pdu, dl_pdu, passes, expected_passes, coordinate, rotation
+                        return available, ul, dl, ul_pdu_str, dl_pdu_str, atten_val, ul_pdu, dl_pdu, passes, expected_passes, coordinate, rotation
+                    if not available:
+                        logger.warning("Endpoint data not available, skipping monitoring.")
+                        continue
                     total_dl_bps, total_ul_bps, total_dl_ll_bps, total_ul_ll_bps = self.monitor(ul, dl, ul_pdu_str, dl_pdu_str, atten_val, coordinate, rotation)
                     self.process_port_interval_statistics(total_dl_bps, total_ul_bps, total_dl_ll_bps, total_ul_ll_bps, ul, dl,
                                                           ul_pdu_str, dl_pdu_str, ul_pdu, dl_pdu, atten_val, passes, expected_passes)

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -2239,13 +2239,25 @@ class L3VariableTime(Realm):
                 "summary": {},
             }
 
-        endp_data = self.json_get(
-            "endp/all?fields=name,tx+rate,rx+rate,rx+bytes,a/b,tos,eid,type,rx+drop+%25"
-        )
+        url = "/endp/all?fields=name,tx+rate,rx+rate,rx+bytes,a/b,tos,eid,type,rx+drop+%25"
+        endp_data = self.json_get(url, debug_=True)
         endpoints = {}
 
-        if endp_data and "endpoint" in endp_data:
-            for endp_item in endp_data["endpoint"]:
+        if endp_data is None:
+            logger.error(
+                "Failed to fetch endpoint data. Received empty response.\n"
+                f"Requested URL: '{url}'\n"
+                f"Response: {endp_data}")
+        elif "endpoint" not in endp_data:
+            logger.error(
+                "'endpoint' key not found in response.\n"
+                f"Requested URL: '{url}'\n"
+                f"Response: {endp_data}")
+        else:
+            endpoint_list = endp_data["endpoint"]
+            if isinstance(endpoint_list, dict):
+                endpoint_list = [{endpoint_list['name']: endpoint_list}]
+            for endp_item in endpoint_list:
                 for name, info in endp_item.items():
                     endpoints[name] = info
 
@@ -2500,13 +2512,27 @@ class L3VariableTime(Realm):
             dict: Collected client data for the given TOS, including clients,
                 uplink/downlink rates, resource aliases, and port signals.
         """
-        port_data = self.json_get('port/all?fields=signal,signal')
+        port_url = 'port/all?fields=signal,signal'
+        port_data = self.json_get(port_url, debug_=True)
+        if not port_data:
+            logger.error(
+                "Failed to fetch port data. Received empty response.\n"
+                f"Requested URL: '{port_url}'\n"
+                f"Response: {port_data}")
+            port_data = {}
         port_data.pop("handler", None)
         port_data.pop("uri", None)
         port_data.pop("warnings", None)
 
         # Gather resource data (only need hostname for alias)
-        resource_data = self.json_get('resource/all?fields=eid,hostname')
+        resource_url = 'resource/all?fields=eid,hostname'
+        resource_data = self.json_get(resource_url, debug_=True)
+        if not resource_data:
+            logger.error(
+                "Failed to fetch resource data. Received empty response.\n"
+                f"Requested URL: '{resource_url}'\n"
+                f"Response: {resource_data}")
+            resource_data = {}
         resource_data.pop("handler", None)
         resource_data.pop("uri", None)
         if not self.dowebgui:
@@ -2519,14 +2545,22 @@ class L3VariableTime(Realm):
 
         # Gather endpoint data (name, tx/rx rate, a/b, tos, eid, type)
         endp_type_present = False
-        endp_data = self.json_get('endp/all?fields=name,tx+rate,rx+rate,a/b,tos,eid,type')
+        endp_url = 'endp/all?fields=name,tx+rate,rx+rate,a/b,tos,eid,type'
+        endp_data = self.json_get(endp_url, debug_=True)
         if endp_data is not None:
             endp_type_present = True
         else:
             logger.info(
                 "Consider upgrading to 5.4.7 + endp field type not supported in LANforge GUI version results for Multicast reversed in graphs and tables")
-            endp_data = self.json_get('endp/all?fields=name,tx+rate,rx+rate,a/b,eid')
+            endp_url = 'endp/all?fields=name,tx+rate,rx+rate,a/b,eid'
+            endp_data = self.json_get(endp_url, debug_=True)
             endp_type_present = False
+        if not endp_data:
+            logger.error(
+                "Failed to fetch endpoint data. Received empty response.\n"
+                f"Requested URL: '{endp_url}'\n"
+                f"Response: {endp_data}")
+            endp_data = {}
         endp_data.pop("handler", None)
         endp_data.pop("uri", None)
 
@@ -2543,7 +2577,11 @@ class L3VariableTime(Realm):
         resource_alias_B = []
         port_signal_B = []
 
-        for endp in endp_data['endpoint']:
+        endpoint = endp_data.get('endpoint', [])
+        if isinstance(endpoint, dict):
+            endp_data['endpoint'] = [{endpoint['name']: endpoint}]
+
+        for endp in endp_data.get('endpoint', []):
             endp_key = list(endp.keys())[0]
             endp_info = endp[endp_key]
 
@@ -2555,7 +2593,7 @@ class L3VariableTime(Realm):
                 # Resource lookup (for alias)
                 eid_tmp_resource = f"{self.name_to_eid(endp_info['eid'])[0]}.{self.name_to_eid(endp_info['eid'])[1]}"
                 alias = 'NA'
-                for res in resource_data['resources']:
+                for res in resource_data.get('resources', []):
                     res_key = list(res.keys())[0]
                     if res_key == eid_tmp_resource:
                         # resource_found = True
@@ -2570,7 +2608,7 @@ class L3VariableTime(Realm):
                 eid_info = endp_info['name'].split('-')
                 eid_tmp_port = f"{eid_tmp_resource}.{eid_info[3 if endp_type_present and endp_info['type'] == 'Mcast' else 1]}"
                 signal = 'NA'
-                for port in port_data['interfaces']:
+                for port in port_data.get('interfaces', []):
                     port_key = list(port.keys())[0]
                     if port_key == eid_tmp_port:
                         signal = port[port_key]['signal']
@@ -3199,22 +3237,21 @@ class L3VariableTime(Realm):
                                               eid[1], eid[2])
 
                     # read LANforge to get the mac
-                    response = self.json_get(url)
-                    if (response is None) or ("interface" not in response):
-                        logger.info(
-                            "query-port: %s: incomplete response:" % url)
-                        logger.info(pformat(response))
+                    response = self.json_get(url, debug_=True)
+                    if response is None:
+                        logger.error(
+                            "Failed to fetch port data. Received empty response.\n"
+                            f"Requested URL: '{url}'\n"
+                            f"Response: {response}")
+                        continue
+                    elif "interface" not in response:
+                        logger.error(
+                            "'interface' key not found in response.\n"
+                            f"Requested URL: '{url}'\n"
+                            f"Response: {response}")
+                        continue
                     else:
-                        if not self.dowebgui:
-                            # print("response".format(response))
-                            logger.info(pformat(response))
                         port_data = response['interface']
-                        logger.info(
-                            "From LANforge: port_data, response['insterface']:{}".format(port_data))
-                        mac = port_data['mac']
-                        if not self.dowebgui:
-                            logger.info(
-                                "From LANforge: port_data, response['insterface']:{}".format(port_data))
                         mac = port_data['mac']
                         logger.debug("mac : {mac}".format(mac=mac))
 
@@ -3229,76 +3266,76 @@ class L3VariableTime(Realm):
                         self.get_endp_stats_for_port(
                             port_data["port"], endps)
 
-                    if tx_dl_mac_found:
-                        if not self.dowebgui:
-                            logger.info("mac {mac} ap_row_tx_dl {ap_row_tx_dl}".format(
-                                mac=mac, ap_row_tx_dl=ap_row_tx_dl))
-                        # Find latency, jitter for connections
-                        # using this port.
-                        (latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll,
-                            dl_rx_drop_percent, total_ul_rate, total_ul_rate_ll,
-                            total_ul_pkts_ll, ul_rx_drop_percent) = self.get_endp_stats_for_port(
-                            port_data["port"], endps)
+                        if tx_dl_mac_found:
+                            if not self.dowebgui:
+                                logger.info("mac {mac} ap_row_tx_dl {ap_row_tx_dl}".format(
+                                    mac=mac, ap_row_tx_dl=ap_row_tx_dl))
+                            # Find latency, jitter for connections
+                            # using this port.
+                            (latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll,
+                                dl_rx_drop_percent, total_ul_rate, total_ul_rate_ll,
+                                total_ul_pkts_ll, ul_rx_drop_percent) = self.get_endp_stats_for_port(
+                                port_data["port"], endps)
 
-                        ap_row_tx_dl.append(ap_row_chanim)
+                            ap_row_tx_dl.append(ap_row_chanim)
 
-                        if self.do_bandsteering:
-                            robot_x, robot_y, from_coordinate, to_coordinate = self.robot_obj.get_robot_pose()
-                            bandsteering_data = [robot_x, robot_y, from_coordinate, to_coordinate]
+                            if self.do_bandsteering:
+                                robot_x, robot_y, from_coordinate, to_coordinate = self.robot_obj.get_robot_pose()
+                                bandsteering_data = [robot_x, robot_y, from_coordinate, to_coordinate]
 
-                        self.write_dl_port_csv(
-                            len(self.station_names_list),
-                            ul,
-                            dl,
-                            ul_pdu_str,
-                            dl_pdu_str,
-                            atten_val,
-                            port_eid,
-                            port_data,
-                            latency,
-                            jitter,
-                            total_ul_rate,
-                            total_ul_rate_ll,
-                            total_ul_pkts_ll,
-                            ul_rx_drop_percent,
-                            total_dl_rate,
-                            total_dl_rate_ll,
-                            total_dl_pkts_ll,
-                            dl_rx_drop_percent,
-                            ap_row_tx_dl,
-                            bandsteering_data=bandsteering_data)  # this is where the AP data is added
+                            self.write_dl_port_csv(
+                                len(self.station_names_list),
+                                ul,
+                                dl,
+                                ul_pdu_str,
+                                dl_pdu_str,
+                                atten_val,
+                                port_eid,
+                                port_data,
+                                latency,
+                                jitter,
+                                total_ul_rate,
+                                total_ul_rate_ll,
+                                total_ul_pkts_ll,
+                                ul_rx_drop_percent,
+                                total_dl_rate,
+                                total_dl_rate_ll,
+                                total_dl_pkts_ll,
+                                dl_rx_drop_percent,
+                                ap_row_tx_dl,
+                                bandsteering_data=bandsteering_data)  # this is where the AP data is added
 
-                        # now report the ap_chanim_stats
+                            # now report the ap_chanim_stats
 
-                    if rx_ul_mac_found:
-                        # Find latency, jitter for connections
-                        # using this port.
-                        # latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll, dl_rx_drop_percent, total_ul_rate,
-                        # total_ul_rate_ll, total_ul_pkts_ll, ul_tx_drop_percent = self.get_endp_stats_for_port(
-                        #    port_data["port"], endps)
-                        self.write_ul_port_csv(
-                            len(self.station_names_list),
-                            ul,
-                            dl,
-                            ul_pdu_str,
-                            dl_pdu_str,
-                            atten_val,
-                            port_eid,
-                            port_data,
-                            latency,
-                            jitter,
-                            total_ul_rate,
-                            total_ul_rate_ll,
-                            total_ul_pkts_ll,
-                            ul_rx_drop_percent,
-                            total_dl_rate,
-                            total_dl_rate_ll,
-                            total_dl_pkts_ll,
-                            dl_rx_drop_percent,
-                            ap_row_rx_ul)  # ap_ul_row added
-                    if not self.dowebgui:
-                        logger.info("ap_row_rx_ul {ap_row_rx_ul}".format(
-                            ap_row_rx_ul=ap_row_rx_ul))
+                            if rx_ul_mac_found:
+                                # Find latency, jitter for connections
+                                # using this port.
+                                # latency, jitter, total_dl_rate, total_dl_rate_ll, total_dl_pkts_ll, dl_rx_drop_percent, total_ul_rate,
+                                # total_ul_rate_ll, total_ul_pkts_ll, ul_tx_drop_percent = self.get_endp_stats_for_port(
+                                #    port_data["port"], endps)
+                                self.write_ul_port_csv(
+                                    len(self.station_names_list),
+                                    ul,
+                                    dl,
+                                    ul_pdu_str,
+                                    dl_pdu_str,
+                                    atten_val,
+                                    port_eid,
+                                    port_data,
+                                    latency,
+                                    jitter,
+                                    total_ul_rate,
+                                    total_ul_rate_ll,
+                                    total_ul_pkts_ll,
+                                    ul_rx_drop_percent,
+                                    total_dl_rate,
+                                    total_dl_rate_ll,
+                                    total_dl_pkts_ll,
+                                    dl_rx_drop_percent,
+                                    ap_row_rx_ul)  # ap_ul_row added
+                                if not self.dowebgui:
+                                    logger.info("ap_row_rx_ul {ap_row_rx_ul}".format(
+                                        ap_row_rx_ul=ap_row_rx_ul))
 
             ####################################
             else:
@@ -3313,12 +3350,17 @@ class L3VariableTime(Realm):
                     eid = self.name_to_eid(port_eid)
                     url = "/port/%s/%s/%s" % (eid[0],
                                               eid[1], eid[2])
-                    response = self.json_get(url)
-                    if (response is None) or (
-                            "interface" not in response):
-                        logger.info(
-                            "query-port: %s: incomplete response:" % url)
-                        logger.debug(pformat(response))
+                    response = self.json_get(url, debug_=True)
+                    if response is None:
+                        logger.error(
+                            "Failed to fetch port information. Received empty response.\n"
+                            f"Requested URL: '{url}'\n"
+                            f"Response: {response}")
+                    elif "interface" not in response:
+                        logger.error(
+                            "'interface' key not found in response.\n"
+                            f"Requested URL: '{url}'\n"
+                            f"Response: {pformat(response)}")
                     else:
                         port_data = response['interface']
                         (latency, jitter, total_dl_rate, total_dl_rate_ll,
@@ -3629,44 +3671,68 @@ class L3VariableTime(Realm):
 
         # gather port data
         # TODO
-        self.port_data = self.json_get('port/all?fields=alias,port,mac,channel,ssid,mode,bps+rx,rx-rate,bps+tx,tx-rate')
-        # self.port_data = self.json_get('port/all')
-        self.port_data.pop("handler")
-        self.port_data.pop("uri")
-        self.port_data.pop("warnings")
-        logger.info("self.port_data type: {dtype} data: {data}".format(dtype=type(self.port_data), data=self.port_data))
+        url = 'port/all?fields=alias,port,mac,channel,ssid,mode,bps+rx,rx-rate,bps+tx,tx-rate'
+        self.port_data = self.json_get(url, debug_=True)
+        if self.port_data is None:
+            logger.error(
+                "Failed to fetch port data. Received empty response.\n"
+                f"Requested URL: '{url}'\n"
+                f"Response: {self.port_data}")
+            self.port_data = {}
+        else:
+            self.port_data.pop("handler", None)
+            self.port_data.pop("uri", None)
+            self.port_data.pop("warnings", None)
+            logger.info("self.port_data type: {dtype} data: {data}".format(dtype=type(self.port_data), data=self.port_data))
 
-        self.resource_data = self.json_get('resource/all?fields=eid,hostname,hw+version,kernel')
+        url = "/resource/all?fields=eid,hostname,hw+version,kernel"
+        self.resource_data = self.json_get(url, debug_=True)
+
+        if self.resource_data is None:
+            logger.error(
+                "Failed to fetch resource data. Received empty response.\n"
+                f"Requested URL: '{url}'\n"
+                f"Response: {self.resource_data}")
+            self.resource_data = {}
+        else:
+            self.resource_data.pop("handler", None)
+            self.resource_data.pop("uri", None)
+            # self.resource_data.pop("warnings")
+            # This is to handle the case where there is only one resourse
+            if "resource" in self.resource_data.keys():
+                self.resource_data["resources"] = [{'1.1': self.resource_data['resource']}]
+                self.resource_data.pop("resource")
+
         # self.resource_data = self.json_get('resource/all')
-        self.resource_data.pop("handler")
-        self.resource_data.pop("uri")
-        # self.resource_data.pop("warnings")
+
         if not self.dowebgui:
             logger.info("self.resource_data type: {dtype}".format(dtype=type(self.port_data)))
         # logger.info("self.resource_data : {data}".format(data=self.port_data))
-
-        # This is to handle the case where there is only one resourse
-        if "resource" in self.resource_data.keys():
-            self.resource_data["resources"] = [{'1.1': self.resource_data['resource']}]
-            self.resource_data.pop("resource")
 
         # Note will type will only work for 5.4.7
         # gather endp data
         endp_type_present = False
 
         # TODO check for 400 bad request instead of try except
-        self.endp_data = self.json_get(
-            'endp/all?fields=name,tx+rate+ll,tx+rate,rx+rate+ll,rx+rate,a/b,tos,eid,type,rx Drop %25')
+        url = "/endp/all?fields=name,tx+rate+ll,tx+rate,rx+rate+ll,rx+rate,a/b,tos,eid,type,rx Drop %25"
+        self.endp_data = self.json_get(url, debug_=True)
         if self.endp_data is not None:
             endp_type_present = True
         else:
             logger.info(
                 "Consider upgrading to 5.4.7 + endp field type not supported in LANforge GUI version results for Multicast reversed in graphs and tables")
-            self.endp_data = self.json_get(
-                'endp/all?fields=name,tx+rate+ll,tx+rate,rx+rate+ll,rx+rate,a/b,eid,rx Drop %25')
-            endp_type_present = False
-        self.endp_data.pop("handler")
-        self.endp_data.pop("uri")
+            url = "/endp/all?fields=name,tx+rate+ll,tx+rate,rx+rate+ll,rx+rate,a/b,eid,rx Drop %25"
+            self.endp_data = self.json_get(url, debug_=True)
+        if not self.endp_data:
+            logger.error(
+                "Failed to fetch endpoint data. Received empty response.\n"
+                f"Requested URL: '{url}'\n"
+                f"Response: {self.endp_data}")
+            self.endp_data = {}
+        else:
+            self.endp_data.pop("handler", None)
+            self.endp_data.pop("uri", None)
+
         logger.info("self.endpoint_data type: {dtype} data: {data}".format(
             dtype=type(self.endp_data), data=self.endp_data))
         # self.side_b_min_bps= str(str(int(self.cx_profile.side_b_min_bps) / 1000000) +' '+'Mbps')
@@ -3674,8 +3740,11 @@ class L3VariableTime(Realm):
 
         self.side_b_min_bps = self.cx_profile.side_b_min_bps
         self.side_a_min_bps = self.cx_profile.side_a_min_bps
-
-        for endp_data in self.endp_data['endpoint']:
+        endpoint = self.endp_data.get('endpoint', [])
+        if isinstance(endpoint, dict):
+            logger.info("endpoint is a dict, converting to list")
+            self.endp_data['endpoint'] = [{endpoint['name']: endpoint}]
+        for endp_data in self.endp_data.get('endpoint', []):
             logger.info("endp_data type {endp_type} endp_data {endp_data}".format(
                 endp_type=type(endp_data), endp_data=endp_data))
             # The dictionary only has one key
@@ -3711,7 +3780,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -3740,7 +3809,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -3777,7 +3846,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -3807,7 +3876,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -3846,7 +3915,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -3876,7 +3945,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -3913,7 +3982,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -3943,7 +4012,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -3982,7 +4051,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4012,7 +4081,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4049,7 +4118,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4079,7 +4148,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4118,7 +4187,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4148,7 +4217,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4185,7 +4254,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4215,7 +4284,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4257,7 +4326,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4286,7 +4355,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4323,7 +4392,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4353,7 +4422,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4393,7 +4462,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4423,7 +4492,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4460,7 +4529,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4491,7 +4560,7 @@ class L3VariableTime(Realm):
                             port_found = False
                             self.be_port_eid_B.append(eid_tmp_port)
 
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4529,7 +4598,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4559,7 +4628,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4596,7 +4665,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4625,7 +4694,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4664,7 +4733,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4693,7 +4762,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4730,7 +4799,7 @@ class L3VariableTime(Realm):
                             # look up the resource may need to have try except to handle cases where
                             # there is an issue getting data
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4760,7 +4829,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4802,7 +4871,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4832,7 +4901,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -4870,7 +4939,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4899,7 +4968,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -4937,7 +5006,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -4966,7 +5035,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5003,7 +5072,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5033,7 +5102,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -5072,7 +5141,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5102,7 +5171,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5140,7 +5209,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5170,7 +5239,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -5209,7 +5278,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5238,7 +5307,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5275,7 +5344,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5305,7 +5374,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -5345,7 +5414,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5375,7 +5444,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5411,7 +5480,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5440,7 +5509,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.bk_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.bk_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -5479,7 +5548,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5508,7 +5577,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5544,7 +5613,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5574,7 +5643,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.be_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.be_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -5611,7 +5680,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5641,7 +5710,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5677,7 +5746,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5707,7 +5776,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vi_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vi_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -5744,7 +5813,7 @@ class L3VariableTime(Realm):
                                                    0]) + '.' + str(self.name_to_eid(endp_data[endp_data_key]['eid'])[1])
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5773,7 +5842,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_A.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_A.append(port_data[port_data_key]['mac'])
@@ -5805,7 +5874,7 @@ class L3VariableTime(Realm):
 
                             # look up the resource
                             resource_found = False
-                            for resource_data in self.resource_data['resources']:
+                            for resource_data in self.resource_data.get('resources', []):
                                 resource_data_key = list(resource_data.keys())[0]
                                 if resource_data_key == eid_tmp_resource:
                                     resource_found = True
@@ -5835,7 +5904,7 @@ class L3VariableTime(Realm):
 
                             port_found = False
                             self.vo_port_eid_B.append(eid_tmp_port)
-                            for port_data in self.port_data['interfaces']:
+                            for port_data in self.port_data.get('interfaces', []):
                                 port_data_key = list(port_data.keys())[0]
                                 if port_data_key == eid_tmp_port:
                                     self.vo_port_mac_B.append(port_data[port_data_key]['mac'])
@@ -7439,7 +7508,24 @@ class L3VariableTime(Realm):
         input_list = []
         drop = []
         statuslist = []
-        interop_tab_data = self.json_get('/adb/')["devices"]
+        adb_url = '/adb/'
+        adb_response = self.json_get(adb_url, debug_=True)
+        if adb_response is None:
+            logger.error(
+                "Failed to fetch adb device data. Received empty response.\n"
+                f"Requested URL: '{adb_url}'\n"
+                f"Response: {adb_response}")
+            interop_tab_data = []
+        elif "devices" not in adb_response:
+            logger.error(
+                "'devices' key not found in response.\n"
+                f"Requested URL: '{adb_url}'\n"
+                f"Response: {adb_response}")
+            interop_tab_data = []
+        else:
+            interop_tab_data = adb_response["devices"]
+            if isinstance(interop_tab_data, dict):
+                interop_tab_data = [{interop_tab_data['name']: interop_tab_data}]
         for i in range(len(devclient)):
             for j in groupdevlist:
                 if j == devhostname[i] and devclient[i].split('_')[-1] != 'Android':
@@ -7596,7 +7682,24 @@ class L3VariableTime(Realm):
         test_input_list = []
         pass_fail_list = []
         # When device_csv_name specified
-        interop_tab_data = self.json_get('/adb/')["devices"]
+        adb_url = '/adb/'
+        adb_response = self.json_get(adb_url, debug_=True)
+        if adb_response is None:
+            logger.error(
+                "Failed to fetch adb device data. Received empty response.\n"
+                f"Requested URL: '{adb_url}'\n"
+                f"Response: {adb_response}")
+            interop_tab_data = []
+        elif "devices" not in adb_response:
+            logger.error(
+                "'devices' key not found in response.\n"
+                f"Requested URL: '{adb_url}'\n"
+                f"Response: {adb_response}")
+            interop_tab_data = []
+        else:
+            interop_tab_data = adb_response["devices"]
+            if isinstance(interop_tab_data, dict):
+                interop_tab_data = [{interop_tab_data['name']: interop_tab_data}]
         if self.expected_passfail_value == '' or self.expected_passfail_value is None:
             for client in self.client_dict_A[tos]['resource_alias_A']:
                 # Check if the client type (second word in "1.15 android samsungmob") is 'android'
@@ -7990,12 +8093,28 @@ def change_port_to_ip(upstream_port, lfclient_host, lfclient_port):
     if upstream_port.count('.') != 3:
         target_port_list = LFUtils.name_to_eid(upstream_port)
         shelf, resource, port, _ = target_port_list
-        try:
-            realm_obj = Realm(lfclient_host=lfclient_host, lfclient_port=lfclient_port)
-            target_port_ip = realm_obj.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
-            upstream_port = target_port_ip
-        except Exception:
-            logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
+        realm_obj = Realm(lfclient_host=lfclient_host, lfclient_port=lfclient_port)
+        port_url = f'/port/{shelf}/{resource}/{port}?fields=ip'
+        response = realm_obj.json_get(port_url, debug_=True)
+        if not response:
+            logging.error(
+                "Failed to fetch port info. Received empty response.\n"
+                f"Requested URL: '{port_url}'\n"
+                f"Response: {response}")
+            exit(1)
+        if 'interface' not in response:
+            logging.error(
+                "'interface' key not found in response.\n"
+                f"Requested URL: '{port_url}'\n"
+                f"Response: {response}")
+            exit(1)
+        if 'ip' not in response['interface']:
+            logging.error(
+                "'ip' key not found in response.\n"
+                f"Requested URL: '{port_url}'\n"
+                f"Response: {response}")
+            exit(1)
+        upstream_port = response['interface']['ip']
         logging.info(f"Upstream port IP {upstream_port}")
     else:
         logging.info(f"Upstream port IP {upstream_port}")

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -2106,6 +2106,15 @@ class L3VariableTime(Realm):
         else:
             # TODO for multicast when using single station there needs to be an interop mode
             # with a single transmitter for all of the multi-cast
+            for etype in self.endp_types:
+                # TODO multi cast build each type only once
+                if etype == "mc_udp" or etype == "mc_udp6":
+                    # TODO add multicast to name be passed in
+                    for _tos in self.tos:
+                        logger.info("Creating Multicast connections for endpoint type:  {etype} TOS: {tos}".format(
+                            etype=etype, tos=_tos))
+                        self.multicast_profile.create_mc_tx(
+                            etype, self.side_b, tos=_tos, add_tos_to_name=True)
             logger.info("Creating test station port(s)")
             for station_profile in self.station_profiles:
                 if not rebuild and not self.use_existing_station_lists:
@@ -2135,8 +2144,6 @@ class L3VariableTime(Realm):
                         for _tos in self.tos:
                             logger.info("Creating Multicast connections for endpoint type:  {etype} TOS: {tos}".format(
                                 etype=etype, tos=_tos))
-                            self.multicast_profile.create_mc_tx(
-                                etype, self.side_b, tos=_tos, add_tos_to_name=True)
                             self.multicast_profile.create_mc_rx(
                                 etype, side_rx=station_profile.station_names, tos=_tos, add_tos_to_name=True)
 

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1439,6 +1439,7 @@ class L3VariableTime(Realm):
         dur = self.duration_time_to_seconds(self.test_duration)
 
         if self.polling_interval_seconds > dur + 1:
+            logger.info(f"Polling interval {self.polling_interval_seconds} is greater than test duration {dur}. Setting polling interval to {dur - 1} seconds.")
             self.polling_interval_seconds = dur - 1
 
         # Full spread-sheet data

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -967,12 +967,16 @@ class L3VariableTime(Realm):
         self.polling_interval = polling_interval
         self.cx_profile = self.new_l3_cx_profile()
         self.multicast_profile = self.new_multicast_profile()
+        self.missing_endp_logged = set()
+        self.not_running_endp_logged = set()
         self.mtx_endps = set()
         self.mrx_endps = set()
         self.multicast_profile.name_prefix = "MLT-"
         self.station_profiles = []
         self.args = args
         self.outfile = outfile
+        self.client_issue_csv_name = os.path.join(os.path.dirname(self.outfile),
+                                                  "client_issue.csv")
         self.csv_started = False
         self.epoch_time = int(time.time())
         self.debug = debug
@@ -7683,6 +7687,140 @@ class L3VariableTime(Realm):
 
                 report.set_custom_html('<hr>')
                 report.build_custom()
+
+    def append_cx_data(self, is_cx, name, state):
+        file_exists = os.path.isfile(self.client_issue_csv_name)
+
+        with open(self.client_issue_csv_name, "a", newline="") as file:
+            writer = csv.writer(file)
+
+            if not file_exists:
+                if is_cx:
+                    writer.writerow(["TIMESTAMP", "CX_NAME", "STATE"])
+                else:
+                    writer.writerow(["TIMESTAMP", "ENDP_NAME", "STATE"])
+
+            writer.writerow([
+                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                name,
+                state
+            ])
+
+    def check_endpoint_availability(self, expected_endps, present_endps, endp_list):
+        for endp_name in expected_endps:
+            if endp_name not in present_endps.keys():
+                if endp_name not in self.missing_endp_logged:
+                    logger.warning(
+                        "Endpoint '{}' is missing from the monitoring data.\n"
+                        "Requested URL: 'endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run'\n"
+                        "Response: {}".format(endp_name, endp_list))
+                    self.append_cx_data(is_cx=False, name=endp_name, state="MISSING")
+                    self.missing_endp_logged.add(endp_name)
+                self.not_running_endp_logged.discard(endp_name)
+            elif not present_endps[endp_name]:
+                if endp_name not in self.not_running_endp_logged:
+                    logger.warning(
+                        "Endpoint '{}' is not running in the monitoring data.\n"
+                        "Requested URL: 'endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run'\n"
+                        "Response: {}".format(endp_name, endp_list))
+                    self.append_cx_data(is_cx=False, name=endp_name, state="NOT RUNNING")
+                    self.not_running_endp_logged.add(endp_name)
+                self.missing_endp_logged.discard(endp_name)
+            else:
+                if endp_name in self.missing_endp_logged or endp_name in self.not_running_endp_logged:
+                    logger.info(
+                        "Endpoint '{}' is running in the monitoring data\n"
+                        "Requested URL: 'endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run'\n"
+                        "Response: {}".format(endp_name, endp_list))
+                    self.append_cx_data(is_cx=False, name=endp_name, state="RUNNING")
+                self.missing_endp_logged.discard(endp_name)
+                self.not_running_endp_logged.discard(endp_name)
+
+    def is_test_stopped_by_webgui(self):
+        if not self.dowebgui:
+            return False
+        running_file = f"{self.result_dir}/../../Running_instances/{self.ip}_{self.test_name}_running.json"
+        try:
+            with open(running_file, "r") as file:
+                data = json.load(file)
+            if data.get("status") != "Running":
+                logging.warning("Test is stopped by the user")
+                self.test_stopped_user = True
+                return True
+        except FileNotFoundError:
+            logging.warning(f"Running instance file not found: {running_file}")
+            return True
+        except json.JSONDecodeError:
+            logging.warning(f"Running instance file corrupted or empty: {running_file}")
+            return True
+        except Exception as e:
+            logging.error(f"Unexpected error reading running.json: {e}")
+            return True
+        return False
+
+    def monitor_endp_availability(self, expected_endps, return_endpoint_data=False, duration=40, interval=5):
+        start_time = time.time()
+        end_time = start_time + duration
+        no_of_attempts = duration // interval
+        count = 0
+        endpoint = []
+        while (start_time <= end_time):
+            count += 1
+            if self.is_test_stopped_by_webgui():
+                logger.info("Test stopped by user via WebGUI. Exiting monitoring.")
+                return [] if return_endpoint_data else False
+            if count > 1:
+                logger.info("Attempt {} of {} to check endpoint availability".format(count, no_of_attempts))
+            endp_url = "endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run"
+            endp_list = self.json_get(endp_url, debug_=True)
+            if not endp_list:
+                logger.error(
+                    "Failed to fetch endpoints. Received empty response.\n"
+                    f"Requested URL: '{endp_url}'\n"
+                    f"Response: {endp_list}")
+                endp_list = {}
+                # time.sleep(interval)
+                # start_time = time.time()
+                # continue
+            endpoint = endp_list.get('endpoint', [])
+            if isinstance(endpoint, dict):
+                endpoint = [{endpoint['name']: endpoint}]
+            present_endps = {}
+            for endp_name in endpoint:
+                for item, endp_value in endp_name.items():
+                    present_endps[item] = endp_value.get('run')
+            self.check_endpoint_availability(expected_endps, present_endps, endp_list)
+            expected_endps_set = set(expected_endps)
+            missing_endps = self.missing_endp_logged & expected_endps_set
+            not_running_endps = self.not_running_endp_logged & expected_endps_set
+            missed = len(missing_endps)
+            not_run = len(not_running_endps)
+            if missed == len(expected_endps):
+                if not return_endpoint_data:
+                    logger.error("All expected tx endpoints ({}) are missing from the monitoring data. So we are checking again".format(
+                        ", ".join(missing_endps)))
+                else:
+                    logger.error("All expected rx endpoints ({}) are missing from the monitoring data. But we are checking again".format(
+                        ", ".join(missing_endps)))
+            elif not_run == len(expected_endps):
+                if not return_endpoint_data:
+                    logger.error("All expected endpoints ({}) are present but not running. So we are checking again".format(
+                        ", ".join(not_running_endps)))
+                else:
+                    logger.error("All expected endpoints ({}) are present but not running. But we are checking again".format(
+                        ", ".join(not_running_endps)))
+            elif missed + not_run == len(expected_endps):
+                if not return_endpoint_data:
+                    logger.error("Some expected endpoints ({}) are missing and some endpoints ({}) are not running. So we are checking again".format(
+                        ", ".join(missing_endps), ", ".join(not_running_endps)))
+                else:
+                    logger.error("Some expected endpoints ({}) are missing and some endpoints ({}) are not running. But we are checking again".format(
+                        ", ".join(missing_endps), ", ".join(not_running_endps)))
+            else:
+                return endpoint if return_endpoint_data else True
+            time.sleep(interval)
+            start_time = time.time()
+        return [] if return_endpoint_data else False
 
 
 # Converting the upstream_port to IP address for configuration purposes

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -969,6 +969,8 @@ class L3VariableTime(Realm):
         self.multicast_profile = self.new_multicast_profile()
         self.missing_endp_logged = set()
         self.not_running_endp_logged = set()
+        self.missing_cx_logged = set()
+        self.not_running_cx_logged = set()
         self.mtx_endps = set()
         self.mrx_endps = set()
         self.multicast_profile.name_prefix = "MLT-"
@@ -7821,6 +7823,79 @@ class L3VariableTime(Realm):
             time.sleep(interval)
             start_time = time.time()
         return [] if return_endpoint_data else False
+
+    def check_cx_availability(self, expected_cxs, present_cxs, cx_list):
+        for cx_name in expected_cxs:
+            if cx_name not in present_cxs.keys():
+                if cx_name not in self.missing_cx_logged:
+                    logger.warning(
+                        "Cross-connect '{}' is missing from the monitoring data.\n"
+                        "Requested URL: 'cx/all'\n"
+                        "Response: {}".format(cx_name, cx_list))
+                    self.append_cx_data(is_cx=True, name=cx_name, state="MISSING")
+                    self.missing_cx_logged.add(cx_name)
+                self.not_running_cx_logged.discard(cx_name)
+            elif present_cxs[cx_name].lower() != "run":
+                if cx_name not in self.not_running_cx_logged:
+                    logger.warning(
+                        "Cross-connect '{}' is not running in the monitoring data.\n"
+                        "Requested URL: 'cx/all'\n"
+                        "Response: {}".format(cx_name, cx_list))
+                    self.append_cx_data(is_cx=True, name=cx_name, state=present_cxs[cx_name])
+                    self.not_running_cx_logged.add(cx_name)
+                self.missing_cx_logged.discard(cx_name)
+            else:
+                if cx_name in self.missing_cx_logged or cx_name in self.not_running_cx_logged:
+                    logger.info(
+                        "Cross-connect '{}' is running in the monitoring data\n"
+                        "Requested URL: 'cx/all'\n"
+                        "Response: {}".format(cx_name, cx_list))
+                    self.append_cx_data(is_cx=True, name=cx_name, state="RUNNING")
+                self.missing_cx_logged.discard(cx_name)
+                self.not_running_cx_logged.discard(cx_name)
+
+    def monitor_cx_availability(self, expected_cxs, duration=40, interval=5):
+        start_time = time.time()
+        end_time = start_time + duration
+        no_of_attempts = duration // interval
+        count = 0
+        while (start_time <= end_time):
+            count += 1
+            if self.is_test_stopped_by_webgui():
+                logger.info("Test stopped by user via WebGUI. Exiting monitoring.")
+                return False
+            if count > 1:
+                logger.info("Attempt {} of {} to check cross-connect availability".format(count, no_of_attempts))
+            cx_list = self.json_get("cx/all", debug_=True)
+            if not cx_list:
+                logger.error(
+                    "Failed to fetch cross-connects. Received empty response.\n"
+                    "Requested URL: 'cx/all'\n"
+                    f"Response: {cx_list}")
+                time.sleep(interval)
+                start_time = time.time()
+                continue
+            present_cxs = {}
+            for cx_name, cx_info in cx_list.items():
+                if cx_name and isinstance(cx_info, dict):
+                    present_cxs[cx_name] = cx_info.get('state', 'Stopped')
+            self.check_cx_availability(expected_cxs, present_cxs, cx_list)
+            missed = len(self.missing_cx_logged)
+            not_run = len(self.not_running_cx_logged)
+            if missed == len(expected_cxs):
+                logger.error("All expected cross-connects ({}) are missing from the monitoring data. So we are checking again".format(
+                    ", ".join(self.missing_cx_logged)))
+            elif not_run == len(expected_cxs):
+                logger.error("All expected cross-connects ({}) are present but not running. So we are checking again".format(
+                    ", ".join(self.not_running_cx_logged)))
+            elif missed + not_run == len(expected_cxs):
+                logger.error("Some expected cross-connects ({}) are missing and some cross-connects ({}) are not running. So we are checking again".format(
+                    ", ".join(self.missing_cx_logged), ", ".join(self.not_running_cx_logged)))
+            else:
+                return True
+            time.sleep(interval)
+            start_time = time.time()
+        return False
 
 
 # Converting the upstream_port to IP address for configuration purposes

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -8296,10 +8296,21 @@ def query_real_clients(args):
     android_list = []
     mac_id1_list = []
     user_list = []
-    response = config_obj.json_get("/resource/all")
+    resource_url = "/resource/all"
+    response = config_obj.json_get(resource_url, debug_=True)
 
-    if "resources" not in response.keys():
-        logger.error("There are no real devices.")
+    if not response:
+        logger.error(
+            "Failed to fetch resources. Received empty response.\n"
+            f"Requested URL: '{resource_url}'\n"
+            f"Response: {response}")
+        exit(1)
+
+    if "resources" not in response:
+        logger.error(
+            "There are no real devices. 'resources' key not found in response.\n"
+            f"Requested URL: '{resource_url}'\n"
+            f"Response: {response}")
         exit(1)
 
     for key, value in response.items():
@@ -8331,9 +8342,19 @@ def query_real_clients(args):
                             android_list.append(b['hw version'])
                             devices_available.append(b['eid'] + " " + 'android' + " " + b['user'])
 
-    response_port = config_obj.json_get("/port/all")
-    if "interfaces" not in response_port.keys():
-        logger.error("Error: 'interfaces' key not found in port data")
+    port_url = "/port/all"
+    response_port = config_obj.json_get(port_url, debug_=True)
+    if not response_port:
+        logger.error(
+            "Failed to fetch ports. Received empty response.\n"
+            f"Requested URL: '{port_url}'\n"
+            f"Response: {response_port}")
+        exit(1)
+    if "interfaces" not in response_port:
+        logger.error(
+            "'interfaces' key not found in response.\n"
+            f"Requested URL: '{port_url}'\n"
+            f"Response: {response_port}")
         exit(1)
     for interface in response_port['interfaces']:
         for port, port_data in interface.items():
@@ -8372,16 +8393,20 @@ def query_real_clients(args):
             for endp in traffic_type:
                 graph_input_list.append('L3_' + endp.split('_')[1].upper() + '_DL')
     sample_list = []
+    matched_devices = []
     if args.device_list:
         for interface in response_port['interfaces']:
             for port, port_data in interface.items():
                 if not port_data['phantom'] and not port_data['down'] and port_data['parent dev'] == "wiphy0" and port_data['alias'] != 'p2p0':
                     port_list = port.split('.')
+                    device_id = port_list[0] + '.' + port_list[1]
                     for device in args.device_list[0].split(','):
-                        if (port_list[0] + '.' + port_list[1]) == device:
+                        if device_id == device:
                             sample_list.append([port])
-        if sample_list == []:
-            logger.info("Selected devices are not available")
+                            matched_devices.append(device_id)
+        if len(sample_list) != len(args.device_list[0].split(',')):
+            not_available_devices = [device for device in args.device_list[0].split(',') if device not in matched_devices]
+            logger.info(f"{', '.join(not_available_devices)} devices are not available")
             exit(1)
         args.existing_station_list = sample_list
         args.use_existing_station_list = True

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -6240,6 +6240,12 @@ class L3VariableTime(Realm):
 
     # Stop traffic and admin down stations.
     def stop(self):
+        # Drop endpoints/cxs confirmed missing from the LANforge side so stop only
+        # targets what's actually present, irrespective of monitoring errors.
+        for endp_name in self.missing_endp_logged:
+            self.multicast_profile.created_mc.pop(endp_name, None)
+        for cx_name in self.missing_cx_logged:
+            self.cx_profile.created_cx.pop(cx_name, None)
         self.cx_profile.stop_cx()
         self.multicast_profile.stop_mc()
         for station_list in self.station_lists:

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -6821,22 +6821,24 @@ class L3VariableTime(Realm):
             group_names = ', '.join(config_devices.keys())
             profile_names = ', '.join(config_devices.values())
             configmap = "Groups:" + group_names + " -> Profiles:" + profile_names
+            report_test_duration = self.actual_test_duration_display if self.need_endps_stopped else self.test_duration
             test_input_info = {
                 "LANforge ip": self.lfmgr,
                 "LANforge port": self.lfmgr_port,
                 "Upstream": self.upstream_port,
-                "Test Duration": self.test_duration,
+                "Test Duration": report_test_duration,
                 "Test Configuration": configmap,
                 "Polling Interval": self.polling_interval,
                 "Total No. of Devices": self.station_count,
             }
         else:
+            report_test_duration = self.actual_test_duration_display if self.need_endps_stopped else self.test_duration
             if self.robo_test:
                 test_input_info = {
                     "LANforge ip": self.lfmgr,
                     "LANforge port": self.lfmgr_port,
                     "Upstream": self.upstream_port,
-                    "Test Duration": self.test_duration,
+                    "Test Duration": report_test_duration,
                     "Polling Interval": self.polling_interval,
                     "Total No. of Devices": self.station_count,
                     "Robot Coordinates": ", ".join(self.coordinate_list),
@@ -6847,7 +6849,7 @@ class L3VariableTime(Realm):
                     "LANforge ip": self.lfmgr,
                     "LANforge port": self.lfmgr_port,
                     "Upstream": self.upstream_port,
-                    "Test Duration": self.test_duration,
+                    "Test Duration": report_test_duration,
                     "Polling Interval": self.polling_interval,
                     "Total No. of Devices": self.station_count,
                 }
@@ -6936,7 +6938,8 @@ class L3VariableTime(Realm):
         # Generate per-coordinate/rotation graphs and tables for robot test
         if self.robo_test and not self.do_bandsteering:
             logger.info("Building per-coordinate/rotation graphs and tables for robot test (from memory dict)")
-            self.add_live_view_images_to_report()
+            if self.dowebgui and self.get_live_view:
+                self.add_live_view_images_to_report()
             if not hasattr(self, "multicast_robot_results") or not self.multicast_robot_results:
                 self.report.set_custom_html("<p><i>No robot test results found.</i></p>")
                 self.report.build_custom()

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -1863,13 +1863,6 @@ class L3VariableTime(Realm):
     # Query all endpoints to generate rx and other stats, returned
     # as an array of objects.
     def __get_rx_values(self):
-        endp_list = self.json_get(
-            "endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll",
-            debug_=False)
-        # multicast only shows tx rates
-        # endp_list = self.json_get(
-        #    "endp?fields=name,eid,delay,jitter,tx+rate,tx+rate+ll,tx+bytes,tx+drop+%25,tx+pkts+ll",
-        #    debug_=False)
 
         endp_rx_drop_map = {}
         endp_rx_map = {}
@@ -1880,101 +1873,114 @@ class L3VariableTime(Realm):
         total_ul_ll = 0
         total_dl = 0
         total_dl_ll = 0
+        # For multicast checking the alteast one tx and alteast one rx endpoint is there if not exiting
+        if self.mtx_endps:
+            available = self.monitor_endp_availability(self.mtx_endps)
+            if not available:
+                return False, endp_rx_map, endp_rx_drop_map, endps, total_dl, total_ul, total_dl_ll, total_ul_ll
+            endpoint = self.monitor_endp_availability(self.mrx_endps, return_endpoint_data=True)
+            if not endpoint:
+                return False, endp_rx_map, endp_rx_drop_map, endps, total_dl, total_ul, total_dl_ll, total_ul_ll
+        # Checking atleast one cx is there if not exiting
+        else:
+            available = self.monitor_cx_availability(self.cx_profile.get_cx_names())
+            if not available:
+                return False, endp_rx_map, endp_rx_drop_map, endps, total_dl, total_ul, total_dl_ll, total_ul_ll
+            endp_url = "endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run"
+            endp_list = self.json_get(endp_url, debug_=True)
+            if not endp_list:
+                logger.error(
+                    "Failed to fetch endpoints. Received empty response.\n"
+                    f"Requested URL: '{endp_url}'\n"
+                    f"Response: {endp_list}")
+                return False, endp_rx_map, endp_rx_drop_map, endps, total_dl, total_ul, total_dl_ll, total_ul_ll
+            endpoint = endp_list.get('endpoint', [])
+            if isinstance(endpoint, dict):
+                endpoint = [{endpoint['name']: endpoint}]
 
         # Multicast endpoints
         for e in self.multicast_profile.get_mc_names():
             our_endps[e] = e
-        try:
-            for endp_name in endp_list['endpoint']:
-                logger.debug("endpoint: {}".format(endp_name))
-                if endp_name != 'uri' and endp_name != 'handler':
-                    for item, endp_value in endp_name.items():
-                        # multicast does not support use existing: or self.use_existing_station_lists:
-                        if item in our_endps:
-                            # endps.append(endp_value) need to see how to affect
-                            # NOTE: during each monitor period the rates are added to get the totals
-                            # this is done so that if there is an issue the rate information will be in
-                            # the csv for the individual polling period
-                            logger.debug(
-                                "multicast endpoint: {item} value:\n".format(item=item))
-                            logger.debug(endp_value)
-                            for value_name, value in endp_value.items():
-                                if isinstance(value, str) and not value.isnumeric():
-                                    logging.debug(
-                                        'Expected integer response for rx rate, received non-numeric string instead. Replacing with 0')
-                                    value = 0
-                                if value_name == 'rx rate':
-                                    # This hack breaks for mcast or if someone names endpoints weirdly.
-                                    # logger.info("item: ", item, " rx-bps: ", value_rx_bps)
-                                    if "-mrx-" in item:
-                                        total_dl += int(value)
-                                    else:
-                                        total_ul += int(value)
-                                if value_name == 'rx rate ll':
-                                    # This hack breaks for mcast or if someone
-                                    # names endpoints weirdly.
-                                    if "-mrx-" in item:
-                                        total_dl_ll += int(value)
-                                    else:
-                                        total_ul_ll += int(value)
 
-                                # TODO need a way to report rates
-        except Exception as e:
-            overall_response = self.json_get('/cx/all/')
-            logger.info(overall_response)
-            logger.error(f"Endpoint not fetched from API {e}")
+        for endp_name in endpoint:
+            logger.debug("endpoint: {}".format(endp_name))
+            for item, endp_value in endp_name.items():
+                # multicast does not support use existing: or self.use_existing_station_lists:
+                if item in our_endps:
+                    # endps.append(endp_value) need to see how to affect
+                    # NOTE: during each monitor period the rates are added to get the totals
+                    # this is done so that if there is an issue the rate information will be in
+                    # the csv for the individual polling period
+                    logger.debug(
+                        "multicast endpoint: {item} value:\n".format(item=item))
+                    logger.debug(endp_value)
+                    for value_name, value in endp_value.items():
+                        if isinstance(value, str) and not value.isnumeric():
+                            logging.debug(
+                                'Expected integer response for rx rate, received non-numeric string instead. Replacing with 0')
+                            value = 0
+                        if value_name == 'rx rate':
+                            # This hack breaks for mcast or if someone names endpoints weirdly.
+                            # logger.info("item: ", item, " rx-bps: ", value_rx_bps)
+                            if "-mrx-" in item:
+                                total_dl += int(value)
+                            else:
+                                total_ul += int(value)
+                        if value_name == 'rx rate ll':
+                            # This hack breaks for mcast or if someone
+                            # names endpoints weirdly.
+                            if "-mrx-" in item:
+                                total_dl_ll += int(value)
+                            else:
+                                total_ul_ll += int(value)
+
+                        # TODO need a way to report rates
         # Unicast endpoints
         for e in self.cx_profile.created_endp.keys():
             our_endps[e] = e
-        try:
-            for endp_name in endp_list['endpoint']:
-                if endp_name != 'uri' and endp_name != 'handler':
-                    for item, endp_value in endp_name.items():
-                        if item in our_endps or self.use_existing_station_lists:
-                            endps.append(endp_value)
-                            logger.debug(
-                                "endpoint: {item} value:\n".format(item=item))
-                            logger.debug(endp_value)
+        for endp_name in endpoint:
+            for item, endp_value in endp_name.items():
+                if item in our_endps:
+                    endps.append(endp_value)
+                    logger.debug(
+                        "endpoint: {item} value:\n".format(item=item))
+                    logger.debug(endp_value)
 
-                            for value_name, value in endp_value.items():
-                                if value_name == 'rx bytes':
-                                    endp_rx_map[item] = value
-                                if value_name == 'rx rate':
-                                    endp_rx_map[item] = value
-                                if value_name == 'rx rate ll':
-                                    endp_rx_map[item] = value
-                                if value_name == 'rx pkts ll':
-                                    endp_rx_map[item] = value
-                                if value_name == 'rx drop %':
-                                    endp_rx_drop_map[item] = value
-                                if value_name == 'rx rate':
-                                    if isinstance(value, str) and not value.isnumeric():
-                                        logging.debug(
-                                            'Expected integer response for rx rate, received non-numeric string instead. Replacing with 0')
-                                        value = 0
-                                    # This hack breaks for mcast or if someone names endpoints weirdly.
-                                    # logger.info("item: ", item, " rx-bps: ", value_rx_bps)
-                                    if item.endswith("-A"):
-                                        total_dl += int(value)
-                                    elif item.endswith("-B"):
-                                        total_ul += int(value)
-                                if value_name == 'rx rate ll':
-                                    if isinstance(value, str) and not value.isnumeric():
-                                        logging.debug(
-                                            'Expected integer response for rx rate ll, received non-numeric string instead. Replacing with 0')
-                                        value = 0
-                                    # This hack breaks for mcast or if someone
-                                    # names endpoints weirdly.
-                                    if item.endswith("-A"):
-                                        total_dl_ll += int(value)
-                                    elif item.endswith("-B"):
-                                        total_ul_ll += int(value)
-        except Exception as e:
-            overall_response = self.json_get('/cx/all/')
-            logger.info(overall_response)
-            logger.error(f"Endpoint not fetched from API {e}")
+                    for value_name, value in endp_value.items():
+                        if value_name == 'rx bytes':
+                            endp_rx_map[item] = value
+                        if value_name == 'rx rate':
+                            endp_rx_map[item] = value
+                        if value_name == 'rx rate ll':
+                            endp_rx_map[item] = value
+                        if value_name == 'rx pkts ll':
+                            endp_rx_map[item] = value
+                        if value_name == 'rx drop %':
+                            endp_rx_drop_map[item] = value
+                        if value_name == 'rx rate':
+                            if isinstance(value, str) and not value.isnumeric():
+                                logging.debug(
+                                    'Expected integer response for rx rate, received non-numeric string instead. Replacing with 0')
+                                value = 0
+                            # This hack breaks for mcast or if someone names endpoints weirdly.
+                            # logger.info("item: ", item, " rx-bps: ", value_rx_bps)
+                            if item.endswith("-A"):
+                                total_dl += int(value)
+                            elif item.endswith("-B"):
+                                total_ul += int(value)
+                        if value_name == 'rx rate ll':
+                            if isinstance(value, str) and not value.isnumeric():
+                                logging.debug(
+                                    'Expected integer response for rx rate ll, received non-numeric string instead. Replacing with 0')
+                                value = 0
+                            # This hack breaks for mcast or if someone
+                            # names endpoints weirdly.
+                            if item.endswith("-A"):
+                                total_dl_ll += int(value)
+                            elif item.endswith("-B"):
+                                total_ul_ll += int(value)
         # logger.debug("total-dl: ", total_dl, " total-ul: ", total_ul, "\n")
-        return endp_rx_map, endp_rx_drop_map, endps, total_dl, total_ul, total_dl_ll, total_ul_ll
+        return True, endp_rx_map, endp_rx_drop_map, endps, total_dl, total_ul, total_dl_ll, total_ul_ll
     # This script supports resetting ports, allowing one to test AP/controller under data load
     # while bouncing wifi stations.  Check here to see if we should reset
     # ports.

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -2355,10 +2355,8 @@ class L3VariableTime(Realm):
             logger.info(f"Moving to coordinate {coord_index}: {coordinate}")
 
             pause_coord, test_stopped_by_user = self.robot_obj.wait_for_battery(self.stop)
-            if pause_coord:
-                print("Test stopped by user, exiting...")
-                exit(0)
-            if self.test_stopped_user:
+            if test_stopped_by_user:
+                logger.info("Test stopped by user, exiting...")
                 break
 
             # Move robot to coordinate
@@ -2373,9 +2371,9 @@ class L3VariableTime(Realm):
                     # Rotation mode - run test at each rotation angle
                     for angle_index, rotation_angle in enumerate(self.rotation_list):
                         pause_coord, test_stopped_by_user = self.robot_obj.wait_for_battery(self.stop)
-                        if pause_coord:
-                            print("Test stopped by user, exiting...")
-                            exit(0)
+                        if test_stopped_by_user:
+                            logger.info("Test stopped by user, exiting...")
+                            break
                         logger.info(f"Rotating to angle {angle_index}: {rotation_angle} degrees")
 
                         robo_rotated = self.robot_obj.rotate_angle(rotation_angle)
@@ -2383,8 +2381,16 @@ class L3VariableTime(Realm):
                         if robo_rotated:
                             logger.info(f"Successfully rotated to {rotation_angle} degrees")
                             self.perform_robo_multicast(coordinate=coordinate, rotation=rotation_angle)
+                            if self.need_endps_stopped:
+                                logger.info("Required endpoints stopped, exiting without performing other rotations ...")
+                                self.robot_obj.update_nav_data_for_all_cxs_stopped()
+                                break
                         else:
                             logger.error(f"Failed to rotate to angle {rotation_angle} at coordinate {coordinate}")
+                if self.need_endps_stopped:
+                    logger.info("Required endpoints stopped, exiting without moving to the other coordinates ...")
+                    self.robot_obj.update_nav_data_for_all_cxs_stopped()
+                    break
             else:
                 logger.error(f"Failed to move to coordinate {coordinate}")
 

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -967,6 +967,8 @@ class L3VariableTime(Realm):
         self.polling_interval = polling_interval
         self.cx_profile = self.new_l3_cx_profile()
         self.multicast_profile = self.new_multicast_profile()
+        self.mtx_endps = set()
+        self.mrx_endps = set()
         self.multicast_profile.name_prefix = "MLT-"
         self.station_profiles = []
         self.args = args
@@ -2115,6 +2117,7 @@ class L3VariableTime(Realm):
                             etype=etype, tos=_tos))
                         self.multicast_profile.create_mc_tx(
                             etype, self.side_b, tos=_tos, add_tos_to_name=True)
+            self.mtx_endps = self.multicast_profile.get_mc_names()
             logger.info("Creating test station port(s)")
             for station_profile in self.station_profiles:
                 if not rebuild and not self.use_existing_station_lists:
@@ -2161,6 +2164,11 @@ class L3VariableTime(Realm):
                                 self.tcp_endps = self.tcp_endps + these_endp
                             # after we create the cxs, append to global
                             self.cx_names.append(these_cx)
+            # for getting only the rx endpoints in the case of multicast
+            if self.mtx_endps:
+                for endp in self.multicast_profile.get_mc_names():
+                    if endp not in self.mtx_endps:
+                        self.mrx_endps.add(endp)
 
         self.cx_count = self.cx_profile.get_cx_count()
 

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -979,6 +979,8 @@ class L3VariableTime(Realm):
         self.outfile = outfile
         self.client_issue_csv_name = os.path.join(os.path.dirname(self.outfile),
                                                   "client_issue.csv")
+        self.need_endps_stopped = False
+        self.actual_test_duration_display = None
         self.csv_started = False
         self.epoch_time = int(time.time())
         self.debug = debug
@@ -3006,6 +3008,15 @@ class L3VariableTime(Realm):
         # individual_device_data = {}
         # Monitor loop
         bandsteering_data = None
+        if self.need_endps_stopped and self.do_bandsteering:
+            logger.info("Required endpoints stopped, moving to the respective coordinate..")
+            data = {
+                "total_dl_bps": total_dl_bps,
+                "total_ul_bps": total_ul_bps,
+                "total_dl_ll_bps": total_dl_ll_bps,
+                "total_ul_ll_bps": total_ul_ll_bps
+            }
+            return data
         while cur_time < end_time:
             # interval_time = cur_time + datetime.timedelta(seconds=5)
             interval_time = cur_time + \
@@ -3024,7 +3035,24 @@ class L3VariableTime(Realm):
                     self.reset_port_check()
 
             self.epoch_time = int(time.time())
-            endp_rx_map, endp_rx_drop_map, endps, total_dl_bps, total_ul_bps, total_dl_ll_bps, total_ul_ll_bps = self.__get_rx_values()
+            available, endp_rx_map, endp_rx_drop_map, endps, total_dl_bps, total_ul_bps, total_dl_ll_bps, total_ul_ll_bps = self.__get_rx_values()
+            if not available:
+                logger.warning("Endpoint data not available, exiting monitoring loop early.")
+                self.actual_test_duration_display = self.format_duration(cur_time - start_time)
+                self.need_endps_stopped = True
+                if self.do_bandsteering:
+                    self.total_dl_bps = total_dl_bps
+                    self.total_ul_bps = total_ul_bps
+                    self.total_dl_ll_bps = total_dl_ll_bps
+                    self.total_ul_ll_bps = total_ul_ll_bps
+                    data = {
+                        "total_dl_bps": total_dl_bps,
+                        "total_ul_bps": total_ul_bps,
+                        "total_dl_ll_bps": total_dl_ll_bps,
+                        "total_ul_ll_bps": total_ul_ll_bps
+                    }
+                    return data
+                return total_dl_bps, total_ul_bps, total_dl_ll_bps, total_ul_ll_bps
 
             log_msg = "main loop, total-dl: {total_dl_bps} total-ul: {total_ul_bps} total-dl-ll: {total_dl_ll_bps}".format(
                 total_dl_bps=total_dl_bps, total_ul_bps=total_ul_bps, total_dl_ll_bps=total_dl_ll_bps)
@@ -7906,8 +7934,28 @@ class L3VariableTime(Realm):
             start_time = time.time()
         return False
 
+    def format_duration(self, td):
+        total_seconds = int(td.total_seconds())
 
+        days, remainder = divmod(total_seconds, 86400)
+        hours, remainder = divmod(remainder, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        parts = []
+
+        if days:
+            parts.append(f"{days} day{'s' if days != 1 else ''}")
+        if hours:
+            parts.append(f"{hours} hour{'s' if hours != 1 else ''}")
+        if minutes:
+            parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+        if seconds or not parts:
+            parts.append(f"{seconds} second{'s' if seconds != 1 else ''}")
+
+        return " ".join(parts)
 # Converting the upstream_port to IP address for configuration purposes
+
+
 def change_port_to_ip(upstream_port, lfclient_host, lfclient_port):
     if upstream_port.count('.') != 3:
         target_port_list = LFUtils.name_to_eid(upstream_port)


### PR DESCRIPTION
**PR: test_l3.py — Improved endpoint/CX monitoring, robot/band-steering termination + device-issue reporting**

**What's handled**
-Adds endpoint/CX status tracking, a 40-second recovery wait, and device-issue recording via client_issue.csv.
-Splits multicast transmit and receive endpoints so each direction's availability is tracked independently.
-Handles empty or malformed LANforge responses across the script, logging missing/not-running endpoints and CXs only when their state changes.
-Stops monitoring and records the actual elapsed duration once required endpoints/CXs are confirmed missing.
-Stops robot and band-steering coordinate/rotation loops from continuing once all expected endpoints go missing.
-Drops endpoints/CXs already confirmed missing before stop and cleanup operations.
-Only captures live-view images when running from the webgui with live view enabled.
-Logs exactly which requested --device_list devices are unavailable instead of a generic message.

Test logs:
```
1785922896.474270 INFO     Starting test test_l3.py 10311
1785922896.474429 INFO     Admin up upstream port and station port(s): ['eth1', '1.25.wlan0', '1.16.wlan0'] test_l3.py 1659
1785922897.989156 INFO     All ports connected successfully test_l3.py 1695
1785922897.990412 INFO     Creating Multicast connections for endpoint type:  mc_udp TOS: VO test_l3.py 2144
1785922898.764578 INFO     Creating test station port(s) test_l3.py 2149
1785922898.765968 INFO     Creating Multicast connections for endpoint type:  mc_udp TOS: VO test_l3.py 2176
1785922900.436119 INFO     Starting multicast traffic (if any configured) test_l3.py 3010
1785922900.437718 INFO     Starting multicast endpoint(s): ['MLT-mtx-VO-eth1-0', 'MLT-mrx-VO-wlan0-1', 'MLT-mrx-VO-wlan0-2'] multicast_profile.py 126
1785922902.035182 INFO     Starting layer-3 traffic (if any configured) test_l3.py 3014
1785922902.035413 INFO     Starting CXs... l3_cxprofile.py 407
1785922902.035600 INFO     Getting initial values. test_l3.py 3019
1785922902.273110 INFO     Monitoring throughput for duration: 1m test_l3.py 3065
1785922953.538036 WARNING  Endpoint 'MLT-mrx-VO-wlan0-1' is missing from the monitoring data.
Requested URL: 'endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run'
Response: {'handler': 'candela.lanforge.HttpEndp$JsonResponse', 'uri': 'endp', 'candela.lanforge.HttpEndp': {'duration': '2'}, 'endpoint': {'delay': 0, 'eid': '1.1.1.463.15', 'jitter': 0, 'name': 'MLT-mtx-VO-eth1-0', 'run': True, 'rx bytes': 0, 'rx drop %': 0.0, 'rx pkts ll': 0, 'rx rate': 0, 'rx rate ll': 0}} test_l3.py 7855
1785922953.538482 WARNING  Endpoint 'MLT-mrx-VO-wlan0-2' is missing from the monitoring data.
Requested URL: 'endp?fields=name,eid,delay,jitter,rx+rate,rx+rate+ll,rx+bytes,rx+drop+%25,rx+pkts+ll,run'
Response: {'handler': 'candela.lanforge.HttpEndp$JsonResponse', 'uri': 'endp', 'candela.lanforge.HttpEndp': {'duration': '2'}, 'endpoint': {'delay': 0, 'eid': '1.1.1.463.15', 'jitter': 0, 'name': 'MLT-mtx-VO-eth1-0', 'run': True, 'rx bytes': 0, 'rx drop %': 0.0, 'rx pkts ll': 0, 'rx rate': 0, 'rx rate ll': 0}} test_l3.py 7855
1785922953.538706 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922958.539115 INFO     Attempt 2 of 8 to check endpoint availability test_l3.py 7913
1785922958.656751 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922963.657266 INFO     Attempt 3 of 8 to check endpoint availability test_l3.py 7913
1785922963.779826 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922968.780396 INFO     Attempt 4 of 8 to check endpoint availability test_l3.py 7913
1785922968.912104 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922973.912593 INFO     Attempt 5 of 8 to check endpoint availability test_l3.py 7913
1785922974.124805 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922979.126329 INFO     Attempt 6 of 8 to check endpoint availability test_l3.py 7913
1785922979.249110 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922984.249812 INFO     Attempt 7 of 8 to check endpoint availability test_l3.py 7913
1785922984.374599 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922989.375502 INFO     Attempt 8 of 8 to check endpoint availability test_l3.py 7913
1785922989.498493 ERROR    All expected rx endpoints (MLT-mrx-VO-wlan0-1, MLT-mrx-VO-wlan0-2) are missing from the monitoring data. But we are checking again test_l3.py 7942
1785922994.499011 WARNING  Endpoint data not available, exiting monitoring loop early. test_l3.py 3101
1785922994.545789 INFO     all_dl_ports_stations_sum_df :             Rx-Bps  Tx-Bps  ...  Dl-Rx-Rate-ll  Dl-Rx-Pkts-ll
Time epoch                  ...                              
1785922907   20416  120498  ...              0              0
1785922912   21326  122926  ...              0              0
1785922917   25446  146406  ...              0              0
1785922922   25498  149236  ...              0              0
1785922927   25498  149236  ...              0              0
1785922932   25252  143812  ...              0              0
1785922937   25012  138412  ...              0              0
1785922943   25586  147838  ...              0              0
1785922948   25672  146242  ...              0              0

[9 rows x 10 columns] test_l3.py 2756
1785922994.561678 INFO     Test complete, stopping traffic test_l3.py 10338
1785922994.561759 INFO     Stopping CXs... l3_cxprofile.py 425
```