### PR TITLE
lf_interop_teams.py: Remove extra API response print

### DIFF
--- a/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
+++ b/py-scripts/real_application_tests/teams_automation/lf_interop_teams.py
@@ -1012,8 +1012,6 @@ class TeamsAutomation(Realm):
                 "ap", "-"
             )  # 'ap' is usually BSSID
 
-        print(lf_stats_map)
-
         return lf_stats_map
 
     def stop_previous_flask_server(self):


### PR DESCRIPTION
- Remove print statement logging API response data in bandsteering scenario.

VERIFIED CLI: python3 lf_interop_teams.py --mgr 192.168.245.117 --duration 2 --resources 1.113,1.153,1.156,1.18 --upstream_port 192.168.245.233 --audio --video