### PR TITLE
Fix Layer4 CX issues and improve logging in tests

### DIFF
--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -1306,6 +1306,8 @@ class RealBrowserTest(Realm):
         are not logged or written again.
         """
         csv_file = "endpoint_status_changes.csv"
+        gen_url = "generic/%s/list?fields=name,status" % (",".join(set(self.generic_endps_profile.created_endp))) if self.generic_endps_profile.created_endp else ""
+        layer4_url = "layer4/%s/list?fields=name,status" % (",".join(self.created_cx.keys())) if self.created_cx else ""
         created_endp = [(e, "generic") for e in self.generic_endps_profile.created_endp] + \
             [(e, "layer4") for e in self.created_cx.keys()]
 
@@ -1335,9 +1337,32 @@ class RealBrowserTest(Realm):
             )
             exit(1)
 
-        for gen_endp, generic_endpoint in endpoint_data.items():
-            url = f"/{api}/{gen_endp}"
-            keys = list(generic_endpoint.keys())
+        def get_keys(resp):
+            if not resp or resp.get("empty") == "no elements":
+                return []
+            items = resp.get("endpoints") or resp.get("endpoint") or []
+            if isinstance(items, dict):
+                items = [items]
+            keys = []
+            for item in items:
+                if isinstance(item, dict):
+                    if "name" in item:
+                        keys.append(item["name"])
+                    else:
+                        keys.extend([k for k, v in item.items() if isinstance(v, dict)])
+            return keys
+
+        gen_resp = self.json_get(gen_url) if gen_url else None
+        layer4_resp = self.json_get(layer4_url) if layer4_url else None
+        active_keys_map = {
+            "generic": get_keys(gen_resp),
+            "layer4": get_keys(layer4_resp)
+        }
+
+        for gen_endp, api in created_endp:
+            generic_endpoint = endpoint_data.get(gen_endp, {})
+            url = layer4_url if api == "layer4" else gen_url
+            keys = active_keys_map.get(api, [])
             if generic_endpoint.get("empty") == "no elements":
                 current_status = "Not Found / Deleted"
                 if gen_endp not in self.missing_cx_logged:
@@ -2376,6 +2401,8 @@ class RealBrowserTest(Realm):
                             if len(self.created_cx.keys()) > 1:
                                 if mobile_data and mobile_data.get('empty') != 'no elements':
                                     data = mobile_data['endpoint']
+                                    if isinstance(data, dict):
+                                        data = [{data.get('name', 'endp'): data}]
                                     for endpoint in data:
                                         for _key, value in endpoint.items():
                                             if True:

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -1400,7 +1400,7 @@ class RealBrowserTest(Realm):
                         gen_endp,
                         current_status,
                         url,
-                        keys
+                        keys if current_status == "Not Found / Deleted" else generic_endpoint.get("endpoint", {})
                     ]
                 )
 

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -239,6 +239,7 @@ class RealBrowserTest(Realm):
         self.app = Flask(__name__)
         self.app.logger.setLevel(logging.WARNING)
         self.laptop_stats = {}
+        self.mobile_stats = {}
         self.user_name = None
         self.hw = None
         self.mac_list = None
@@ -2355,47 +2356,47 @@ class RealBrowserTest(Realm):
                             cx_names = []
                             # Check if multiple CX endpoints are created
                             if len(self.created_cx.keys()) > 1:
-                                data = mobile_data['endpoint']
-                                for endpoint in data:
-                                    for _key, value in endpoint.items():
-                                        if True:
-                                            cx_name = value.get('name', 'NA')
-                                            match = re.search(r'http(\d+)', cx_name)
-                                            res_no = match.group(1) if match else 'NA'
-                                            hostname = self.local_realm.json_get("resource/1/%s/list?fields=user" % (res_no))
-                                            hostname = hostname["resource"]["user"]
-                                            pass_url = value.get('total-urls', 0)
-                                            total_urls.append(pass_url)
-                                            uc_min.append(value.get('uc-min', 0.0))
-                                            uc_avg.append(value.get('uc-avg', 0.0))
-                                            uc_max.append(value.get('uc-max', 0.0))
-                                            total_err.append(value.get('total-err', 0))
-                                            hostnames.append(hostname)
-                                            cx_names.append(cx_name)
-                                            if hostname not in self.device_targets:
-                                                self.device_targets[hostname] = initial_target_urls
-                                            # Check if the mobile device reaches the current target URL count
-                                            if pass_url >= self.device_targets[hostname] and hostname not in time_taken:
-                                                time_taken[hostname] = (datetime.now() - start_time).total_seconds()
-                                # Save each mobile device's data to the CSV
-                                for i in range(len(total_urls)):
-                                    row = {
-                                        'device_type': 'mobile',
-                                        'device_name': hostnames[i],
-                                        'total_urls': total_urls[i],
-                                        'uc_min': float(uc_min[i]) / 1000,
-                                        'uc_avg': float(uc_avg[i]) / 1000,
-                                        'uc_max': float(uc_max[i]) / 1000,
-                                        'total_err': total_err[i],
-                                        'time_to_target_urls': time_taken.get(hostnames[i], 0.0),
-                                        'cx_name': cx_names[i],
-                                    }
-                                    writer.writerow(row)
-                                    last_data.append(row)
+                                if mobile_data and mobile_data.get('empty') != 'no elements':
+                                    data = mobile_data['endpoint']
+                                    for endpoint in data:
+                                        for _key, value in endpoint.items():
+                                            if True:
+                                                cx_name = value.get('name', 'NA')
+                                                match = re.search(r'http(\d+)', cx_name)
+                                                res_no = match.group(1) if match else 'NA'
+                                                hostname = self.local_realm.json_get("resource/1/%s/list?fields=user" % (res_no))
+                                                hostname = hostname["resource"]["user"]
+                                                pass_url = value.get('total-urls', 0)
+                                                total_urls.append(pass_url)
+                                                uc_min.append(value.get('uc-min', 0.0))
+                                                uc_avg.append(value.get('uc-avg', 0.0))
+                                                uc_max.append(value.get('uc-max', 0.0))
+                                                total_err.append(value.get('total-err', 0))
+                                                hostnames.append(hostname)
+                                                cx_names.append(cx_name)
+                                                if hostname not in self.device_targets:
+                                                    self.device_targets[hostname] = initial_target_urls
+                                                # Check if the mobile device reaches the current target URL count
+                                                if pass_url >= self.device_targets[hostname] and hostname not in time_taken:
+                                                    time_taken[hostname] = (datetime.now() - start_time).total_seconds()
+                                    # Save each mobile device's data to the Cache
+                                    for i in range(len(total_urls)):
+                                        row = {
+                                            'device_type': 'mobile',
+                                            'device_name': hostnames[i],
+                                            'total_urls': total_urls[i],
+                                            'uc_min': float(uc_min[i]) / 1000,
+                                            'uc_avg': float(uc_avg[i]) / 1000,
+                                            'uc_max': float(uc_max[i]) / 1000,
+                                            'total_err': total_err[i],
+                                            'time_to_target_urls': time_taken.get(hostnames[i], 0.0),
+                                            'cx_name': cx_names[i],
+                                        }
+                                        self.mobile_stats[cx_names[i]] = row
                             # Handle the case where only one CX endpoint is created
                             elif len(self.created_cx.keys()) == 1:
-                                endpoint = mobile_data.get('endpoint', {})
-                                if endpoint:
+                                if mobile_data and mobile_data.get('empty') != 'no elements':
+                                    endpoint = mobile_data.get('endpoint', {})
                                     cx_name = endpoint.get('name', 'NA')
                                     match = re.search(r'http(\d+)', cx_name)
                                     res_no = match.group(1) if match else 'NA'
@@ -2419,8 +2420,10 @@ class RealBrowserTest(Realm):
                                         'time_to_target_urls': time_taken.get(hostname, 0.0),
                                         'cx_name': cx_name
                                     }
-                                    writer.writerow(row)
-                                    last_data.append(row)
+                                    self.mobile_stats[cx_name] = row
+                            for _, row in self.mobile_stats.items():
+                                writer.writerow(row)
+                                last_data.append(row)
                     self.monitor_endpoint_status_changes()
                     time.sleep(1)
                 except Exception as e:
@@ -3248,6 +3251,7 @@ class RealBrowserTest(Realm):
             start_time = datetime.now()
             self.device_targets = {}
             self.laptop_stats = {}
+            self.mobile_stats = {}
             while datetime.now() <= end_time or not self.check_gen_cx():
                 pause, _ = self.robo_obj.wait_for_battery()
                 if pause:
@@ -3314,55 +3318,55 @@ class RealBrowserTest(Realm):
                             cx_names = []
                             # Check if multiple CX endpoints are created
                             if len(self.created_cx.keys()) > 1:
-                                data = mobile_data['endpoint']
-                                for endpoint in data:
-                                    for _key, value in endpoint.items():
-                                        if True:
-                                            cx_name = value.get('name', 'NA')
-                                            match = re.search(r'http(\d+)', cx_name)
-                                            res_no = match.group(1) if match else 'NA'
-                                            hostname = self.local_realm.json_get("resource/1/%s/list?fields=user" % (res_no))
-                                            hostname = hostname["resource"]["user"]
-                                            pass_url = value.get('total-urls', 0)
-                                            total_urls.append(pass_url)
-                                            uc_min.append(value.get('uc-min', 0.0))
-                                            uc_avg.append(value.get('uc-avg', 0.0))
-                                            uc_max.append(value.get('uc-max', 0.0))
-                                            total_err.append(value.get('total-err', 0))
-                                            hostnames.append(hostname)
-                                            cx_names.append(cx_name)
-                                            if hostname not in self.device_targets:
-                                                self.device_targets[hostname] = initial_target_urls
-                                            # Check if the mobile device reaches the current target URL count
-                                            if pass_url >= self.device_targets[hostname] and hostname not in time_taken:
-                                                time_taken[hostname] = (datetime.now() - start_time).total_seconds()
-                                            if self.do_robo:
-                                                self.robo_mobile_data[hostname] = {
-                                                    'current_angle': self.current_angle,
-                                                    'current_cord': self.current_cord,
-                                                    'rotations_enabled': self.rotations_enabled,
-                                                    'total_urls': pass_url
-                                                }
-                                # Save each mobile device's data to the CSV
-                                for i in range(len(total_urls)):
-                                    row = {
-                                        'device_type': 'mobile',
-                                        'device_name': hostnames[i],
-                                        'total_urls': total_urls[i],
-                                        'uc_min': float(uc_min[i]) / 1000,
-                                        'uc_avg': float(uc_avg[i]) / 1000,
-                                        'uc_max': float(uc_max[i]) / 1000,
-                                        'total_err': total_err[i],
-                                        'time_to_target_urls': time_taken.get(hostnames[i], 0.0),
-                                        'cx_name': cx_names[i],
-                                        'angle': angle
-                                    }
-                                    writer.writerow(row)
-                                    last_data.append(row)
+                                if mobile_data and mobile_data.get('empty') != 'no elements':
+                                    data = mobile_data.get('endpoint')
+                                    for endpoint in data:
+                                        for _key, value in endpoint.items():
+                                            if True:
+                                                cx_name = value.get('name', 'NA')
+                                                match = re.search(r'http(\d+)', cx_name)
+                                                res_no = match.group(1) if match else 'NA'
+                                                hostname = self.local_realm.json_get("resource/1/%s/list?fields=user" % (res_no))
+                                                hostname = hostname["resource"]["user"]
+                                                pass_url = value.get('total-urls', 0)
+                                                total_urls.append(pass_url)
+                                                uc_min.append(value.get('uc-min', 0.0))
+                                                uc_avg.append(value.get('uc-avg', 0.0))
+                                                uc_max.append(value.get('uc-max', 0.0))
+                                                total_err.append(value.get('total-err', 0))
+                                                hostnames.append(hostname)
+                                                cx_names.append(cx_name)
+                                                if hostname not in self.device_targets:
+                                                    self.device_targets[hostname] = initial_target_urls
+                                                # Check if the mobile device reaches the current target URL count
+                                                if pass_url >= self.device_targets[hostname] and hostname not in time_taken:
+                                                    time_taken[hostname] = (datetime.now() - start_time).total_seconds()
+                                                if self.do_robo:
+                                                    self.robo_mobile_data[hostname] = {
+                                                        'current_angle': self.current_angle,
+                                                        'current_cord': self.current_cord,
+                                                        'rotations_enabled': self.rotations_enabled,
+                                                        'total_urls': pass_url
+                                                    }
+                                    # Save each mobile device's data to the Cache
+                                    for i in range(len(total_urls)):
+                                        row = {
+                                            'device_type': 'mobile',
+                                            'device_name': hostnames[i],
+                                            'total_urls': total_urls[i],
+                                            'uc_min': float(uc_min[i]) / 1000,
+                                            'uc_avg': float(uc_avg[i]) / 1000,
+                                            'uc_max': float(uc_max[i]) / 1000,
+                                            'total_err': total_err[i],
+                                            'time_to_target_urls': time_taken.get(hostnames[i], 0.0),
+                                            'cx_name': cx_names[i],
+                                            'angle': angle
+                                        }
+                                        self.mobile_stats[cx_names[i]] = row
                             # Handle the case where only one CX endpoint is created
                             elif len(self.created_cx.keys()) == 1:
-                                endpoint = mobile_data.get('endpoint', {})
-                                if endpoint:
+                                if mobile_data and mobile_data.get('empty') != 'no elements':
+                                    endpoint = mobile_data.get('endpoint', {})
                                     cx_name = endpoint.get('name', 'NA')
                                     match = re.search(r'http(\d+)', cx_name)
                                     res_no = match.group(1) if match else 'NA'
@@ -3394,8 +3398,10 @@ class RealBrowserTest(Realm):
                                             'rotations_enabled': self.rotations_enabled,
                                             'total_urls': pass_url
                                         }
-                                    writer.writerow(row)
-                                    last_data.append(row)
+                                    self.mobile_stats[cx_name] = row
+                            for _, row in self.mobile_stats.items():
+                                writer.writerow(row)
+                                last_data.append(row)
                     self.monitor_endpoint_status_changes()
                     time.sleep(1)
                 except Exception as e:

--- a/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
+++ b/py-scripts/real_application_tests/real_browser/lf_interop_real_browser_test.py
@@ -240,6 +240,7 @@ class RealBrowserTest(Realm):
         self.app.logger.setLevel(logging.WARNING)
         self.laptop_stats = {}
         self.mobile_stats = {}
+        self.missing_cx_logged = set()
         self.user_name = None
         self.hw = None
         self.mac_list = None
@@ -1323,7 +1324,7 @@ class RealBrowserTest(Realm):
                 break
 
             logger.warning(
-                "No data received for any of the created endpoints; retrying..."
+                f"All {len(created_endp)} generic endpoint(s) are unreachable - retrying... {int(time.time() - start_time)}s/{wait_time}s before giving up and stopping the test."
             )
             time.sleep(poll_interval)
 
@@ -1335,29 +1336,46 @@ class RealBrowserTest(Realm):
             exit(1)
 
         for gen_endp, generic_endpoint in endpoint_data.items():
+            url = f"/{api}/{gen_endp}"
+            keys = list(generic_endpoint.keys())
             if generic_endpoint.get("empty") == "no elements":
                 current_status = "Not Found / Deleted"
+                if gen_endp not in self.missing_cx_logged:
+                    logger.warning(
+                        f"CX '{gen_endp}' is missing from the monitoring data, the device may have disconnected "
+                        f"or its connection was not created. Continuing the test with the remaining devices.\n"
+                        f"URL     : {url}\n"
+                        f"Response keys: {keys}"
+                    )
+                    self.missing_cx_logged.add(gen_endp)
             else:
                 current_status = generic_endpoint["endpoint"].get("status", "")
+                if gen_endp in self.missing_cx_logged:
+                    logger.info(f"CX '{gen_endp}' data is available again.")
+                    self.missing_cx_logged.discard(gen_endp)
+
             previous_status = self.endpoint_last_status.get(gen_endp)
 
             if current_status == previous_status:
                 continue
 
-            logger.info(
-                f"Endpoint {gen_endp} status changed to: {current_status}"
-            )
+            if current_status != "Not Found / Deleted":
+                logger.info(
+                    f"Endpoint {gen_endp} status changed to: {current_status}"
+                )
 
             file_exists = os.path.isfile(csv_file) and os.path.getsize(csv_file) > 0
             with open(csv_file, mode="a", newline="") as f:
                 writer = csv.writer(f)
                 if not file_exists:
-                    writer.writerow(["timestamp", "endpoint_name", "status"])
+                    writer.writerow(["timestamp", "endpoint_name", "status", "url", "response_keys"])
                 writer.writerow(
                     [
                         datetime.now().strftime("%d-%m-%Y %H:%M:%S"),
                         gen_endp,
                         current_status,
+                        url,
+                        keys
                     ]
                 )
 


### PR DESCRIPTION
- Storing layer4 data in self.mobile_stats similar to laptops and filtering responses if they are valid or not, if not valid using the last stored data, else update to latest. This prevents androids being removed in reports and live data
- Storing url and response keys in endpoint_status_changes.csv and also logging them when a cx is missing

VERIFIED CLI: 
```
python3 lf_interop_real_browser_test.py --mgr 192.168.244.97 --url "https://google.com" --duration 1m --debug --upstream_port 1.1.eth1 --device_list 1.10,1.134
```

Also verified for webGUI and robo test

Example logs:
```
1786303728.105720 INFO     Estimated End time of the Test 2026-08-10 01:00:48.105645 lf_interop_real_browser_test.py 2343
1786303728.115959 INFO     Endpoint rb-1.134.wlan0 status changed to: Stopped lf_interop_real_browser_test.py 1388
1786303728.116205 INFO     Endpoint rb-1.233.wlan0 status changed to: Stopped lf_interop_real_browser_test.py 1388
1786303728.116330 INFO     Endpoint rb_wlan0_http10_l4 status changed to: Stopped lf_interop_real_browser_test.py 1388
1786303728.116464 INFO     Endpoint rb_wlan0_http13_l4 status changed to: Stopped lf_interop_real_browser_test.py 1388
1786303730.137468 INFO     Endpoint rb-1.134.wlan0 status changed to: Run lf_interop_real_browser_test.py 1388
1786303730.137658 INFO     Endpoint rb-1.233.wlan0 status changed to: Run lf_interop_real_browser_test.py 1388
1786303732.159461 INFO     Endpoint rb_wlan0_http10_l4 status changed to: Run lf_interop_real_browser_test.py 1388
1786303733.170532 INFO     Endpoint rb_wlan0_http13_l4 status changed to: Run lf_interop_real_browser_test.py 1388
1786303737.214039 WARNING  CX 'rb-1.233.wlan0' is missing from the monitoring data, the device may have disconnected or its connection was not created. Continuing the test with the remaining devices.
URL     : generic/rb-1.134.wlan0,rb-1.233.wlan0/list?fields=name,status
Response keys: ['rb-1.134.wlan0'] lf_interop_real_browser_test.py 1369
1786303744.288804 WARNING  CX 'rb_wlan0_http10_l4' is missing from the monitoring data, the device may have disconnected or its connection was not created. Continuing the test with the remaining devices.
URL     : layer4/rb_wlan0_http10_l4,rb_wlan0_http13_l4/list?fields=name,status
Response keys: ['rb_wlan0_http13_l4'] lf_interop_real_browser_test.py 1369
1786303788.780572 INFO     Error fetching endpoint data for rb-1.233.wlan0 lf_interop_real_browser_test.py 1252
1786303788.781598 INFO     Error fetching endpoint data for rb_wlan0_http10_l4 lf_interop_real_browser_test.py 1252
1786303788.782714 INFO     Stopping CXs... http_profile.py 68
```

Client logs are being fetched and moved to report dir:
```
1786303811.428014 INFO     write_output_html: 2026-08-10-01-00-11_Real_Browser_Report/Real_Browser_Report.html lf_report.py 368
1786303811.901913 INFO     Moved iteration_0_final_data.csv to 2026-08-10-01-00-11_Real_Browser_Report lf_interop_real_browser_test.py 3118
1786303811.902005 INFO     Moved real_time_data.csv to 2026-08-10-01-00-11_Real_Browser_Report lf_interop_real_browser_test.py 3118
1786303811.902067 INFO     Moved endpoint_status_changes.csv to 2026-08-10-01-00-11_Real_Browser_Report lf_interop_real_browser_test.py 3118
1786303811.902158 INFO     Moved DesktopLatitude5490_client_test.log to 2026-08-10-01-00-11_Real_Browser_Report/log lf_interop_real_browser_test.py 3130
1786303811.902247 INFO     Moved DESKTOP-6UC6DNN_client_test.log to 2026-08-10-01-00-11_Real_Browser_Report/log lf_interop_real_browser_test.py 3130
```

Report dir: (client logs are stored in /log)
<img width="458" height="540" alt="image" src="https://github.com/user-attachments/assets/0a68f43e-f61b-4695-b1f0-92de5c13b15b" />

Current `endpoint_status_changes.csv` file output:
```
timestamp,endpoint_name,status,url,response_keys
10-08-2026 06:04:28,rb_wlan0_http11_l4,Stopped,"layer4/rb_wlan0_http11_l4/list?fields=name,status","{'!conn': 0, '_links': 'NA', 'acc. denied': 0, 'audio-format-bitrate': 0, 'bad-proto': 0, 'bad-url': 0, 'bytes-rd': 0, 'bytes-wr': 0, 'dns-avg': 0.0, 'dns-max': 0, 'dns-min': 0, 'eid': '1.11.0.88.11', 'elapsed': 0, 'entity id': '1.11.0.88.11', 'fb-avg': 0.0, 'fb-max': 0, 'fb-min': 0, 'frame-rate': 0, 'ftp-host': 0, 'ftp-port': 0, 'ftp-stor': 0, 'http-p': 0, 'http-r': 0, 'http-t': 0, 'login-denied': 0, 'name': 'rb_wlan0_http11_l4', 'nf (4xx)': 0, 'other-err': 0, 'read': 0, 'redir': 0, 'rpt timer': 5000, 'rslv-h': 0, 'rslv-p': 0, 'rx rate': 0, 'rx rate (1m)': 0, 'rx rate (last)': 0, 'status': 'Stopped', 'time-stamp': 1786341868050, 'timeout': 0, 'total-buffers': 0, 'total-err': 0, 'total-rebuffers': 0, 'total-urls': 0, 'total-wait-time': 0, 'tx rate': 0, 'tx-rate-1m': 0, 'tx rate (last)': 0, 'type': 'L4/Gen', 'uc-avg': 0.0, 'uc-max': 0, 'uc-min': 0, 'urls/s': 0.0, 'video-format-bitrate': 0, 'video-quality': '0X0', 'write': 0}"
10-08-2026 06:04:33,rb_wlan0_http11_l4,Run,"layer4/rb_wlan0_http11_l4/list?fields=name,status","{'!conn': 0, '_links': 'NA', 'acc. denied': 0, 'audio-format-bitrate': 0, 'bad-proto': 0, 'bad-url': 0, 'bytes-rd': 0, 'bytes-wr': 0, 'dns-avg': 0.0, 'dns-max': 0, 'dns-min': 0, 'eid': '1.11.0.88.11', 'elapsed': 0, 'entity id': '1.11.0.88.11', 'fb-avg': 0.0, 'fb-max': 0, 'fb-min': 0, 'frame-rate': 0, 'ftp-host': 0, 'ftp-port': 0, 'ftp-stor': 0, 'http-p': 0, 'http-r': 0, 'http-t': 0, 'login-denied': 0, 'name': 'rb_wlan0_http11_l4', 'nf (4xx)': 0, 'other-err': 0, 'read': 0, 'redir': 0, 'rpt timer': 5000, 'rslv-h': 0, 'rslv-p': 0, 'rx rate': 0, 'rx rate (1m)': 0, 'rx rate (last)': 0, 'status': 'Run', 'time-stamp': 1786341872430, 'timeout': 0, 'total-buffers': 0, 'total-err': 0, 'total-rebuffers': 0, 'total-urls': 0, 'total-wait-time': 0, 'tx rate': 0, 'tx-rate-1m': 0, 'tx rate (last)': 0, 'type': 'L4/Gen', 'uc-avg': 0.0, 'uc-max': 0, 'uc-min': 0, 'urls/s': 0.0, 'video-format-bitrate': 0, 'video-quality': '0X0', 'write': 0}"
10-08-2026 06:05:22,rb_wlan0_http11_l4,Not Found / Deleted,"layer4/rb_wlan0_http11_l4/list?fields=name,status",[]

```