### PR TITLE
test_l3.py: Add toolbox functionality

### DIFF
--- a/py-json/realm.py
+++ b/py-json/realm.py
@@ -534,8 +534,10 @@ class Realm(LFCliBase):
             response = self.json_get("/port/?fields=alias,port+type")
             if response is None:
                 return None
-            if 'interfaces' in response and isinstance(response['interfaces'], list):
-                for interface_item in response['interfaces']:
+            if 'interfaces' in response:
+                raw_interfaces = response['interfaces']
+                interfaces_list = raw_interfaces if isinstance(raw_interfaces, list) else [raw_interfaces] if isinstance(raw_interfaces, dict) else []
+                for interface_item in interfaces_list:
                     if isinstance(interface_item, dict):
                         for alias, details in interface_item.items():
                             info = self.name_to_eid(alias)
@@ -578,8 +580,10 @@ class Realm(LFCliBase):
             response = self.json_get("/port/?fields=alias,port+type")
             if response is None:
                 return None
-            if 'interfaces' in response and isinstance(response['interfaces'], list):
-                for interface_item in response['interfaces']:
+            if 'interfaces' in response:
+                raw_interfaces = response['interfaces']
+                interfaces_list = raw_interfaces if isinstance(raw_interfaces, list) else [raw_interfaces] if isinstance(raw_interfaces, dict) else []
+                for interface_item in interfaces_list:
                     if isinstance(interface_item, dict):
                         for alias, details in interface_item.items():
                             info = self.name_to_eid(alias)

--- a/py-json/realm.py
+++ b/py-json/realm.py
@@ -388,35 +388,30 @@ class Realm(LFCliBase):
         return False
 
     def admin_up(self, port_eid):
-        # logger.info("186 admin_up port_eid: "+port_eid)
         eid = self.name_to_eid(port_eid)
         resource = eid[1]
         port = eid[2]
         request = LFUtils.port_up_request(resource_id=resource, port_name=port, debug_on=self.debug)
-        # logger.info("192.admin_up request: resource: %s port_name %s"%(resource, port))
         dbg_param = ""
         if logger.getEffectiveLevel() == logging.DEBUG:
-            # logger.info("enabling url debugging")
             dbg_param = "?__debug=1"
         collected_responses = list()
-        self.json_post("/cli-json/set_port%s" % dbg_param, request, debug_=self.debug,
-                       response_json_list_=collected_responses)
-        # TODO: when doing admin-up ath10k radios, want a LF complaint about a license exception
-        # if len(collected_responses) > 0: ...
+        return self.json_post("/cli-json/set_port%s" % dbg_param, request, debug_=self.debug,
+                              response_json_list_=collected_responses)
 
     def admin_down(self, port_eid):
         eid = self.name_to_eid(port_eid)
         resource = eid[1]
         port = eid[2]
         request = LFUtils.port_down_request(resource_id=resource, port_name=port)
-        self.json_post("/cli-json/set_port", request)
+        return self.json_post("/cli-json/set_port", request)
 
     def reset_port(self, port_eid):
         eid = self.name_to_eid(port_eid)
         resource = eid[1]
         port = eid[2]
         request = LFUtils.port_reset_request(resource_id=resource, port_name=port)
-        self.json_post("cli-json/reset_port", request)
+        return self.json_post("cli-json/reset_port", request)
 
     def rm_cx(self, cx_name):
         req_url = "cli-json/rm_cx"
@@ -424,14 +419,14 @@ class Realm(LFCliBase):
             "test_mgr": "ALL",
             "cx_name": cx_name
         }
-        self.json_post(req_url, data)
+        return self.json_post(req_url, data)
 
     def rm_endp(self, ename, debug_=False, suppress_related_commands_=True):
         req_url = "cli-json/rm_endp"
         data = {
             "endp_name": ename
         }
-        self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
+        return self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
 
     def add_vrcx_(self, vr_name, local_dev, dhcp_min, dhcp_max, resource=1, debug_=False,
                   suppress_related_commands_=True):
@@ -444,16 +439,15 @@ class Realm(LFCliBase):
             "dhcp_min": dhcp_min,
             "dhcp_max": dhcp_max}
         logger.info("Modifying Connection...")
-        self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
+        return self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
 
     def netsmith_apply(self, resource, debug_=False, suppress_related_commands_=True):
         data = {
             "shelf": 1,
             "resource": resource}
         logger.info("Applying the Netsmith Config")
-        self.json_post("/cli-json/apply_vr_cfg", data, debug_=debug_,
-                       suppress_related_commands_=suppress_related_commands_)
-        time.sleep(1)
+        return self.json_post("/cli-json/apply_vr_cfg", data, debug_=debug_,
+                               suppress_related_commands_=suppress_related_commands_)
 
     def set_endp_details(self, ename, pkt_to_send, debug_=False, suppress_related_commands_=True):
         req_url = "cli-json/set_endp_details"
@@ -463,7 +457,7 @@ class Realm(LFCliBase):
             "name": ename,
             "pkts_to_send": pkt_to_send
         }
-        self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
+        return self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
 
     def set_endp_tos(self, ename, _tos, debug_=False, suppress_related_commands_=True):
         req_url = "cli-json/set_endp_tos"
@@ -485,17 +479,17 @@ class Realm(LFCliBase):
             "name": ename,
             "tos": tos
         }
-        self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
+        return self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
 
     def start_cx(self, cx_name):
-        self.json_post("/cli-json/set_cx_state", {
+        return self.json_post("/cli-json/set_cx_state", {
             "test_mgr": "ALL",
             "cx_name": cx_name,
             "cx_state": "RUNNING"
         }, debug_=self.debug)
 
     def stop_cx(self, cx_name):
-        self.json_post("/cli-json/set_cx_state", {
+        return self.json_post("/cli-json/set_cx_state", {
             "test_mgr": "ALL",
             "cx_name": cx_name,
             "cx_state": "STOPPED"
@@ -503,7 +497,7 @@ class Realm(LFCliBase):
 
     # def quiesce_cx(self, cx_name):
     def drain_stop_cx(self, cx_name):
-        self.json_post("/cli-json/set_cx_state", {
+        return self.json_post("/cli-json/set_cx_state", {
             "test_mgr": "ALL",
             "cx_name": cx_name,
             "cx_state": "QUIESCE"
@@ -515,35 +509,97 @@ class Realm(LFCliBase):
         ignore_keys = {'handler', 'uri', 'warnings'}
 
         cx_json = self.json_get("cx")
-        if cx_json and 'empty' not in cx_json and isinstance(cx_json, dict):
+        if cx_json is None:
+            return None
+
+        if 'empty' not in cx_json and isinstance(cx_json, dict):
             for key in cx_json.keys():
                 if key not in ignore_keys:
                     cx_names.append(key)
 
         return cx_names
 
-    def get_all_stations(self, prefix="sta"):
-        """Get all station names with a specific prefix.
+    def get_all_ports(self, port_type=None, prefix=None):
+        """Get all port names/EIDs on LANforge manager, optionally filtering by port type or prefix.
 
         Args:
-            prefix: Station prefix.
+            port_type: Optional port type filter (e.g., "station", "sta", "eth", "wlan", or None for all ports).
+            prefix: Optional port prefix to filter (e.g. "sta", "wlan", "eth").
 
         Returns:
-            List of station names with the specified prefix.
+            List of port EIDs/names or None if API error occurs.
+        """
+        port_names = []
+        try:
+            response = self.json_get("/port/?fields=alias,port+type")
+            if response is None:
+                return None
+            if 'interfaces' in response and isinstance(response['interfaces'], list):
+                for interface_item in response['interfaces']:
+                    if isinstance(interface_item, dict):
+                        for alias, details in interface_item.items():
+                            info = self.name_to_eid(alias)
+                            if len(info) >= 3:
+                                port_name = str(info[2])
+                                ptype = ""
+                                if isinstance(details, dict):
+                                    ptype = str(details.get('port type', details.get('type', ''))).upper()
+
+                                # Check port type filter if specified
+                                if port_type and str(port_type).lower() in {'station', 'sta', 'wifi-sta', 'wireless'}:
+                                    ptype_clean = ptype.replace(' ', '-').replace('_', '-')
+                                    is_station = (ptype_clean == 'WIFI-STA') or ('WIFI-STA' in ptype_clean) or (ptype_clean == 'WIFI-STATION') or (ptype_clean == 'STA')
+                                    if is_station:
+                                        port_names.append(alias)
+                                elif prefix and str(prefix).lower() != "all":
+                                    if port_name.startswith(str(prefix)) or (str(prefix) in port_name) or (str(prefix).upper() in ptype):
+                                        port_names.append(alias)
+                                else:
+                                    port_names.append(alias)
+                            else:
+                                port_names.append(alias)
+        except Exception as e:
+            logger.warning("Error querying ports from LANforge: %s", e)
+            return None
+
+        return port_names
+
+    def get_all_stations(self, prefix=None):
+        """Get all station port names based on LANforge port-type 'WIFI-STA' or 'STA' (not assuming 'sta' name prefix).
+
+        Args:
+            prefix: Optional prefix filter if user explicitly specifies a prefix. If None or 'sta' or 'all', matches all WIFI-STA ports.
+
+        Returns:
+            List of station port names or None if API error occurs.
         """
         sta_names = []
         try:
-            response = self.json_get("/port/?fields=alias")
-            if response and 'interfaces' in response and isinstance(response['interfaces'], list):
+            response = self.json_get("/port/?fields=alias,port+type")
+            if response is None:
+                return None
+            if 'interfaces' in response and isinstance(response['interfaces'], list):
                 for interface_item in response['interfaces']:
                     if isinstance(interface_item, dict):
-                        for alias in interface_item.keys():
+                        for alias, details in interface_item.items():
                             info = self.name_to_eid(alias)
-                            port_name = str(info[2])
-                            if port_name.startswith(prefix) or ('sta' in port_name):
+                            port_name = str(info[2]) if len(info) >= 3 else str(alias)
+                            ptype = ""
+                            if isinstance(details, dict):
+                                ptype = str(details.get('port type', details.get('type', ''))).strip().upper().replace(' ', '-').replace('_', '-')
+
+                            is_sta_type = ('WIFI-STA' in ptype) or (ptype == 'STA') or ('WIFI-STATION' in ptype)
+                            if is_sta_type:
+                                if prefix and str(prefix).lower() not in ("sta", "all"):
+                                    if port_name.startswith(str(prefix)) or str(prefix) in port_name:
+                                        sta_names.append(alias)
+                                else:
+                                    sta_names.append(alias)
+                            elif prefix and str(prefix).lower() not in ("sta", "all") and (port_name.startswith(str(prefix)) or str(prefix) in port_name):
                                 sta_names.append(alias)
         except Exception as e:
-            logger.warning("Error querying stations from LANforge: %s", e)
+            logger.warning("Error querying station ports from LANforge: %s", e)
+            return None
 
         return sta_names
 

--- a/py-json/realm.py
+++ b/py-json/realm.py
@@ -487,6 +487,13 @@ class Realm(LFCliBase):
         }
         self.json_post(req_url, data, debug_=debug_, suppress_related_commands_=suppress_related_commands_)
 
+    def start_cx(self, cx_name):
+        self.json_post("/cli-json/set_cx_state", {
+            "test_mgr": "ALL",
+            "cx_name": cx_name,
+            "cx_state": "RUNNING"
+        }, debug_=self.debug)
+
     def stop_cx(self, cx_name):
         self.json_post("/cli-json/set_cx_state", {
             "test_mgr": "ALL",
@@ -501,6 +508,78 @@ class Realm(LFCliBase):
             "cx_name": cx_name,
             "cx_state": "QUIESCE"
         }, debug_=self.debug)
+
+    def get_all_cxs(self):
+        """Get all Cross-connection names."""
+        cx_names = []
+        ignore_keys = {'handler', 'uri', 'warnings'}
+
+        cx_json = self.json_get("cx")
+        if cx_json and 'empty' not in cx_json and isinstance(cx_json, dict):
+            for key in cx_json.keys():
+                if key not in ignore_keys:
+                    cx_names.append(key)
+
+        return cx_names
+
+    def get_all_stations(self, prefix="sta"):
+        """Get all station names with a specific prefix.
+
+        Args:
+            prefix: Station prefix.
+
+        Returns:
+            List of station names with the specified prefix.
+        """
+        sta_names = []
+        try:
+            response = self.json_get("/port/?fields=alias")
+            if response and 'interfaces' in response and isinstance(response['interfaces'], list):
+                for interface_item in response['interfaces']:
+                    if isinstance(interface_item, dict):
+                        for alias in interface_item.keys():
+                            info = self.name_to_eid(alias)
+                            port_name = str(info[2])
+                            if port_name.startswith(prefix) or ('sta' in port_name):
+                                sta_names.append(alias)
+        except Exception as e:
+            logger.warning("Error querying stations from LANforge: %s", e)
+
+        return sta_names
+
+    def is_port_exists(self, target, existing_ports):
+        """Verify the target or given port present or not.
+
+        Args:
+            target: The port name to check.
+            existing_ports: List of existing port names.
+
+        Returns:
+            The matching port name if found, otherwise None.
+        """
+        target_clean = str(target).strip()
+        for port in existing_ports:
+            port_clean = str(port).strip()
+            if target_clean == port_clean or port_clean.endswith(f".{target_clean}") or target_clean in port_clean:
+                return port_clean
+        return None
+
+    def is_cx_exists(self, target, existing_cxs):
+        """Verify the target or given cross-connection present or not.
+
+        Args:
+            target: The cross-connection name to check.
+            existing_cxs: List of existing cross-connection names.
+
+        Returns:
+            The matching cross-connection name if found, otherwise None.
+        """
+        target_clean = str(target).strip()
+        for cx in existing_cxs:
+            cx_clean = str(cx).strip()
+            if target_clean == cx_clean or target_clean in cx_clean:
+                return cx_clean
+        return None
 
     def cleanup_cxe_prefix(self, prefix):
         cx_list = self.cx_list()

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -9534,7 +9534,402 @@ INCLUDE_IN_README: False
                           default='',
                           help='Comma-separated list of device counts to incrementally test (e.g., "1,3,5")')
 
+    # TOOLBOX ARGS
+    optional.add_argument('--toolbox', '--tool_box',
+                          dest='toolbox',
+                          action='store_true',
+                          help='Enable toolbox mode to execute a single building block action and exit immediately.')
+
+    optional.add_argument('--create_station', '--create_stations',
+                          dest='create_station',
+                          action='store_true',
+                          help='Toolbox action: Create stations using specified --radio configuration.')
+
+    optional.add_argument('--stations',
+                          nargs='+',
+                          default=None,
+                          help='Specify station port EIDs / names (comma or space separated, e.g. "1.1.sta1000,1.1.sta10001").')
+
+    optional.add_argument('--build_cxs', '--build_cx', '--build_cx',
+                          dest='build_cxs',
+                          action='store_true',
+                          help='Toolbox action: Build Layer-3 cross-connections between --upstream_port and --stations for specified --endp_type.')
+
+    optional.add_argument('--stop_cx',
+                          nargs='?',
+                          const='all',
+                          default=None,
+                          help='Toolbox action: Stop specified cross-connections (comma-separated list, e.g. "cx_1,cx_2" or "all" [default]).')
+
+    optional.add_argument('--start_cx',
+                          nargs='?',
+                          const='all',
+                          default=None,
+                          help='Toolbox action: Start specified cross-connections (comma-separated list, e.g. "cx_1,cx_2" or "all" [default]).')
+
+    optional.add_argument('--del_cx',
+                          nargs='?',
+                          const='all',
+                          default=None,
+                          help='Toolbox action: Delete specified cross-connections (comma-separated list, e.g. "cx_1,cx_2" or "all" [default]). Also removes associated endpoints.')
+
+    optional.add_argument('--del_stations',
+                          nargs='?',
+                          const='all',
+                          default=None,
+                          help='Toolbox action: Delete specified Wi-Fi stations (comma-separated list, e.g. "sta0000,sta0001" or default: all stations with "sta" prefix).')
+
+    optional.add_argument('--ports_up',
+                          nargs='?',
+                          const='all',
+                          default=None,
+                          help='Toolbox action: Set specified stations/ports admin UP (comma-separated list, e.g. "sta0000,sta0001" or default: all stations with "sta" prefix).')
+
+    optional.add_argument('--ports_down',
+                          nargs='?',
+                          const='all',
+                          default=None,
+                          help='Toolbox action: Set specified stations/ports admin DOWN (comma-separated list, e.g. "sta0000,sta0001" or default: all stations with "sta" prefix).')
+
+
     return parser.parse_args()
+
+
+def handle_toolbox(args):
+    """Execute standalone toolbox actions for LANforge building-block operations.
+
+    Args:
+        args: Parsed command line arguments instance.
+
+    Returns:
+        bool: True if a toolbox action was executed, otherwise False.
+    """
+    if not args.toolbox:
+        return False
+
+    logger.info("Toolbox mode enabled.")
+    lf_realm = Realm(lfclient_host=args.lfmgr, lfclient_port=args.lfmgr_port, debug_=args.debug)
+    action_performed = False
+
+    # Action 1: Station Creation (--create_station)
+    if getattr(args, 'create_station', False):
+        action_performed = True
+        logger.info("Toolbox: Creating station(s)...")
+
+        if not args.radio:
+            logger.warning("Toolbox: --create_station specified, but no --radio configuration provided.")
+        else:
+            radios = args.radio if isinstance(args.radio, list) else [args.radio]
+            sta_offset = int(args.sta_start_offset) if args.sta_start_offset else 0
+            total_created = 0
+
+            for radio_ in radios:
+                radio_info_dict = dict(
+                    map(
+                        lambda x: x.split('=='),
+                        str(radio_).replace('"', '').replace('[', '').replace(']', '').replace("'", "").replace(',', ' ').split()
+                    )
+                )
+                radio_name = radio_info_dict.get('radio', 'wiphy0')
+                num_stations = int(radio_info_dict.get('stations', 1))
+                ssid = radio_info_dict.get('ssid', '')
+                ssid_pw = radio_info_dict.get('ssid_pw', '[BLANK]')
+                security = radio_info_dict.get('security', 'open')
+                wifi_mode = radio_info_dict.get('mode', None)
+
+                logger.info(
+                    "Toolbox: Creating %d station(s) on radio '%s' (SSID: '%s', Security: '%s', Start Offset: %d)...",
+                    num_stations, radio_name, ssid, security, sta_offset
+                )
+
+                station_profile = lf_realm.new_station_profile()
+                station_profile.lfclient_url = lf_realm.lfclient_url
+                station_profile.ssid = ssid
+                station_profile.ssid_pass = ssid_pw
+                station_profile.security = security
+                if wifi_mode is not None:
+                    station_profile.mode = wifi_mode
+
+                station_list = LFUtils.portNameSeries(
+                    prefix_="sta",
+                    start_id_=sta_offset,
+                    end_id_=sta_offset + num_stations - 1,
+                    padding_number_=10000,
+                    radio=radio_name
+                )
+
+                station_profile.use_security(security, ssid, ssid_pw)
+                station_profile.create(
+                    radio=radio_name,
+                    sta_names_=station_list,
+                    debug=args.debug,
+                    up_=True
+                )
+
+                for sta in station_list:
+                    lf_realm.admin_up(sta)
+
+                sta_offset += 1000
+                total_created += num_stations
+
+            logger.info("Toolbox: Successfully created %d station(s).", total_created)
+
+    # Action 2: Layer-3 Cross-Connection Building (--build_cxs)
+    if getattr(args, 'build_cxs', False) or getattr(args, 'build_cx', False):
+        action_performed = True
+        logger.info("Toolbox: Building Layer-3 cross-connection(s)...")
+        if not args.stations:
+            logger.warning("Toolbox: --build_cxs specified, but no --stations provided.")
+        else:
+            stations = []
+            st_raw = args.stations if isinstance(args.stations, list) else [args.stations]
+            for s in st_raw:
+                cleaned = str(s).replace('[', '').replace(']', '').replace("'", '').replace('"', '').split(',')
+                for item in cleaned:
+                    if item.strip():
+                        stations.append(item.strip())
+
+            upstream_port = args.upstream_port
+            endp_types = args.endp_type if isinstance(args.endp_type, list) else [args.endp_type] if args.endp_type else ["lf_udp"]
+            tos_list = args.tos if isinstance(args.tos, list) else [args.tos] if args.tos else ["BE"]
+
+            cx_profile = lf_realm.new_l3_cx_profile()
+            cx_profile.host = args.lfmgr
+            cx_profile.port = args.lfmgr_port
+            cx_profile.side_a_min_bps = args.side_a_min_bps if hasattr(args, 'side_a_min_bps') else "256000"
+            cx_profile.side_a_max_bps = cx_profile.side_a_min_bps
+            cx_profile.side_b_min_bps = args.side_b_min_bps if getattr(args, 'side_b_min_bps', None) else "256000"
+            cx_profile.side_b_max_bps = cx_profile.side_b_min_bps
+
+            for etype in endp_types:
+                for _tos in tos_list:
+                    logger.info("Creating Layer-3 connections for endpoint type: %s, TOS: %s between upstream '%s' and stations %s", etype, _tos, upstream_port, stations)
+                    these_cx, these_endp = cx_profile.create(
+                        endp_type=etype,
+                        side_a=stations,
+                        side_b=upstream_port,
+                        sleep_time=0,
+                        tos=_tos,
+                        add_tos_to_name=True
+                    )
+                    logger.info("Created Layer-3 cross-connections: %s", these_cx)
+
+    # Action 3: Stop Cross Connections (--stop_cx)
+    if args.stop_cx is not None:
+        action_performed = True
+        target_cxs = str(args.stop_cx).strip()
+        existing_cxs = lf_realm.get_all_cxs()
+
+        if not target_cxs or target_cxs.lower() == 'all':
+            logger.info("Toolbox: Stopping all cross-connections ('all')...")
+            if not existing_cxs:
+                logger.warning("No cross-connection stopped due to unavailable")
+            else:
+                logger.info("Found %d cross-connection(s): %s", len(existing_cxs), existing_cxs)
+                for cx_name in existing_cxs:
+                    logger.info("Stopping cross-connection '%s'", cx_name)
+                    lf_realm.stop_cx(cx_name)
+                logger.info("Successfully stopped %d cross-connection(s).", len(existing_cxs))
+        else:
+            cx_list = [c.strip() for c in target_cxs.split(',') if c.strip()]
+            logger.info("Toolbox: Stopping specified cross-connections: %s", cx_list)
+            stopped_count = 0
+            for cx_name in cx_list:
+                matched_cx = lf_realm.is_cx_exists(cx_name, existing_cxs)
+                if matched_cx:
+                    logger.info("Stopping cross-connection '%s'", matched_cx)
+                    lf_realm.stop_cx(matched_cx)
+                    stopped_count += 1
+                else:
+                    logger.warning("No cross-connection stopped due to unavailable: '%s'", cx_name)
+
+            if stopped_count == 0:
+                logger.warning("No cross-connection stopped due to unavailable")
+            else:
+                logger.info("Completed stopping %d cross-connection(s).", stopped_count)
+
+    # Action 4: Start Cross Connections (--start_cx)
+    if args.start_cx is not None:
+        action_performed = True
+        target_cxs = str(args.start_cx).strip()
+        existing_cxs = lf_realm.get_all_cxs()
+
+        if not target_cxs or target_cxs.lower() == 'all':
+            logger.info("Toolbox: Starting all cross-connections ('all')...")
+            if not existing_cxs:
+                logger.warning("No cross-connection started due to unavailable")
+            else:
+                logger.info("Found %d cross-connection(s): %s", len(existing_cxs), existing_cxs)
+                for cx_name in existing_cxs:
+                    logger.info("Starting cross-connection '%s'", cx_name)
+                    lf_realm.start_cx(cx_name)
+                logger.info("Successfully started %d cross-connection(s).", len(existing_cxs))
+        else:
+            cx_list = [c.strip() for c in target_cxs.split(',') if c.strip()]
+            logger.info("Toolbox: Starting specified cross-connections: %s", cx_list)
+            started_count = 0
+            for cx_name in cx_list:
+                matched_cx = lf_realm.is_cx_exists(cx_name, existing_cxs)
+                if matched_cx:
+                    logger.info("Starting cross-connection '%s'", matched_cx)
+                    lf_realm.start_cx(matched_cx)
+                    started_count += 1
+                else:
+                    logger.warning("No cross-connection started due to unavailable: '%s'", cx_name)
+
+            if started_count == 0:
+                logger.warning("No cross-connection started due to unavailable")
+            else:
+                logger.info("Completed starting %d cross-connection(s).", started_count)
+
+    # Action 5: Delete Cross Connections (--del_cx)
+    if args.del_cx is not None:
+        action_performed = True
+        target_cxs = str(args.del_cx).strip()
+        existing_cxs = lf_realm.get_all_cxs()
+
+        if not target_cxs or target_cxs.lower() == 'all':
+            logger.info("Toolbox: Deleting all cross-connections ('all')...")
+            if not existing_cxs:
+                logger.warning("No cross-connection deleted due to unavailable")
+            else:
+                logger.info("Found %d cross-connection(s) to delete: %s", len(existing_cxs), existing_cxs)
+                for cx_name in existing_cxs:
+                    logger.info("Deleting cross-connection '%s'", cx_name)
+                    lf_realm.rm_cx(cx_name)
+                    lf_realm.rm_endp(cx_name + "-A")
+                    lf_realm.rm_endp(cx_name + "-B")
+                logger.info("Successfully deleted %d cross-connection(s).", len(existing_cxs))
+        else:
+            cx_list = [c.strip() for c in target_cxs.split(',') if c.strip()]
+            logger.info("Toolbox: Deleting specified cross-connections: %s", cx_list)
+            deleted_count = 0
+            for cx_name in cx_list:
+                matched_cx = lf_realm.is_cx_exists(cx_name, existing_cxs)
+                if matched_cx:
+                    logger.info("Deleting cross-connection '%s'", matched_cx)
+                    lf_realm.rm_cx(matched_cx)
+                    lf_realm.rm_endp(matched_cx + "-A")
+                    lf_realm.rm_endp(matched_cx + "-B")
+                    deleted_count += 1
+                else:
+                    logger.warning("No cross-connection deleted due to unavailable: '%s'", cx_name)
+
+            if deleted_count == 0:
+                logger.warning("No cross-connection deleted due to unavailable")
+            else:
+                logger.info("Completed deleting %d cross-connection(s).", deleted_count)
+
+    # Action 6: Delete Stations (--del_stations)
+    if args.del_stations is not None:
+        action_performed = True
+        target_stas = str(args.del_stations).strip()
+        existing_stas = lf_realm.get_all_stations(prefix="sta")
+
+        if not target_stas or target_stas.lower() == 'all':
+            logger.info("Toolbox: Deleting all stations with 'sta' prefix...")
+            if not existing_stas:
+                logger.warning("No stations deleted due to unavailable")
+            else:
+                logger.info("Found %d station(s) to delete: %s", len(existing_stas), existing_stas)
+                for sta_name in existing_stas:
+                    logger.info("Deleting station '%s'", sta_name)
+                    lf_realm.admin_down(sta_name)
+                    lf_realm.rm_port(sta_name)
+                logger.info("Successfully deleted %d station(s).", len(existing_stas))
+        else:
+            sta_list = [s.strip() for s in target_stas.split(',') if s.strip()]
+            logger.info("Toolbox: Deleting specified stations: %s", sta_list)
+            deleted_count = 0
+            for sta_name in sta_list:
+                matched_port = lf_realm.is_port_exists(sta_name, existing_stas)
+                if matched_port:
+                    logger.info("Deleting station '%s'", matched_port)
+                    lf_realm.admin_down(matched_port)
+                    lf_realm.rm_port(matched_port)
+                    deleted_count += 1
+                else:
+                    logger.warning("No stations deleted due to unavailable: '%s'", sta_name)
+
+            if deleted_count == 0:
+                logger.warning("No stations deleted due to unavailable")
+            else:
+                logger.info("Completed deleting %d station(s).", deleted_count)
+
+    # Action 7: Ports Admin UP (--ports_up)
+    if args.ports_up is not None:
+        action_performed = True
+        target_stas = str(args.ports_up).strip()
+        existing_stas = lf_realm.get_all_stations(prefix="sta")
+
+        if not target_stas or target_stas.lower() == 'all':
+            logger.info("Toolbox: Setting all stations with 'sta' prefix admin UP...")
+            if not existing_stas:
+                logger.warning("No ports set admin up due to unavailable")
+            else:
+                logger.info("Found %d station(s) to set admin UP: %s", len(existing_stas), existing_stas)
+                for sta_name in existing_stas:
+                    logger.info("Setting station '%s' admin UP", sta_name)
+                    lf_realm.admin_up(sta_name)
+                logger.info("Successfully set %d station(s) admin UP.", len(existing_stas))
+        else:
+            sta_list = [s.strip() for s in target_stas.split(',') if s.strip()]
+            logger.info("Toolbox: Setting specified stations admin UP: %s", sta_list)
+            up_count = 0
+            for sta_name in sta_list:
+                matched_port = lf_realm.is_port_exists(sta_name, existing_stas)
+                if matched_port:
+                    logger.info("Setting station '%s' admin UP", matched_port)
+                    lf_realm.admin_up(matched_port)
+                    up_count += 1
+                else:
+                    logger.warning("No ports set admin up due to unavailable: '%s'", sta_name)
+
+            if up_count == 0:
+                logger.warning("No ports set admin up due to unavailable")
+            else:
+                logger.info("Completed setting %d station(s) admin UP.", up_count)
+
+    # Action 8: Ports Admin DOWN (--ports_down)
+    if args.ports_down is not None:
+        action_performed = True
+        target_stas = str(args.ports_down).strip()
+        existing_stas = lf_realm.get_all_stations(prefix="sta")
+
+        if not target_stas or target_stas.lower() == 'all':
+            logger.info("Toolbox: Setting all stations with 'sta' prefix admin DOWN...")
+            if not existing_stas:
+                logger.warning("No ports set admin down due to unavailable")
+            else:
+                logger.info("Found %d station(s) to set admin DOWN: %s", len(existing_stas), existing_stas)
+                for sta_name in existing_stas:
+                    logger.info("Setting station '%s' admin DOWN", sta_name)
+                    lf_realm.admin_down(sta_name)
+                logger.info("Successfully set %d station(s) admin DOWN.", len(existing_stas))
+        else:
+            sta_list = [s.strip() for s in target_stas.split(',') if s.strip()]
+            logger.info("Toolbox: Setting specified stations admin DOWN: %s", sta_list)
+            down_count = 0
+            for sta_name in sta_list:
+                matched_port = lf_realm.is_port_exists(sta_name, existing_stas)
+                if matched_port:
+                    logger.info("Setting station '%s' admin DOWN", matched_port)
+                    lf_realm.admin_down(matched_port)
+                    down_count += 1
+                else:
+                    logger.warning("No ports set admin down due to unavailable: '%s'", sta_name)
+
+            if down_count == 0:
+                logger.warning("No ports set admin down due to unavailable")
+            else:
+                logger.info("Completed setting %d station(s) admin DOWN.", down_count)
+
+    if action_performed:
+        logger.info("Toolbox action completed successfully.")
+        return True
+
+    logger.warning("Toolbox flag specified, but no valid toolbox action provided.")
+    return True
 
 
 # Starting point for running this from cmd line.
@@ -9698,6 +10093,10 @@ and generate a report.
         # logger_config.lf_logger_config_json = "lf_logger_config.json"
         logger_config.lf_logger_config_json = args.lf_logger_config_json
         logger_config.load_lf_logger_config()
+
+    if args.toolbox:
+        handle_toolbox(args)
+        sys.exit(0)
 
     validate_args(args)
     endp_input_list = []

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -10277,12 +10277,35 @@ def main():
 
     help_summary = '''\
 The Layer 3 Traffic Generation Test is designed to test the performance of the
-Access Point by running layer 3 TCP and/or UDP Traffic.  Layer-3 Cross-Connects represent a stream
+Access Point by running layer 3 TCP and/or UDP Traffic. Layer-3 Cross-Connects represent a stream
 of data flowing through the system under test. A Cross-Connect (CX) is composed of two Endpoints,
 each of which is associated with a particular Port (physical or virtual interface).
 
 The test will create stations, create CX traffic between upstream port and stations, run traffic
 and generate a report.
+
+Toolbox Mode (--toolbox):
+Executes standalone, atomic LANforge building-block actions and exits immediately with status code 0 on success or 1 on failure.
+
+Toolbox Actions:
+  --create_station       Create stations using specified --radio config
+  --build_cxs            Build Layer-3 cross-connections between --upstream_port and --ports (or --downstream_ports)
+  --cx_names             Specify custom cross-connection name or prefix (e.g. wlan0, toolbox)
+  --start_cx             Start specified cross-connection(s) by name or 'all'
+  --stop_cx              Stop specified cross-connection(s) by name or 'all'
+  --del_cx               Delete specified cross-connection(s) by name or 'all'
+  --del_stations         Delete specified Wi-Fi station ports by name or 'all'
+  --ports_up             Set specified ports Admin UP
+  --ports_down           Set specified ports Admin DOWN
+
+Examples:
+  # Create station & build cross-connection with custom name 'wlan0':
+  python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --create_station --radio "radio==wiphy0 stations==1" --build_cxs --upstream_port 1.1.eth1 --cx_names wlan0
+
+  # Start, stop, or delete specific cross-connection by name:
+  python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --start_cx wlan0
+  python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --stop_cx wlan0
+  python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --del_cx wlan0
 '''
     args = parse_args()
 

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -9667,7 +9667,8 @@ def handle_toolbox(args):
             existing_all_ports = lf_realm.get_all_ports() or []
             existing_sta_indices = []
             for p in existing_all_ports:
-                p_name = p.split('.')[-1] if '.' in p else p
+                eid = lf_realm.name_to_eid(p)
+                p_name = str(eid[2]) if len(eid) >= 3 else str(p)
                 if p_name.startswith('sta'):
                     digits = ''.join(c for c in p_name[3:] if c.isdigit())
                     if digits:
@@ -9704,7 +9705,8 @@ def handle_toolbox(args):
                 wifi_mode = radio_info_dict.get('mode', None)
 
                 # Validate radio interface via LANforge JSON API port-type
-                radio_clean = radio_name.split('.')[-1] if '.' in radio_name else radio_name
+                r_eid = lf_realm.name_to_eid(radio_name)
+                radio_clean = str(r_eid[2]) if len(r_eid) >= 3 else str(radio_name)
                 port_type = None
                 try:
                     port_info = lf_realm.json_get("/port/1/1/%s?fields=alias,port+type" % radio_clean)
@@ -9797,10 +9799,14 @@ def handle_toolbox(args):
                 sta_offset += 1000
                 total_processed += num_stations
 
-            if total_processed > 0:
+            if total_processed > 0 and action_success:
                 logger.info("Toolbox: Successfully processed %d station(s).", total_processed)
             else:
                 action_success = False
+
+        if not action_success:
+            logger.error("Toolbox: Station creation action failed. Halting remaining actions.")
+            return False
 
     # Action 2: Layer-3 Cross-Connection Building (--build_cxs / --build_cx)
     if getattr(args, 'build_cxs', False) or getattr(args, 'build_cx', False):
@@ -9877,7 +9883,13 @@ def handle_toolbox(args):
                                     logger.info("Created Layer-3 cross-connections: %s", these_cx)
                             except Exception as cx_err:
                                 logger.error("Toolbox: Failed to create Layer-3 cross-connections: %s", cx_err)
-                            # Action 3: Stop Cross Connections (--stop_cx)
+                                action_success = False
+
+        if not action_success:
+            logger.error("Toolbox: Cross-connection building action failed. Halting remaining actions.")
+            return False
+
+    # Action 3: Stop Cross Connections (--stop_cx)
     if args.stop_cx is not None:
         action_performed = True
         target_cxs = str(args.stop_cx).strip()
@@ -9930,6 +9942,10 @@ def handle_toolbox(args):
                 logger.info("Completed stopping %d cross-connection(s).", stopped_count)
             else:
                 logger.error("Completed stopping cross-connections with errors (%d of %d succeeded).", stopped_count, len(cx_list))
+
+        if not action_success:
+            logger.error("Toolbox: Stop cross-connections action failed. Halting remaining actions.")
+            return False
 
     # Action 4: Start Cross Connections (--start_cx)
     if args.start_cx is not None:
@@ -9985,6 +10001,10 @@ def handle_toolbox(args):
             else:
                 logger.error("Completed starting cross-connections with errors (%d of %d succeeded).", started_count, len(cx_list))
 
+        if not action_success:
+            logger.error("Toolbox: Start cross-connections action failed. Halting remaining actions.")
+            return False
+
     # Action 5: Delete Cross Connections (--del_cx)
     if args.del_cx is not None:
         action_performed = True
@@ -10035,6 +10055,10 @@ def handle_toolbox(args):
                 logger.info("Completed deleting %d cross-connection(s).", deleted_count)
             else:
                 logger.error("Completed deleting cross-connections with errors (%d of %d succeeded).", deleted_count, len(cx_list))
+
+        if not action_success:
+            logger.error("Toolbox: Delete cross-connections action failed. Halting remaining actions.")
+            return False
 
     # Action 6: Delete Stations (--del_stations)
     if getattr(args, 'del_stations', None) is not None:
@@ -10090,6 +10114,10 @@ def handle_toolbox(args):
             else:
                 logger.error("Completed deleting stations with errors (%d of %d succeeded).", deleted_count, len(sta_list))
 
+        if not action_success:
+            logger.error("Toolbox: Delete stations action failed. Halting remaining actions.")
+            return False
+
     # Action 7: Ports Admin UP (--ports_up)
     if args.ports_up is not None:
         action_performed = True
@@ -10144,6 +10172,10 @@ def handle_toolbox(args):
                 logger.info("Completed setting %d port(s) admin UP.", up_count)
             else:
                 logger.error("Completed setting ports admin UP with errors (%d of %d succeeded).", up_count, len(port_list))
+
+        if not action_success:
+            logger.error("Toolbox: Ports admin UP action failed. Halting remaining actions.")
+            return False
 
     # Action 8: Ports Admin DOWN (--ports_down)
     if args.ports_down is not None:

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -9703,16 +9703,38 @@ def handle_toolbox(args):
                 security = radio_info_dict.get('security', 'open')
                 wifi_mode = radio_info_dict.get('mode', None)
 
-                # Reject station creation on non-wireless radios (e.g. 1.1.eth2, eth0, br0, macvlan0)
-                radio_clean = radio_name.split('.')[-1].lower() if '.' in radio_name else radio_name.lower()
-                invalid_prefixes = ('eth', 'br', 'macvlan', 'bond', 'vlan', 'lo', 'gre', 'tun', 'tap')
-                if any(radio_clean.startswith(p) for p in invalid_prefixes) or 'eth' in radio_clean:
-                    logger.error(
-                        "Toolbox: Invalid radio '%s' specified for station creation. Non-wireless interfaces (e.g., eth, bridge, macvlan) cannot be used as radios for station creation.",
-                        radio_name
-                    )
-                    action_success = False
-                    continue
+                # Validate radio interface via LANforge JSON API port-type
+                radio_clean = radio_name.split('.')[-1] if '.' in radio_name else radio_name
+                port_type = None
+                try:
+                    port_info = lf_realm.json_get("/port/1/1/%s?fields=alias,port+type" % radio_clean)
+                    if port_info and 'interface' in port_info:
+                        port_type = str(port_info['interface'].get('port type', port_info['interface'].get('type', ''))).strip().upper()
+                except Exception as p_err:
+                    logger.debug("Toolbox: Could not query port type for radio '%s': %s", radio_name, p_err)
+
+                if port_type:
+                    # Validate port type returned by LANforge JSON API
+                    is_radio_type = any(t in port_type for t in ('RADIO', 'WIFI', 'WIPHY', 'DEV', 'PHY'))
+                    is_non_radio = any(t in port_type for t in ('ETH', 'ETHERNET', 'BRIDGE', 'VLAN', 'MACVLAN', 'BOND', 'TUN', 'TAP', 'GRE'))
+                    if is_non_radio or not is_radio_type:
+                        logger.error(
+                            "Toolbox: Port '%s' has port-type '%s' and cannot be used for station creation. Radio interface must be a wireless radio (e.g., WIFI-RADIO).",
+                            radio_name, port_type
+                        )
+                        action_success = False
+                        continue
+                else:
+                    # Fallback to name check if port-type is not returned by JSON API
+                    radio_clean_lower = radio_clean.lower()
+                    invalid_prefixes = ('eth', 'br', 'macvlan', 'bond', 'vlan', 'lo', 'gre', 'tun', 'tap')
+                    if any(radio_clean_lower.startswith(p) for p in invalid_prefixes) or 'eth' in radio_clean_lower:
+                        logger.error(
+                            "Toolbox: Invalid radio '%s' specified for station creation. Non-wireless interfaces (e.g., eth, bridge, macvlan) cannot be used as radios for station creation.",
+                            radio_name
+                        )
+                        action_success = False
+                        continue
 
                 if num_stations <= 0:
                     logger.error("Toolbox: Invalid station count (%d) specified for radio '%s'. Count must be at least 1.", num_stations, radio_name)
@@ -9855,9 +9877,7 @@ def handle_toolbox(args):
                                     logger.info("Created Layer-3 cross-connections: %s", these_cx)
                             except Exception as cx_err:
                                 logger.error("Toolbox: Failed to create Layer-3 cross-connections: %s", cx_err)
-                                action_success = False
-
-    # Action 3: Stop Cross Connections (--stop_cx)
+                            # Action 3: Stop Cross Connections (--stop_cx)
     if args.stop_cx is not None:
         action_performed = True
         target_cxs = str(args.stop_cx).strip()
@@ -9872,12 +9892,19 @@ def handle_toolbox(args):
                 logger.warning("No cross-connections found on LANforge manager to stop.")
             else:
                 logger.info("Found %d cross-connection(s): %s", len(existing_cxs), existing_cxs)
+                success_count = 0
                 for cx_name in existing_cxs:
                     logger.info("Stopping cross-connection '%s'", cx_name)
                     res = lf_realm.stop_cx(cx_name)
                     if res is None or res is False:
+                        logger.error("Toolbox: Failed to stop cross-connection '%s'.", cx_name)
                         action_success = False
-                logger.info("Successfully stopped %d cross-connection(s).", len(existing_cxs))
+                    else:
+                        success_count += 1
+                if action_success:
+                    logger.info("Successfully stopped %d cross-connection(s).", success_count)
+                else:
+                    logger.error("Failed to stop some cross-connections (%d of %d succeeded).", success_count, len(existing_cxs))
         else:
             cx_list = parse_list(target_cxs)
             logger.info("Toolbox: Stopping specified cross-connections: %s", cx_list)
@@ -9888,8 +9915,10 @@ def handle_toolbox(args):
                     logger.info("Stopping cross-connection '%s'", matched_cx)
                     res = lf_realm.stop_cx(matched_cx)
                     if res is None or res is False:
+                        logger.error("Toolbox: Failed to stop cross-connection '%s'.", matched_cx)
                         action_success = False
-                    stopped_count += 1
+                    else:
+                        stopped_count += 1
                 else:
                     logger.error("Requested cross-connection '%s' not found on LANforge manager.", cx_name)
                     action_success = False
@@ -9897,34 +9926,10 @@ def handle_toolbox(args):
             if stopped_count == 0 and cx_list:
                 logger.error("Failed to stop any requested cross-connections.")
                 action_success = False
-            else:
+            elif action_success:
                 logger.info("Completed stopping %d cross-connection(s).", stopped_count)
-
-    # Helper function to check if cross-connection uses a disconnected Wi-Fi station
-    def check_cx_sta_connection(cx_name):
-        try:
-            all_ports = lf_realm.get_all_ports() or []
-            for port_eid in all_ports:
-                port_name = port_eid.split('.')[-1] if '.' in port_eid else port_eid
-                if port_name.startswith('sta') and port_name in cx_name:
-                    port_info = lf_realm.json_get("/port/1/1/%s?fields=alias,ip,port+type,flags" % port_name)
-                    if port_info and 'interface' in port_info:
-                        p_data = port_info['interface']
-                        ip_addr = p_data.get('ip', '0.0.0.0')
-                        if ip_addr in ('0.0.0.0', 'NA', '', '0.0.0.0/0'):
-                            logger.error(
-                                "Toolbox: Cannot start endpoint A because it is on a wifi STA ('%s') that is not connected.",
-                                port_name
-                            )
-                            return True
-                    logger.error(
-                        "Toolbox: Cannot start endpoint A because it is on a wifi STA ('%s') that is not connected.",
-                        port_name
-                    )
-                    return True
-        except Exception as err:
-            logger.debug("Toolbox: Station connection check error for '%s': %s", cx_name, err)
-        return False
+            else:
+                logger.error("Completed stopping cross-connections with errors (%d of %d succeeded).", stopped_count, len(cx_list))
 
     # Action 4: Start Cross Connections (--start_cx)
     if args.start_cx is not None:
@@ -9941,13 +9946,19 @@ def handle_toolbox(args):
                 logger.warning("No cross-connections found on LANforge manager to start.")
             else:
                 logger.info("Found %d cross-connection(s): %s", len(existing_cxs), existing_cxs)
+                success_count = 0
                 for cx_name in existing_cxs:
                     logger.info("Starting cross-connection '%s'", cx_name)
                     res = lf_realm.start_cx(cx_name)
                     if res is None or res is False:
+                        logger.error("Toolbox: Failed to start cross-connection '%s'.", cx_name)
                         action_success = False
-                        check_cx_sta_connection(cx_name)
-                logger.info("Successfully processed %d cross-connection(s).", len(existing_cxs))
+                    else:
+                        success_count += 1
+                if action_success:
+                    logger.info("Successfully started %d cross-connection(s).", success_count)
+                else:
+                    logger.error("Failed to start some cross-connections (%d of %d succeeded).", success_count, len(existing_cxs))
         else:
             cx_list = parse_list(target_cxs)
             logger.info("Toolbox: Starting specified cross-connections: %s", cx_list)
@@ -9958,9 +9969,10 @@ def handle_toolbox(args):
                     logger.info("Starting cross-connection '%s'", matched_cx)
                     res = lf_realm.start_cx(matched_cx)
                     if res is None or res is False:
+                        logger.error("Toolbox: Failed to start cross-connection '%s'.", matched_cx)
                         action_success = False
-                        check_cx_sta_connection(matched_cx)
-                    started_count += 1
+                    else:
+                        started_count += 1
                 else:
                     logger.error("Requested cross-connection '%s' not found on LANforge manager.", cx_name)
                     action_success = False
@@ -9968,8 +9980,10 @@ def handle_toolbox(args):
             if started_count == 0 and cx_list:
                 logger.error("Failed to start any requested cross-connections.")
                 action_success = False
-            else:
+            elif action_success:
                 logger.info("Completed starting %d cross-connection(s).", started_count)
+            else:
+                logger.error("Completed starting cross-connections with errors (%d of %d succeeded).", started_count, len(cx_list))
 
     # Action 5: Delete Cross Connections (--del_cx)
     if args.del_cx is not None:
@@ -9986,12 +10000,19 @@ def handle_toolbox(args):
                 logger.warning("No cross-connections found on LANforge manager to delete.")
             else:
                 logger.info("Found %d cross-connection(s) to delete: %s", len(existing_cxs), existing_cxs)
+                success_count = 0
                 for cx_name in existing_cxs:
                     logger.info("Deleting cross-connection '%s'", cx_name)
                     res1 = lf_realm.rm_cx(cx_name)
                     if res1 is None or res1 is False:
+                        logger.error("Toolbox: Failed to delete cross-connection '%s'.", cx_name)
                         action_success = False
-                logger.info("Successfully deleted %d cross-connection(s).", len(existing_cxs))
+                    else:
+                        success_count += 1
+                if action_success:
+                    logger.info("Successfully deleted %d cross-connection(s).", success_count)
+                else:
+                    logger.error("Failed to delete some cross-connections (%d of %d succeeded).", success_count, len(existing_cxs))
         else:
             cx_list = parse_list(target_cxs)
             logger.info("Toolbox: Deleting specified cross-connections: %s", cx_list)
@@ -10002,17 +10023,18 @@ def handle_toolbox(args):
                     logger.info("Deleting cross-connection '%s'", matched_cx)
                     res1 = lf_realm.rm_cx(matched_cx)
                     if res1 is None or res1 is False:
+                        logger.error("Toolbox: Failed to delete cross-connection '%s'.", matched_cx)
                         action_success = False
-                    deleted_count += 1
+                    else:
+                        deleted_count += 1
                 else:
-                    logger.error("Requested cross-connection '%s' not found on LANforge manager.", cx_name)
-                    action_success = False
+                    logger.info("Requested cross-connection '%s' not found on LANforge manager (already deleted).", cx_name)
+                    deleted_count += 1
 
-            if deleted_count == 0 and cx_list:
-                logger.error("Failed to delete any requested cross-connections.")
-                action_success = False
-            else:
+            if action_success:
                 logger.info("Completed deleting %d cross-connection(s).", deleted_count)
+            else:
+                logger.error("Completed deleting cross-connections with errors (%d of %d succeeded).", deleted_count, len(cx_list))
 
     # Action 6: Delete Stations (--del_stations)
     if getattr(args, 'del_stations', None) is not None:
@@ -10029,13 +10051,20 @@ def handle_toolbox(args):
                 logger.warning("No station ports found on LANforge manager to delete.")
             else:
                 logger.info("Found %d station port(s) to delete: %s", len(existing_stas), existing_stas)
+                success_count = 0
                 for sta_name in existing_stas:
                     logger.info("Deleting station '%s'", sta_name)
                     lf_realm.admin_down(sta_name)
                     res = lf_realm.rm_port(sta_name, check_exists=False)
                     if res is False or res is None:
+                        logger.error("Toolbox: Failed to delete station '%s'.", sta_name)
                         action_success = False
-                logger.info("Successfully deleted %d station port(s).", len(existing_stas))
+                    else:
+                        success_count += 1
+                if action_success:
+                    logger.info("Successfully deleted %d station port(s).", success_count)
+                else:
+                    logger.error("Failed to delete some station ports (%d of %d succeeded).", success_count, len(existing_stas))
         else:
             sta_list = parse_list(target_stas)
             logger.info("Toolbox: Deleting specified stations: %s", sta_list)
@@ -10048,17 +10077,18 @@ def handle_toolbox(args):
                     lf_realm.admin_down(matched_sta)
                     res = lf_realm.rm_port(matched_sta, check_exists=False)
                     if res is False or res is None:
+                        logger.error("Toolbox: Failed to delete station '%s'.", matched_sta)
                         action_success = False
-                    deleted_count += 1
+                    else:
+                        deleted_count += 1
                 else:
-                    logger.error("Error: Requested station '%s' not found on LANforge manager.", sta_name)
-                    action_success = False
+                    logger.info("Requested station '%s' not found on LANforge manager (already deleted).", sta_name)
+                    deleted_count += 1
 
-            if deleted_count == 0 and sta_list:
-                logger.error("Error: Failed to delete any requested stations: %s", sta_list)
-                action_success = False
-            else:
+            if action_success:
                 logger.info("Completed deleting %d station(s).", deleted_count)
+            else:
+                logger.error("Completed deleting stations with errors (%d of %d succeeded).", deleted_count, len(sta_list))
 
     # Action 7: Ports Admin UP (--ports_up)
     if args.ports_up is not None:
@@ -10076,12 +10106,19 @@ def handle_toolbox(args):
                 logger.warning("No ports found on LANforge manager to set admin UP.")
             else:
                 logger.info("Found %d station/wireless port(s) to set admin UP: %s", len(sta_ports), sta_ports)
+                success_count = 0
                 for sta_name in sta_ports:
                     logger.info("Setting port '%s' admin UP", sta_name)
                     res = lf_realm.admin_up(sta_name)
                     if res is False or res is None:
+                        logger.error("Toolbox: Failed to set port '%s' admin UP.", sta_name)
                         action_success = False
-                logger.info("Successfully set %d station/wireless port(s) admin UP.", len(sta_ports))
+                    else:
+                        success_count += 1
+                if action_success:
+                    logger.info("Successfully set %d station/wireless port(s) admin UP.", success_count)
+                else:
+                    logger.error("Failed to set some ports admin UP (%d of %d succeeded).", success_count, len(sta_ports))
         else:
             port_list = parse_list(target_ports)
             logger.info("Toolbox: Setting specified ports admin UP: %s", port_list)
@@ -10092,8 +10129,10 @@ def handle_toolbox(args):
                     logger.info("Setting port '%s' admin UP", matched_port)
                     res = lf_realm.admin_up(matched_port)
                     if res is False or res is None:
+                        logger.error("Toolbox: Failed to set port '%s' admin UP.", matched_port)
                         action_success = False
-                    up_count += 1
+                    else:
+                        up_count += 1
                 else:
                     logger.error("Requested port '%s' not found on LANforge manager.", port_name)
                     action_success = False
@@ -10101,8 +10140,10 @@ def handle_toolbox(args):
             if up_count == 0 and port_list:
                 logger.error("Failed to set any requested ports admin UP.")
                 action_success = False
-            else:
+            elif action_success:
                 logger.info("Completed setting %d port(s) admin UP.", up_count)
+            else:
+                logger.error("Completed setting ports admin UP with errors (%d of %d succeeded).", up_count, len(port_list))
 
     # Action 8: Ports Admin DOWN (--ports_down)
     if args.ports_down is not None:
@@ -10120,12 +10161,19 @@ def handle_toolbox(args):
                 logger.warning("No ports found on LANforge manager to set admin DOWN.")
             else:
                 logger.info("Found %d station/wireless port(s) to set admin DOWN: %s", len(sta_ports), sta_ports)
+                success_count = 0
                 for sta_name in sta_ports:
                     logger.info("Setting port '%s' admin DOWN", sta_name)
                     res = lf_realm.admin_down(sta_name)
                     if res is False or res is None:
+                        logger.error("Toolbox: Failed to set port '%s' admin DOWN.", sta_name)
                         action_success = False
-                logger.info("Successfully set %d station/wireless port(s) admin DOWN.", len(sta_ports))
+                    else:
+                        success_count += 1
+                if action_success:
+                    logger.info("Successfully set %d station/wireless port(s) admin DOWN.", success_count)
+                else:
+                    logger.error("Failed to set some ports admin DOWN (%d of %d succeeded).", success_count, len(sta_ports))
         else:
             port_list = parse_list(target_ports)
             logger.info("Toolbox: Setting specified ports admin DOWN: %s", port_list)
@@ -10136,8 +10184,10 @@ def handle_toolbox(args):
                     logger.info("Setting port '%s' admin DOWN", matched_port)
                     res = lf_realm.admin_down(matched_port)
                     if res is False or res is None:
+                        logger.error("Toolbox: Failed to set port '%s' admin DOWN.", matched_port)
                         action_success = False
-                    down_count += 1
+                    else:
+                        down_count += 1
                 else:
                     logger.error("Requested port '%s' not found on LANforge manager.", port_name)
                     action_success = False
@@ -10145,8 +10195,10 @@ def handle_toolbox(args):
             if down_count == 0 and port_list:
                 logger.error("Failed to set any requested ports admin DOWN.")
                 action_success = False
-            else:
+            elif action_success:
                 logger.info("Completed setting %d port(s) admin DOWN.", down_count)
+            else:
+                logger.error("Completed setting ports admin DOWN with errors (%d of %d succeeded).", down_count, len(port_list))
 
     # Final Result Evaluation
     if action_performed:

--- a/py-scripts/test_l3.py
+++ b/py-scripts/test_l3.py
@@ -9152,6 +9152,22 @@ Multicast traffic :
 
     Can't decide what columns to use? You can just use 'all' to select all available columns from both tables.
 
+Toolbox Examples with Custom CX Names:
+  - Create stations & build cross-connection with custom name 'wlan0':
+      python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --create_station --radio "radio==wiphy0 stations==1" --build_cxs --upstream_port 1.1.eth1 --cx_names wlan0
+
+  - Build cross-connections with custom names for specific ports:
+      python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --build_cxs --upstream_port 1.1.eth1 --ports 1.1.eth2,1.1.eth3 --cx_names cx_eth2,cx_eth3
+
+  - Start specific cross-connections by name:
+      python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --start_cx wlan0
+
+  - Stop specific cross-connections by name:
+      python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --stop_cx wlan0,cx_eth2
+
+  - Delete specific cross-connections by name:
+      python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --del_cx wlan0
+
 STATUS: Functional
 
 VERIFIED_ON: MAY 2025,
@@ -9545,15 +9561,22 @@ INCLUDE_IN_README: False
                           action='store_true',
                           help='Toolbox action: Create stations using specified --radio configuration.')
 
-    optional.add_argument('--stations',
+    optional.add_argument('--ports', '--downstream_ports',
+                          dest='ports',
                           nargs='+',
                           default=None,
-                          help='Specify station port EIDs / names (comma or space separated, e.g. "1.1.sta1000,1.1.sta10001").')
+                          help='Specify target/downstream port EIDs / names (comma or space separated, e.g. "1.1.eth1,1.1.eth2" or "sta0000,sta0001").')
 
-    optional.add_argument('--build_cxs', '--build_cx', '--build_cx',
+    optional.add_argument('--cx_names', '--cx_name',
+                          dest='cx_names',
+                          nargs='+',
+                          default=None,
+                          help='Specify custom cross-connection name(s) when creating cross-connections (comma or space separated, e.g. "wlan0" or "cx_1,cx_2").')
+
+    optional.add_argument('--build_cxs', '--build_cx',
                           dest='build_cxs',
                           action='store_true',
-                          help='Toolbox action: Build Layer-3 cross-connections between --upstream_port and --stations for specified --endp_type.')
+                          help='Toolbox action: Build Layer-3 cross-connections between --upstream_port and --ports for specified --endp_type.')
 
     optional.add_argument('--stop_cx',
                           nargs='?',
@@ -9602,7 +9625,7 @@ def handle_toolbox(args):
         args: Parsed command line arguments instance.
 
     Returns:
-        bool: True if a toolbox action was executed, otherwise False.
+        bool: True if all toolbox actions succeeded, otherwise False.
     """
     if not args.toolbox:
         return False
@@ -9610,6 +9633,22 @@ def handle_toolbox(args):
     logger.info("Toolbox mode enabled.")
     lf_realm = Realm(lfclient_host=args.lfmgr, lfclient_port=args.lfmgr_port, debug_=args.debug)
     action_performed = False
+    action_success = True
+    created_stations_session = []
+
+    # Helper function to parse comma/space separated argument lists
+    def parse_list(raw_val):
+        if not raw_val:
+            return []
+        if isinstance(raw_val, list):
+            items = []
+            for item in raw_val:
+                cleaned = str(item).replace('[', '').replace(']', '').replace("'", '').replace('"', '').split(',')
+                for sub in cleaned:
+                    if sub.strip():
+                        items.append(sub.strip())
+            return items
+        return [p.strip() for p in str(raw_val).replace('[', '').replace(']', '').replace("'", '').replace('"', '').split(',') if p.strip()]
 
     # Action 1: Station Creation (--create_station)
     if getattr(args, 'create_station', False):
@@ -9617,25 +9656,68 @@ def handle_toolbox(args):
         logger.info("Toolbox: Creating station(s)...")
 
         if not args.radio:
-            logger.warning("Toolbox: --create_station specified, but no --radio configuration provided.")
+            logger.error("Toolbox: --create_station specified, but no --radio configuration provided.")
+            action_success = False
         else:
             radios = args.radio if isinstance(args.radio, list) else [args.radio]
-            sta_offset = int(args.sta_start_offset) if args.sta_start_offset else 0
-            total_created = 0
+            user_offset_specified = getattr(args, 'sta_start_offset', None) is not None
+            sta_offset = int(args.sta_start_offset) if user_offset_specified else 0
+            total_processed = 0
+
+            existing_all_ports = lf_realm.get_all_ports() or []
+            existing_sta_indices = []
+            for p in existing_all_ports:
+                p_name = p.split('.')[-1] if '.' in p else p
+                if p_name.startswith('sta'):
+                    digits = ''.join(c for c in p_name[3:] if c.isdigit())
+                    if digits:
+                        existing_sta_indices.append(int(digits))
+
+            # Auto-adjust start offset if user did not specify one and existing stations are found
+            if not user_offset_specified and existing_sta_indices:
+                next_avail = max(existing_sta_indices) + 1
+                if sta_offset < next_avail:
+                    logger.info(
+                        "Toolbox: Existing station(s) detected on LANforge (e.g. sta%04d). Auto-adjusting start offset from %d to %d to avoid station overwrite collision.",
+                        max(existing_sta_indices), sta_offset, next_avail
+                    )
+                    sta_offset = next_avail
 
             for radio_ in radios:
-                radio_info_dict = dict(
-                    map(
-                        lambda x: x.split('=='),
-                        str(radio_).replace('"', '').replace('[', '').replace(']', '').replace("'", "").replace(',', ' ').split()
+                try:
+                    radio_info_dict = dict(
+                        map(
+                            lambda x: x.split('=='),
+                            str(radio_).replace('"', '').replace('[', '').replace(']', '').replace("'", "").replace(',', ' ').split()
+                        )
                     )
-                )
+                except Exception as parse_err:
+                    logger.error("Toolbox: Failed to parse radio configuration '%s': %s", radio_, parse_err)
+                    action_success = False
+                    continue
+
                 radio_name = radio_info_dict.get('radio', 'wiphy0')
                 num_stations = int(radio_info_dict.get('stations', 1))
                 ssid = radio_info_dict.get('ssid', '')
                 ssid_pw = radio_info_dict.get('ssid_pw', '[BLANK]')
                 security = radio_info_dict.get('security', 'open')
                 wifi_mode = radio_info_dict.get('mode', None)
+
+                # Reject station creation on non-wireless radios (e.g. 1.1.eth2, eth0, br0, macvlan0)
+                radio_clean = radio_name.split('.')[-1].lower() if '.' in radio_name else radio_name.lower()
+                invalid_prefixes = ('eth', 'br', 'macvlan', 'bond', 'vlan', 'lo', 'gre', 'tun', 'tap')
+                if any(radio_clean.startswith(p) for p in invalid_prefixes) or 'eth' in radio_clean:
+                    logger.error(
+                        "Toolbox: Invalid radio '%s' specified for station creation. Non-wireless interfaces (e.g., eth, bridge, macvlan) cannot be used as radios for station creation.",
+                        radio_name
+                    )
+                    action_success = False
+                    continue
+
+                if num_stations <= 0:
+                    logger.error("Toolbox: Invalid station count (%d) specified for radio '%s'. Count must be at least 1.", num_stations, radio_name)
+                    action_success = False
+                    continue
 
                 logger.info(
                     "Toolbox: Creating %d station(s) on radio '%s' (SSID: '%s', Security: '%s', Start Offset: %d)...",
@@ -9658,61 +9740,122 @@ def handle_toolbox(args):
                     radio=radio_name
                 )
 
-                station_profile.use_security(security, ssid, ssid_pw)
-                station_profile.create(
-                    radio=radio_name,
-                    sta_names_=station_list,
-                    debug=args.debug,
-                    up_=True
-                )
+                # Separate brand new stations from already existing stations to avoid LANforge add_sta overwrite error
+                new_stations = []
+                already_existing = []
+                for sta in station_list:
+                    if lf_realm.is_port_exists(sta, existing_all_ports):
+                        already_existing.append(sta)
+                    else:
+                        new_stations.append(sta)
+
+                if already_existing:
+                    logger.info("Toolbox: Station(s) %s already exist on LANforge manager. Re-using existing station(s).", already_existing)
+
+                if new_stations:
+                    station_profile.use_security(security, ssid, ssid_pw)
+                    try:
+                        res = station_profile.create(
+                            radio=radio_name,
+                            sta_names_=new_stations,
+                            debug=args.debug,
+                            up_=True
+                        )
+                        if res is False:
+                            logger.error("Toolbox: station_profile.create returned failure status for radio '%s'.", radio_name)
+                            action_success = False
+                    except Exception as create_err:
+                        logger.error("Toolbox: Station creation API error on radio '%s': %s", radio_name, create_err)
+                        action_success = False
 
                 for sta in station_list:
                     lf_realm.admin_up(sta)
+                    created_stations_session.append(sta)
 
                 sta_offset += 1000
-                total_created += num_stations
+                total_processed += num_stations
 
-            logger.info("Toolbox: Successfully created %d station(s).", total_created)
+            if total_processed > 0:
+                logger.info("Toolbox: Successfully processed %d station(s).", total_processed)
+            else:
+                action_success = False
 
-    # Action 2: Layer-3 Cross-Connection Building (--build_cxs)
+    # Action 2: Layer-3 Cross-Connection Building (--build_cxs / --build_cx)
     if getattr(args, 'build_cxs', False) or getattr(args, 'build_cx', False):
         action_performed = True
         logger.info("Toolbox: Building Layer-3 cross-connection(s)...")
-        if not args.stations:
-            logger.warning("Toolbox: --build_cxs specified, but no --stations provided.")
+        raw_ports = getattr(args, 'ports', None) or getattr(args, 'downstream_ports', None)
+        ports = parse_list(raw_ports) if raw_ports else created_stations_session
+
+        if not ports:
+            logger.error("Toolbox: --build_cxs specified, but no --ports/--downstream_ports provided and no stations created in this session.")
+            action_success = False
         else:
-            stations = []
-            st_raw = args.stations if isinstance(args.stations, list) else [args.stations]
-            for s in st_raw:
-                cleaned = str(s).replace('[', '').replace(']', '').replace("'", '').replace('"', '').split(',')
-                for item in cleaned:
-                    if item.strip():
-                        stations.append(item.strip())
+            upstream_port = getattr(args, 'upstream_port', None)
+            existing_ports = lf_realm.get_all_ports()
 
-            upstream_port = args.upstream_port
-            endp_types = args.endp_type if isinstance(args.endp_type, list) else [args.endp_type] if args.endp_type else ["lf_udp"]
-            tos_list = args.tos if isinstance(args.tos, list) else [args.tos] if args.tos else ["BE"]
+            if existing_ports is None:
+                logger.error("Toolbox: Failed to query ports from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+                action_success = False
+            elif not upstream_port:
+                logger.error("Toolbox: --build_cxs specified, but no --upstream_port provided.")
+                action_success = False
+            else:
+                matched_upstream = lf_realm.is_port_exists(upstream_port, existing_ports)
+                if not matched_upstream:
+                    logger.error("Toolbox: Specified upstream port '%s' not found on LANforge manager.", upstream_port)
+                    action_success = False
 
-            cx_profile = lf_realm.new_l3_cx_profile()
-            cx_profile.host = args.lfmgr
-            cx_profile.port = args.lfmgr_port
-            cx_profile.side_a_min_bps = args.side_a_min_bps if hasattr(args, 'side_a_min_bps') else "256000"
-            cx_profile.side_a_max_bps = cx_profile.side_a_min_bps
-            cx_profile.side_b_min_bps = args.side_b_min_bps if getattr(args, 'side_b_min_bps', None) else "256000"
-            cx_profile.side_b_max_bps = cx_profile.side_b_min_bps
+                valid_ports = []
+                for p in ports:
+                    matched_p = lf_realm.is_port_exists(p, existing_ports)
+                    if matched_p:
+                        valid_ports.append(matched_p)
+                    else:
+                        logger.error("Toolbox: Specified target port '%s' not found on LANforge manager.", p)
+                        action_success = False
 
-            for etype in endp_types:
-                for _tos in tos_list:
-                    logger.info("Creating Layer-3 connections for endpoint type: %s, TOS: %s between upstream '%s' and stations %s", etype, _tos, upstream_port, stations)
-                    these_cx, these_endp = cx_profile.create(
-                        endp_type=etype,
-                        side_a=stations,
-                        side_b=upstream_port,
-                        sleep_time=0,
-                        tos=_tos,
-                        add_tos_to_name=True
-                    )
-                    logger.info("Created Layer-3 cross-connections: %s", these_cx)
+                if valid_ports and matched_upstream and action_success:
+                    endp_types = args.endp_type if isinstance(args.endp_type, list) else [args.endp_type] if args.endp_type else ["lf_udp"]
+                    tos_list = args.tos if isinstance(args.tos, list) else [args.tos] if args.tos else ["BE"]
+                    raw_cx_names = getattr(args, 'cx_names', None)
+                    parsed_cx_names = parse_list(raw_cx_names)
+                    custom_cx_name = parsed_cx_names[0] if parsed_cx_names else None
+
+                    cx_profile = lf_realm.new_l3_cx_profile()
+                    cx_profile.host = args.lfmgr
+                    cx_profile.port = args.lfmgr_port
+                    if custom_cx_name:
+                        cx_profile.name_prefix = str(custom_cx_name)
+
+                    min_rate = getattr(args, 'side_a_min_bps', None) or getattr(args, 'rates_a', None) or "256000"
+                    min_rate_b = getattr(args, 'side_b_min_bps', None) or getattr(args, 'rates_b', None) or min_rate
+                    cx_profile.side_a_min_bps = min_rate
+                    cx_profile.side_a_max_bps = min_rate
+                    cx_profile.side_b_min_bps = min_rate_b
+                    cx_profile.side_b_max_bps = min_rate_b
+
+                    for etype in endp_types:
+                        for _tos in tos_list:
+                            logger.info("Creating Layer-3 connections for endpoint type: %s, TOS: %s between upstream '%s' and ports %s (CX name prefix: %s)",
+                                        etype, _tos, matched_upstream, valid_ports, cx_profile.name_prefix)
+                            try:
+                                these_cx, these_endp = cx_profile.create(
+                                    endp_type=etype,
+                                    side_a=valid_ports,
+                                    side_b=matched_upstream,
+                                    sleep_time=0,
+                                    tos=_tos,
+                                    add_tos_to_name=True
+                                )
+                                if not these_cx:
+                                    logger.error("Toolbox: Failed to create Layer-3 cross-connections.")
+                                    action_success = False
+                                else:
+                                    logger.info("Created Layer-3 cross-connections: %s", these_cx)
+                            except Exception as cx_err:
+                                logger.error("Toolbox: Failed to create Layer-3 cross-connections: %s", cx_err)
+                                action_success = False
 
     # Action 3: Stop Cross Connections (--stop_cx)
     if args.stop_cx is not None:
@@ -9720,33 +9863,68 @@ def handle_toolbox(args):
         target_cxs = str(args.stop_cx).strip()
         existing_cxs = lf_realm.get_all_cxs()
 
-        if not target_cxs or target_cxs.lower() == 'all':
+        if existing_cxs is None:
+            logger.error("Toolbox: Failed to query cross-connections from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+            action_success = False
+        elif not target_cxs or target_cxs.lower() == 'all':
             logger.info("Toolbox: Stopping all cross-connections ('all')...")
             if not existing_cxs:
-                logger.warning("No cross-connection stopped due to unavailable")
+                logger.warning("No cross-connections found on LANforge manager to stop.")
             else:
                 logger.info("Found %d cross-connection(s): %s", len(existing_cxs), existing_cxs)
                 for cx_name in existing_cxs:
                     logger.info("Stopping cross-connection '%s'", cx_name)
-                    lf_realm.stop_cx(cx_name)
+                    res = lf_realm.stop_cx(cx_name)
+                    if res is None or res is False:
+                        action_success = False
                 logger.info("Successfully stopped %d cross-connection(s).", len(existing_cxs))
         else:
-            cx_list = [c.strip() for c in target_cxs.split(',') if c.strip()]
+            cx_list = parse_list(target_cxs)
             logger.info("Toolbox: Stopping specified cross-connections: %s", cx_list)
             stopped_count = 0
             for cx_name in cx_list:
                 matched_cx = lf_realm.is_cx_exists(cx_name, existing_cxs)
                 if matched_cx:
                     logger.info("Stopping cross-connection '%s'", matched_cx)
-                    lf_realm.stop_cx(matched_cx)
+                    res = lf_realm.stop_cx(matched_cx)
+                    if res is None or res is False:
+                        action_success = False
                     stopped_count += 1
                 else:
-                    logger.warning("No cross-connection stopped due to unavailable: '%s'", cx_name)
+                    logger.error("Requested cross-connection '%s' not found on LANforge manager.", cx_name)
+                    action_success = False
 
-            if stopped_count == 0:
-                logger.warning("No cross-connection stopped due to unavailable")
+            if stopped_count == 0 and cx_list:
+                logger.error("Failed to stop any requested cross-connections.")
+                action_success = False
             else:
                 logger.info("Completed stopping %d cross-connection(s).", stopped_count)
+
+    # Helper function to check if cross-connection uses a disconnected Wi-Fi station
+    def check_cx_sta_connection(cx_name):
+        try:
+            all_ports = lf_realm.get_all_ports() or []
+            for port_eid in all_ports:
+                port_name = port_eid.split('.')[-1] if '.' in port_eid else port_eid
+                if port_name.startswith('sta') and port_name in cx_name:
+                    port_info = lf_realm.json_get("/port/1/1/%s?fields=alias,ip,port+type,flags" % port_name)
+                    if port_info and 'interface' in port_info:
+                        p_data = port_info['interface']
+                        ip_addr = p_data.get('ip', '0.0.0.0')
+                        if ip_addr in ('0.0.0.0', 'NA', '', '0.0.0.0/0'):
+                            logger.error(
+                                "Toolbox: Cannot start endpoint A because it is on a wifi STA ('%s') that is not connected.",
+                                port_name
+                            )
+                            return True
+                    logger.error(
+                        "Toolbox: Cannot start endpoint A because it is on a wifi STA ('%s') that is not connected.",
+                        port_name
+                    )
+                    return True
+        except Exception as err:
+            logger.debug("Toolbox: Station connection check error for '%s': %s", cx_name, err)
+        return False
 
     # Action 4: Start Cross Connections (--start_cx)
     if args.start_cx is not None:
@@ -9754,31 +9932,42 @@ def handle_toolbox(args):
         target_cxs = str(args.start_cx).strip()
         existing_cxs = lf_realm.get_all_cxs()
 
-        if not target_cxs or target_cxs.lower() == 'all':
+        if existing_cxs is None:
+            logger.error("Toolbox: Failed to query cross-connections from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+            action_success = False
+        elif not target_cxs or target_cxs.lower() == 'all':
             logger.info("Toolbox: Starting all cross-connections ('all')...")
             if not existing_cxs:
-                logger.warning("No cross-connection started due to unavailable")
+                logger.warning("No cross-connections found on LANforge manager to start.")
             else:
                 logger.info("Found %d cross-connection(s): %s", len(existing_cxs), existing_cxs)
                 for cx_name in existing_cxs:
                     logger.info("Starting cross-connection '%s'", cx_name)
-                    lf_realm.start_cx(cx_name)
-                logger.info("Successfully started %d cross-connection(s).", len(existing_cxs))
+                    res = lf_realm.start_cx(cx_name)
+                    if res is None or res is False:
+                        action_success = False
+                        check_cx_sta_connection(cx_name)
+                logger.info("Successfully processed %d cross-connection(s).", len(existing_cxs))
         else:
-            cx_list = [c.strip() for c in target_cxs.split(',') if c.strip()]
+            cx_list = parse_list(target_cxs)
             logger.info("Toolbox: Starting specified cross-connections: %s", cx_list)
             started_count = 0
             for cx_name in cx_list:
                 matched_cx = lf_realm.is_cx_exists(cx_name, existing_cxs)
                 if matched_cx:
                     logger.info("Starting cross-connection '%s'", matched_cx)
-                    lf_realm.start_cx(matched_cx)
+                    res = lf_realm.start_cx(matched_cx)
+                    if res is None or res is False:
+                        action_success = False
+                        check_cx_sta_connection(matched_cx)
                     started_count += 1
                 else:
-                    logger.warning("No cross-connection started due to unavailable: '%s'", cx_name)
+                    logger.error("Requested cross-connection '%s' not found on LANforge manager.", cx_name)
+                    action_success = False
 
-            if started_count == 0:
-                logger.warning("No cross-connection started due to unavailable")
+            if started_count == 0 and cx_list:
+                logger.error("Failed to start any requested cross-connections.")
+                action_success = False
             else:
                 logger.info("Completed starting %d cross-connection(s).", started_count)
 
@@ -9788,148 +9977,188 @@ def handle_toolbox(args):
         target_cxs = str(args.del_cx).strip()
         existing_cxs = lf_realm.get_all_cxs()
 
-        if not target_cxs or target_cxs.lower() == 'all':
+        if existing_cxs is None:
+            logger.error("Toolbox: Failed to query cross-connections from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+            action_success = False
+        elif not target_cxs or target_cxs.lower() == 'all':
             logger.info("Toolbox: Deleting all cross-connections ('all')...")
             if not existing_cxs:
-                logger.warning("No cross-connection deleted due to unavailable")
+                logger.warning("No cross-connections found on LANforge manager to delete.")
             else:
                 logger.info("Found %d cross-connection(s) to delete: %s", len(existing_cxs), existing_cxs)
                 for cx_name in existing_cxs:
                     logger.info("Deleting cross-connection '%s'", cx_name)
-                    lf_realm.rm_cx(cx_name)
-                    lf_realm.rm_endp(cx_name + "-A")
-                    lf_realm.rm_endp(cx_name + "-B")
+                    res1 = lf_realm.rm_cx(cx_name)
+                    if res1 is None or res1 is False:
+                        action_success = False
                 logger.info("Successfully deleted %d cross-connection(s).", len(existing_cxs))
         else:
-            cx_list = [c.strip() for c in target_cxs.split(',') if c.strip()]
+            cx_list = parse_list(target_cxs)
             logger.info("Toolbox: Deleting specified cross-connections: %s", cx_list)
             deleted_count = 0
             for cx_name in cx_list:
                 matched_cx = lf_realm.is_cx_exists(cx_name, existing_cxs)
                 if matched_cx:
                     logger.info("Deleting cross-connection '%s'", matched_cx)
-                    lf_realm.rm_cx(matched_cx)
-                    lf_realm.rm_endp(matched_cx + "-A")
-                    lf_realm.rm_endp(matched_cx + "-B")
+                    res1 = lf_realm.rm_cx(matched_cx)
+                    if res1 is None or res1 is False:
+                        action_success = False
                     deleted_count += 1
                 else:
-                    logger.warning("No cross-connection deleted due to unavailable: '%s'", cx_name)
+                    logger.error("Requested cross-connection '%s' not found on LANforge manager.", cx_name)
+                    action_success = False
 
-            if deleted_count == 0:
-                logger.warning("No cross-connection deleted due to unavailable")
+            if deleted_count == 0 and cx_list:
+                logger.error("Failed to delete any requested cross-connections.")
+                action_success = False
             else:
                 logger.info("Completed deleting %d cross-connection(s).", deleted_count)
 
     # Action 6: Delete Stations (--del_stations)
-    if args.del_stations is not None:
+    if getattr(args, 'del_stations', None) is not None:
         action_performed = True
         target_stas = str(args.del_stations).strip()
-        existing_stas = lf_realm.get_all_stations(prefix="sta")
+        existing_stas = lf_realm.get_all_stations()
 
-        if not target_stas or target_stas.lower() == 'all':
-            logger.info("Toolbox: Deleting all stations with 'sta' prefix...")
+        if existing_stas is None:
+            logger.error("Toolbox: Failed to query stations from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+            action_success = False
+        elif not target_stas or target_stas.lower() == 'all':
+            logger.info("Toolbox: Deleting all station ports...")
             if not existing_stas:
-                logger.warning("No stations deleted due to unavailable")
+                logger.warning("No station ports found on LANforge manager to delete.")
             else:
-                logger.info("Found %d station(s) to delete: %s", len(existing_stas), existing_stas)
+                logger.info("Found %d station port(s) to delete: %s", len(existing_stas), existing_stas)
                 for sta_name in existing_stas:
                     logger.info("Deleting station '%s'", sta_name)
                     lf_realm.admin_down(sta_name)
-                    lf_realm.rm_port(sta_name)
-                logger.info("Successfully deleted %d station(s).", len(existing_stas))
+                    res = lf_realm.rm_port(sta_name, check_exists=False)
+                    if res is False or res is None:
+                        action_success = False
+                logger.info("Successfully deleted %d station port(s).", len(existing_stas))
         else:
-            sta_list = [s.strip() for s in target_stas.split(',') if s.strip()]
+            sta_list = parse_list(target_stas)
             logger.info("Toolbox: Deleting specified stations: %s", sta_list)
             deleted_count = 0
+            all_ports = lf_realm.get_all_ports() or existing_stas
             for sta_name in sta_list:
-                matched_port = lf_realm.is_port_exists(sta_name, existing_stas)
-                if matched_port:
-                    logger.info("Deleting station '%s'", matched_port)
-                    lf_realm.admin_down(matched_port)
-                    lf_realm.rm_port(matched_port)
+                matched_sta = lf_realm.is_port_exists(sta_name, all_ports)
+                if matched_sta:
+                    logger.info("Deleting station '%s'", matched_sta)
+                    lf_realm.admin_down(matched_sta)
+                    res = lf_realm.rm_port(matched_sta, check_exists=False)
+                    if res is False or res is None:
+                        action_success = False
                     deleted_count += 1
                 else:
-                    logger.warning("No stations deleted due to unavailable: '%s'", sta_name)
+                    logger.error("Error: Requested station '%s' not found on LANforge manager.", sta_name)
+                    action_success = False
 
-            if deleted_count == 0:
-                logger.warning("No stations deleted due to unavailable")
+            if deleted_count == 0 and sta_list:
+                logger.error("Error: Failed to delete any requested stations: %s", sta_list)
+                action_success = False
             else:
                 logger.info("Completed deleting %d station(s).", deleted_count)
 
     # Action 7: Ports Admin UP (--ports_up)
     if args.ports_up is not None:
         action_performed = True
-        target_stas = str(args.ports_up).strip()
-        existing_stas = lf_realm.get_all_stations(prefix="sta")
+        target_ports = str(args.ports_up).strip()
+        existing_ports = lf_realm.get_all_ports()
 
-        if not target_stas or target_stas.lower() == 'all':
-            logger.info("Toolbox: Setting all stations with 'sta' prefix admin UP...")
-            if not existing_stas:
-                logger.warning("No ports set admin up due to unavailable")
+        if existing_ports is None:
+            logger.error("Toolbox: Failed to query ports from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+            action_success = False
+        elif not target_ports or target_ports.lower() == 'all':
+            logger.info("Toolbox: Setting all station/wireless ports admin UP...")
+            sta_ports = lf_realm.get_all_stations() or []
+            if not sta_ports:
+                logger.warning("No ports found on LANforge manager to set admin UP.")
             else:
-                logger.info("Found %d station(s) to set admin UP: %s", len(existing_stas), existing_stas)
-                for sta_name in existing_stas:
-                    logger.info("Setting station '%s' admin UP", sta_name)
-                    lf_realm.admin_up(sta_name)
-                logger.info("Successfully set %d station(s) admin UP.", len(existing_stas))
+                logger.info("Found %d station/wireless port(s) to set admin UP: %s", len(sta_ports), sta_ports)
+                for sta_name in sta_ports:
+                    logger.info("Setting port '%s' admin UP", sta_name)
+                    res = lf_realm.admin_up(sta_name)
+                    if res is False or res is None:
+                        action_success = False
+                logger.info("Successfully set %d station/wireless port(s) admin UP.", len(sta_ports))
         else:
-            sta_list = [s.strip() for s in target_stas.split(',') if s.strip()]
-            logger.info("Toolbox: Setting specified stations admin UP: %s", sta_list)
+            port_list = parse_list(target_ports)
+            logger.info("Toolbox: Setting specified ports admin UP: %s", port_list)
             up_count = 0
-            for sta_name in sta_list:
-                matched_port = lf_realm.is_port_exists(sta_name, existing_stas)
+            for port_name in port_list:
+                matched_port = lf_realm.is_port_exists(port_name, existing_ports)
                 if matched_port:
-                    logger.info("Setting station '%s' admin UP", matched_port)
-                    lf_realm.admin_up(matched_port)
+                    logger.info("Setting port '%s' admin UP", matched_port)
+                    res = lf_realm.admin_up(matched_port)
+                    if res is False or res is None:
+                        action_success = False
                     up_count += 1
                 else:
-                    logger.warning("No ports set admin up due to unavailable: '%s'", sta_name)
+                    logger.error("Requested port '%s' not found on LANforge manager.", port_name)
+                    action_success = False
 
-            if up_count == 0:
-                logger.warning("No ports set admin up due to unavailable")
+            if up_count == 0 and port_list:
+                logger.error("Failed to set any requested ports admin UP.")
+                action_success = False
             else:
-                logger.info("Completed setting %d station(s) admin UP.", up_count)
+                logger.info("Completed setting %d port(s) admin UP.", up_count)
 
     # Action 8: Ports Admin DOWN (--ports_down)
     if args.ports_down is not None:
         action_performed = True
-        target_stas = str(args.ports_down).strip()
-        existing_stas = lf_realm.get_all_stations(prefix="sta")
+        target_ports = str(args.ports_down).strip()
+        existing_ports = lf_realm.get_all_ports()
 
-        if not target_stas or target_stas.lower() == 'all':
-            logger.info("Toolbox: Setting all stations with 'sta' prefix admin DOWN...")
-            if not existing_stas:
-                logger.warning("No ports set admin down due to unavailable")
+        if existing_ports is None:
+            logger.error("Toolbox: Failed to query ports from LANforge API at %s:%s. Check connection.", args.lfmgr, args.lfmgr_port)
+            action_success = False
+        elif not target_ports or target_ports.lower() == 'all':
+            logger.info("Toolbox: Setting all station/wireless ports admin DOWN...")
+            sta_ports = lf_realm.get_all_stations() or []
+            if not sta_ports:
+                logger.warning("No ports found on LANforge manager to set admin DOWN.")
             else:
-                logger.info("Found %d station(s) to set admin DOWN: %s", len(existing_stas), existing_stas)
-                for sta_name in existing_stas:
-                    logger.info("Setting station '%s' admin DOWN", sta_name)
-                    lf_realm.admin_down(sta_name)
-                logger.info("Successfully set %d station(s) admin DOWN.", len(existing_stas))
+                logger.info("Found %d station/wireless port(s) to set admin DOWN: %s", len(sta_ports), sta_ports)
+                for sta_name in sta_ports:
+                    logger.info("Setting port '%s' admin DOWN", sta_name)
+                    res = lf_realm.admin_down(sta_name)
+                    if res is False or res is None:
+                        action_success = False
+                logger.info("Successfully set %d station/wireless port(s) admin DOWN.", len(sta_ports))
         else:
-            sta_list = [s.strip() for s in target_stas.split(',') if s.strip()]
-            logger.info("Toolbox: Setting specified stations admin DOWN: %s", sta_list)
+            port_list = parse_list(target_ports)
+            logger.info("Toolbox: Setting specified ports admin DOWN: %s", port_list)
             down_count = 0
-            for sta_name in sta_list:
-                matched_port = lf_realm.is_port_exists(sta_name, existing_stas)
+            for port_name in port_list:
+                matched_port = lf_realm.is_port_exists(port_name, existing_ports)
                 if matched_port:
-                    logger.info("Setting station '%s' admin DOWN", matched_port)
-                    lf_realm.admin_down(matched_port)
+                    logger.info("Setting port '%s' admin DOWN", matched_port)
+                    res = lf_realm.admin_down(matched_port)
+                    if res is False or res is None:
+                        action_success = False
                     down_count += 1
                 else:
-                    logger.warning("No ports set admin down due to unavailable: '%s'", sta_name)
+                    logger.error("Requested port '%s' not found on LANforge manager.", port_name)
+                    action_success = False
 
-            if down_count == 0:
-                logger.warning("No ports set admin down due to unavailable")
+            if down_count == 0 and port_list:
+                logger.error("Failed to set any requested ports admin DOWN.")
+                action_success = False
             else:
-                logger.info("Completed setting %d station(s) admin DOWN.", down_count)
+                logger.info("Completed setting %d port(s) admin DOWN.", down_count)
 
+    # Final Result Evaluation
     if action_performed:
-        logger.info("Toolbox action completed successfully.")
-        return True
+        if action_success:
+            logger.info("Toolbox action completed successfully.")
+            return True
+        else:
+            logger.error("Toolbox action failed with errors.")
+            return False
 
-    logger.warning("Toolbox flag specified, but no valid toolbox action provided.")
-    return True
+    logger.error("Toolbox flag specified, but no valid toolbox action provided.")
+    return False
 
 
 # Starting point for running this from cmd line.
@@ -10095,8 +10324,8 @@ and generate a report.
         logger_config.load_lf_logger_config()
 
     if args.toolbox:
-        handle_toolbox(args)
-        sys.exit(0)
+        toolbox_success = handle_toolbox(args)
+        sys.exit(0 if toolbox_success else 1)
 
     validate_args(args)
     endp_input_list = []


### PR DESCRIPTION
### Description:
- Current implementation is focused on the required toolbox functionality.
- Refactoring for better code reuse with test_l3 can be handled separately later.

### Verified CLI

#### 1. Station Creation

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --create_station --radio "radio==wiphy0 stations==2 ssid==TestAP ssid_pw==12345678 security==wpa2"
```

#### 2. Layer-3 Cross-Connection Building

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --build_cxs --upstream_port 1.1.eth1 --ports 1.1.sta5000,1.1.sta5001
```

#### 3. Layer-3 Cross-Connection Building with Custom Name

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --build_cxs --upstream_port 1.1.eth1 --ports 1.1.sta0000 --cx_names toolbox
```

#### 4. Cross-Connection Building with Ethernet Ports

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --build_cxs --upstream_port 1.1.eth1 --downstream_ports 1.1.eth2 --cx_names eth_link
```

#### 5. Start Cross-Connections

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --start_cx toolbox
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --start_cx all
```

#### 6. Stop Cross-Connections

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --stop_cx wlan0
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --stop_cx all
```

#### 7. Set Ports Admin UP/DOWN

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --ports_down 1.1.sta5000,1.1.eth2
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --ports_up 1.1.sta5000,1.1.eth2
```

#### 8. Delete Cross-Connections

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --del_cx toolbox
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --del_cx all
```

#### 9. Delete Wi-Fi Stations

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --del_stations sta5000,sta5001
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --del_stations all
```

#### 10. Chained Workflow: Station Creation + CX Building

```bash
python3 py-scripts/test_l3.py --lfmgr 192.168.244.45 --toolbox --create_station --radio "radio==wiphy0 stations==2 ssid==TestAP ssid_pw==12345678 security==wpa2" --build_cxs --upstream_port 1.1.eth1 --cx_names test_flow
```

#### 11. Error and Edge-Case Validation

Verified invalid inputs and missing required arguments return the expected non-zero exit code (`1`), including invalid radio, station count, ports, CX names, and missing `--upstream_port`.


- Please refer to the following documentation for the different `--toolbox` scenarios.
https://docs.google.com/document/d/1f4rBcs_BI9K718BRkEge8y27-lLS35sWt2HYqet4WsY/edit?usp=sharing


