### PR TITLE
lf_ftp.py : Add api_response column in client issue CSV.

### DIFF
--- a/py-scripts/lf_ftp.py
+++ b/py-scripts/lf_ftp.py
@@ -1094,11 +1094,12 @@ class FtpTest(LFCliBase):
             self.bytes_rd[i] = max(self.max_bytes_rd[i], self.bytes_rd[i])
         return list(dataset)
 
-    def record_device_issue(self, device, issue):
+    def record_device_issue(self, device, issue, api_response=None):
         self.device_issue_log.append({
             "Time": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             "Device": device,
             "Issue": issue,
+            "API Response": api_response if api_response is not None else '',
         })
 
     def monitoring_elapsed_seconds(self):
@@ -1106,7 +1107,7 @@ class FtpTest(LFCliBase):
             return 0
         return (datetime.now() - self.monitoring_start_time).total_seconds()
 
-    def track_cx_status(self, cx, status):
+    def track_cx_status(self, cx, status, api_response=None):
         # Ignore CX status for the first 10s of monitoring: CXs are still settling into "Run"
         # right after the test starts (e.g. Login/Wait), and treating that startup ramp-up as a
         # real status change/recovery would be a false positive. Nothing is recorded - not even
@@ -1118,10 +1119,10 @@ class FtpTest(LFCliBase):
         if previous is not None and previous != status:
             if status.lower() != 'run':
                 logger.warning("CX '{}' status changed: {} -> {}".format(cx, previous, status))
-                self.record_device_issue(cx, "Status changed: {} -> {}".format(previous, status))
+                self.record_device_issue(cx, "Status changed: {} -> {}".format(previous, status), api_response=api_response)
             elif previous.lower() != 'run':
                 logger.info("CX '{}' recovered: {} -> {}".format(cx, previous, status))
-                self.record_device_issue(cx, "Recovered: {} -> {}".format(previous, status))
+                self.record_device_issue(cx, "Recovered: {} -> {}".format(previous, status), api_response=api_response)
         self.cx_status_log[cx] = status
 
     def format_monitoring_duration(self):
@@ -1445,7 +1446,7 @@ class FtpTest(LFCliBase):
                         l4_dict['bytes_rd'].append(value['bytes-rd'])
                         l4_dict['total_err'].append(value['total-err'])
                         l4_dict['status'].append(value['status'])
-                        self.track_cx_status(cx, value['status'])
+                        self.track_cx_status(cx, value['status'], api_response=value)
                         cx_found = True
             if not cx_found:
                 if cx not in self.missing_cx_logged:
@@ -1458,7 +1459,7 @@ class FtpTest(LFCliBase):
                         "Response CXs : {}".format(cx, url_str, response_cx_names))
                     self.missing_cx_logged.add(cx)
                     self.failed_cx.append(cx)
-                    self.record_device_issue(cx, "CX missing from monitoring data")
+                    self.record_device_issue(cx, "CX missing from monitoring data", api_response=response_cx_names)
                 l4_dict['uc_avg_data'].append(0 if not self.tracking_map else self.tracking_map['uc_avg_data'][idx])
                 l4_dict['uc_max_data'].append(0 if not self.tracking_map else self.tracking_map['uc_max_data'][idx])
                 l4_dict['uc_min_data'].append(0 if not self.tracking_map else self.tracking_map['uc_min_data'][idx])
@@ -1547,7 +1548,8 @@ class FtpTest(LFCliBase):
                         "Signal data for device '{}' is unavailable, it may have disconnected. "
                         "Continuing the test with the remaining devices.".format(sta))
                     self.missing_device_logged.add(sta)
-                    self.record_device_issue(sta, "Signal data unavailable (device may have disconnected)")
+                    self.record_device_issue(sta, "Signal data unavailable (device may have disconnected)",
+                                             api_response=list(interfaces_dict.keys()))
                 self.rssi_list.append('-')
                 self.tx_rate.append('-')
                 self.port_rx_rate.append('-')


### PR DESCRIPTION
Verified CLI : python3 lf_ftp.py --ssid Netgear-5g --passwd sharedsecret --file_sizes 10MB --mgr 192.168.207.75 --traffic_duration 1m --security wpa2 --directions Download --clients_type Real --ap_name Netgear --bands 5G --upstream_port eth1


Test Logs : 
```

1786379101.748376 INFO     Test is about to start lf_ftp.py 222
1786379101.902435 INFO     Test is Initialized lf_ftp.py 351
1786379102.052268 INFO     Connected (version 2.0, client OpenSSH_9.3) transport.py 1938
1786379102.569767 INFO     Authentication (password) successful! transport.py 1938
1786379102.963308 INFO     ['True\n'] lf_ftp.py 980
1786379113.349430 INFO     File creation done 10MB lf_ftp.py 988
1786379114.908986 INFO     Upstream port IP 192.168.0.177 lf_ftp.py 611
1.11  1.11 android xms
1786379115.311695 INFO     AVAILABLE DEVICES TO RUN TEST: ['1.11 android xms'] lf_ftp.py 498
1786379115.311944 INFO     ['1.11 android xms'] lf_ftp.py 499
1786379115.312011 INFO     AVAILABLE DEVICES TO RUN TEST : ['1.11 android xms'] lf_ftp.py 502
Enter the desired resources to run the test:1.11
1786379131.601532 INFO     Test is initiated on devices: ['1.11'] lf_ftp.py 522
1786379131.601668 INFO     device got from webui are: 1.11 lf_ftp.py 539
1786379131.601755 INFO     INPUT DEVICES LIST ['1.11.wlan0'] lf_ftp.py 557
REAL CLIENT LIST ['1.11 android xms']
1786379131.601864 INFO     MAC ID LIST ['76:58:e8:63:f3:f6'] lf_ftp.py 576
1786379131.601983 INFO     Cleaning up cxs and endpoints http_profile.py 77
1786379131.602049 INFO     Cleaning up stations station_profile.py 474
1786379131.602098 INFO     INFO: StationProfile cleanup, list is empty station_profile.py 480
1786379132.602329 INFO     precleanup done lf_ftp.py 677
1786379133.041958 INFO     Create HTTP CXs...py-json.http_profile http_profile.py 119
1786379133.210660 INFO     ###### url:dl ftp://lanforge:lanforge@192.168.0.177/ftp_test.txt /dev/null http_profile.py 184
1786379134.555275 INFO     Test Build done lf_ftp.py 842
1786379134.555451 ERROR    passes: zero test results, Chamberview tests will show zero test results so not an error lfcli_base.py 530
1786379134.685829 INFO     cross connections found for all devices lf_ftp.py 3195
1786379134.685968 INFO     Test started on the devices : ['1.11.wlan0'] lf_ftp.py 4073
1786379134.686053 INFO     Traffic started running at 2026-08-10 16:25:34.686035 lf_ftp.py 4076
1786379134.686333 INFO     Starting CXs... http_profile.py 59
1786379134.855135 INFO     Test Started lf_ftp.py 865
1786379198.413990 INFO     Monitoring complete lf_ftp.py 1712
1786379198.414179 INFO     Stopping CXs... http_profile.py 68
Traffic stopped running
1786379198.583651 INFO     Cleaning up cxs and endpoints http_profile.py 77
1786379198.994260 INFO     Cleaning up stations station_profile.py 474
1786379198.994511 INFO     INFO: StationProfile cleanup, list is empty station_profile.py 480
1786379198.994642 INFO     Test ended at 2026-08-10 16:26:38.994598 lf_ftp.py 4105
1786379198.994947 INFO     path set:  lf_report.py 85
1786379198.995125 INFO     path_date_time 2026-08-10-16-26-38_ftp_test lf_report.py 239
1786379198.995859 INFO     report path : 2026-08-10-16-26-38_ftp_test lf_report.py 248
1786379198.997388 INFO     path set:  lf_report.py 85
1786379198.997496 INFO     path_date_time 2026-08-10-16-26-38_ftp_test lf_report.py 239
1786379198.997555 INFO     report path : 2026-08-10-16-26-38_ftp_test lf_report.py 248
       Client names  Download
0  1.11 android xms        36
graph name Total-url_ftp.png
1786379199.210075 INFO     graph_src_file: Total-url_ftp.png lf_report.py 212
1786379199.210166 INFO     graph_dst_file: 2026-08-10-16-26-38_ftp_test/Total-url_ftp.png lf_report.py 213
1786379199.210352 INFO     csv_src_file: Total-url_ftp.csv lf_report.py 219
1786379199.210419 INFO     csv_dst_file: 2026-08-10-16-26-38_ftp_test/Total-url_ftp.csv lf_report.py 220
       Client names  Download
0  1.11 android xms  1474.638
graph name ucg-avg_ftp.png
1786379199.336132 INFO     graph_src_file: ucg-avg_ftp.png lf_report.py 212
1786379199.336240 INFO     graph_dst_file: 2026-08-10-16-26-38_ftp_test/ucg-avg_ftp.png lf_report.py 213
1786379199.336406 INFO     csv_src_file: ucg-avg_ftp.csv lf_report.py 219
1786379199.336466 INFO     csv_dst_file: 2026-08-10-16-26-38_ftp_test/ucg-avg_ftp.csv lf_report.py 220
1786379199.339924 INFO     write_output_html: 2026-08-10-16-26-38_ftp_test/ftp_test.html lf_report.py 368
1786379199.340247 INFO     returned file 2026-08-10-16-26-38_ftp_test/ftp_test.html lf_ftp.py 2808
1786379199.340330 INFO     2026-08-10-16-26-38_ftp_test/ftp_test.html lf_ftp.py 2809
1786379199.810267 INFO     Monitoring Duration: 1m 3s lf_ftp.py 2811
1786379199.810540 INFO     output file 2026-08-10-16-26-38_ftp_test/_2026-08-10-16-26-39-test_l4_ftp.csv lf_report.py 350
1786379199.810692 INFO     csv output file : 2026-08-10-16-26-38_ftp_test/_2026-08-10-16-26-39-test_l4_ftp.csv lf_ftp.py 2997
```