### PR TITLE
lf_interop_ping_plotter.py: Enhanced ping plotter for logging

### DIFF
--- a/py-scripts/lf_interop_ping_plotter.py
+++ b/py-scripts/lf_interop_ping_plotter.py
@@ -208,6 +208,10 @@ class Ping(Realm):
         self.endpoint_status_csv_path = os.path.join(os.getcwd(), 'endpoint_status_log.csv')
         with open(self.endpoint_status_csv_path, 'w', newline='') as f:
             csv.writer(f).writerow(['timestamp', 'resource_id', 'endpoint_name', 'status'])
+        self.device_issue_log = []
+        self.monitor_start_time = None
+        self.actual_monitor_duration = 0
+        self.all_devices_stopped = False
         self.generic_endps_profile = self.new_generic_endp_profile()
         self.generic_endps_profile.type = 'lfping'
         self.generic_endps_profile.dest = self.change_target_to_ip()
@@ -464,10 +468,32 @@ class Ping(Realm):
         self.generic_endps_profile.stop_cx()
         self.stop_time = datetime.now()
 
+    def record_device_issue(self, device, issue, api_response=None):
+        """Records a timestamped device issue, later written to clients_issue.csv."""
+        self.device_issue_log.append({
+            "Time": datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            "Device": device,
+            "Issue": issue,
+            "API Response": api_response if api_response is not None else '',
+        })
+
+    def monitoring_elapsed_seconds(self):
+        """Seconds since the current monitor() call started, or 0 if not monitoring."""
+        if not self.monitor_start_time:
+            return 0
+        return (datetime.now() - self.monitor_start_time).total_seconds()
+
+    def format_monitoring_duration(self):
+        """Formats the actual time spent monitoring as "Xm Ys"."""
+        total_seconds = int(self.actual_monitor_duration)
+        minutes, seconds = divmod(total_seconds, 60)
+        return "{}m {}s".format(minutes, seconds)
+
     def log_endpoint_status_change(self, endpoint_name, endpoint_data):
         status = endpoint_data.get('status')
         if self.endpoint_status_history.get(endpoint_name) == status:
             return
+        previous_status = self.endpoint_status_history.get(endpoint_name)
         self.endpoint_status_history[endpoint_name] = status
 
         resource_id = ''
@@ -481,7 +507,12 @@ class Ping(Realm):
         timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         with open(self.endpoint_status_csv_path, 'a', newline='') as f:
             csv.writer(f).writerow([timestamp, resource_id, endpoint_name, status])
-        logger.info(f"Endpoint {endpoint_name} (resource {resource_id}) status changed to {status}")
+        # 10s grace period: skip noise from endpoints still starting up
+        if previous_status is not None and self.monitoring_elapsed_seconds() >= 10:
+            logger.info(f"Endpoint {endpoint_name} (resource {resource_id}) status changed to {status}")
+            self.record_device_issue(resource_id or endpoint_name,
+                                     "Endpoint '{}' status changed: {} -> {}".format(endpoint_name, previous_status, status),
+                                     api_response=endpoint_data)
 
     def get_results(self):
         endp = "/generic/{}".format(','.join(self.generic_endps_profile.created_endp))
@@ -505,9 +536,18 @@ class Ping(Realm):
                 missing = [name for name in self.generic_endps_profile.created_endp if name not in returned_names]
                 newly_missing = [name for name in missing if name not in self.reported_missing_endpoints]
                 if newly_missing:
-                    logger.warning(f"GET {endp} response is missing results for endpoints: {newly_missing}")
-                    logger.warning(json.dumps(results, indent=2))
+                    logger.warning(
+                        "GET %s response is missing results for endpoints: %s\n"
+                        "Response keys: %s", endp, newly_missing, returned_names)
+                    for endpoint_name in newly_missing:
+                        self.record_device_issue(endpoint_name, "Endpoint missing from monitoring data",
+                                                 api_response=returned_names)
                     self.reported_missing_endpoints.update(newly_missing)
+                elif self.reported_missing_endpoints:
+                    recovered = [name for name in self.reported_missing_endpoints if name in returned_names]
+                    if recovered:
+                        logger.info("Endpoint(s) data is available again: %s", recovered)
+                        self.reported_missing_endpoints.difference_update(recovered)
             except Exception:
                 logger.error(f"GET {endp} 'endpoints' list is not in the expected format.")
                 return results
@@ -517,10 +557,14 @@ class Ping(Realm):
             results = results['endpoint']
             self.log_endpoint_status_change(results['name'], results)
         except Exception:
-            logger.error(f"GET {endp} response does not contain the 'endpoint' or 'endpoints' key, or the data is not in the expected format.")
-            overallres = self.json_get("/generic/all")
-            logger.error("GET /generic/all response:")
-            logger.error(json.dumps(overallres, indent=2))
+            response_keys = list(results.keys()) if isinstance(results, dict) else []
+            logger.error(
+                "GET %s response does not contain the 'endpoint' or 'endpoints' key, or the data "
+                "is not in the expected format.\n"
+                "Response keys: %s", endp, response_keys)
+            self.record_device_issue(','.join(self.generic_endps_profile.created_endp),
+                                     "Unexpected GET {} response format".format(endp),
+                                     api_response=response_keys)
             return results
 
         return results
@@ -537,6 +581,20 @@ class Ping(Realm):
             return 'UNKNOWN' not in result_data.get('name', 'UNKNOWN')
         keys = [list(d.keys())[0] for d in result_data]
         return any('UNKNOWN' not in key for key in keys)
+
+    def all_endpoints_stopped(self, result_data):
+        """
+        True if every non-UNKNOWN endpoint in result_data reports a 'Stopped' status. A stopped
+        endpoint keeps a valid name, so has_valid_endpoint_data() alone won't catch it - this is
+        the actual signal that a device stopped responding.
+        """
+        if result_data is None:
+            return False
+        entries = [result_data] if isinstance(result_data, dict) else [list(d.values())[0] for d in result_data]
+        valid_entries = [e for e in entries if 'UNKNOWN' not in e.get('name', 'UNKNOWN')]
+        if not valid_entries:
+            return False
+        return all(str(e.get('status', '')).lower() == 'stopped' for e in valid_entries)
 
     def wait_for_valid_endpoints(self, timeout=40, poll_interval=2):
         """
@@ -555,9 +613,12 @@ class Ping(Realm):
         wait_start = datetime.now()
         while (datetime.now() - wait_start).total_seconds() < timeout:
             time.sleep(poll_interval)
-            if self.has_valid_endpoint_data(self.get_results()):
+            latest_result = self.get_results()
+            if self.has_valid_endpoint_data(latest_result) and not self.all_endpoints_stopped(latest_result):
                 logger.info("Valid endpoint data recovered; resuming the test.")
                 return True
+            elapsed = (datetime.now() - wait_start).total_seconds()
+            logger.warning("Still no valid generic endpoints after %.0fs, retrying...", elapsed)
         logger.error(f"No valid generic endpoints recovered after waiting {timeout}s.")
         return False
 
@@ -580,6 +641,8 @@ class Ping(Realm):
             if ports_response is not None:
                 logger.info("GET /ports/all/ succeeded; resuming the test.")
                 return ports_response
+            elapsed = (datetime.now() - wait_start).total_seconds()
+            logger.warning("GET /ports/all/ still no response after %.0fs, retrying...", elapsed)
         logger.error(f"GET /ports/all/ still returned no response after waiting {timeout}s.")
         return None
 
@@ -602,6 +665,8 @@ class Ping(Realm):
             if adb_response is not None:
                 logger.info("GET /adb/ succeeded.")
                 return adb_response
+            elapsed = (datetime.now() - wait_start).total_seconds()
+            logger.warning("GET /adb/ still no response after %.0fs, retrying...", elapsed)
         logger.error(f"GET /adb/ still returned no response after waiting {timeout}s.")
         return None
 
@@ -1246,7 +1311,7 @@ class Ping(Realm):
         if config_devices == '':
             test_setup_info = {
                 'SSID': [self.ssid if self.ssid else 'TEST CONFIGURED'][0],
-                'Security': [self.security if self.ssid else 'TEST CONFIGURED'][0],
+                'Security': [self.security if self.security else 'TEST CONFIGURED'][0],
                 'Website / IP': self.target,
                 'No of Devices': '{} (V:{}, A:{}, W:{}, L:{}, M:{})'.format(len(self.sta_list), len(self.sta_list) - len(self.real_sta_list), self.android, self.windows, self.linux, self.mac),
                 'Duration': self.duration
@@ -1505,9 +1570,13 @@ class Ping(Realm):
             report.build_table()
 
         # closing
+        if self.device_issue_log:
+            issues_df = pd.DataFrame(self.device_issue_log)
+            issues_df.to_csv(os.path.join(report_path_date_time, "clients_issue.csv"), index=False)
         report.build_footer()
         report.write_html()
         report.write_pdf()
+        logger.info("Monitoring Duration: %s", self.format_monitoring_duration())
 
         if self.do_webUI:
             self.copy_reports(report_path_date_time)
@@ -1726,6 +1795,17 @@ class Ping(Realm):
                 - In standard mode: returns None implicitly after the loop ends.
         """
         logging.info("Monitoringcx")
+        if self.all_devices_stopped:
+            # already gave up on recovery earlier; don't re-run the 40s wait on every bandsteering tick
+            return (individual_df, True) if self.do_bandsteering else None
+        if self.do_bandsteering:
+            # one continuous session: start the grace period once, not every tick
+            if self.monitor_start_time is None:
+                self.monitor_start_time = datetime.now()
+        else:
+            # fresh endpoints per coordinate/rotation: restart the grace period each call
+            self.monitor_start_time = datetime.now()
+        monitor_start = datetime.now()
         if Devices is None:
             Devices = RealDevice(manager_ip=self.host, selected_bands=[])
         stop_status = False
@@ -1755,14 +1835,26 @@ class Ping(Realm):
                     time.sleep(1)
                     loop_timer += abs(t_init - datetime.now()).total_seconds()
                     continue
-                if not self.has_valid_endpoint_data(result_data):
-                    raise ValueError("There are no valid generic endpoints to run the test")
+                # skip the stopped-status check during the startup grace period, since endpoints
+                # can briefly still report their pre-start status right after start_generic()
+                stopped = self.monitoring_elapsed_seconds() >= 10 and self.all_endpoints_stopped(result_data)
+                if not self.has_valid_endpoint_data(result_data) or stopped:
+                    raise ValueError("There are no valid generic endpoints to run the test" if not stopped
+                                     else "All generic endpoints have stopped responding")
             except ValueError as e:
                 logger.info(result_data)
                 logger.error(e)
                 if self.wait_for_valid_endpoints(timeout=40):
                     loop_timer += abs(t_init - datetime.now()).total_seconds()
                     continue
+                logger.error("No devices responded within 40 seconds during monitoring, ending "
+                             "the monitor loop gracefully; the test will continue with the data "
+                             "collected so far.")
+                self.record_device_issue(','.join(self.generic_endps_profile.created_endp), str(e))
+                self.all_devices_stopped = True
+                if self.robot is not None:
+                    # mark the WebUI nav state as completed rather than stuck mid-navigation
+                    self.robot.update_nav_data_for_all_cxs_stopped()
                 break
             # logging.info(result_data)
             # Robot battery management — check every 300 seconds
@@ -2035,6 +2127,7 @@ class Ping(Realm):
                         individual_data, stop_status = self.store_bandsteeringcsv()
                         stop_status = True
                         individual_df.to_csv('bandsteering_data.csv', index=False)
+                        self.actual_monitor_duration += (datetime.now() - monitor_start).total_seconds()
                         return individual_df, stop_status
                     break
 
@@ -2043,6 +2136,7 @@ class Ping(Realm):
                 if not stop_status:
                     individual_df.loc[len(individual_df)] = individual_data
                     individual_df.to_csv('bandsteering_data.csv', index=False)
+                self.actual_monitor_duration += (datetime.now() - monitor_start).total_seconds()
                 return individual_df, stop_status
 
             time.sleep(1)
@@ -2051,6 +2145,7 @@ class Ping(Realm):
             t_end = datetime.now()
             # print(t_end, abs(t_init - t_end).total_seconds())
             loop_timer += abs(t_init - t_end).total_seconds()
+        self.actual_monitor_duration += (datetime.now() - monitor_start).total_seconds()
 
     def perform_robo(self, Devices, config_devices, group_device_map):
         """
@@ -2136,6 +2231,9 @@ class Ping(Realm):
             exit(1)
         # Standard robot test — iterate over coordinates and angles
         for coord in self.coordinate_list:
+            if self.all_devices_stopped:
+                logging.warning("Robot test stopped because no devices recovered within 40 seconds.")
+                break
             # WebUI stop request between coordinates
             if self.do_webUI:
                 if self.check_stop_status():
@@ -2204,6 +2302,9 @@ class Ping(Realm):
                 logging.info('Stopping the cx')
                 self.stop_generic()
                 # self.clear_counter_endp()
+
+                if self.all_devices_stopped:
+                    break
 
             if self.do_webUI:
                 self.copy_reports_to_home_dir()
@@ -2357,7 +2458,7 @@ class Ping(Realm):
         if config_devices == '':
             test_setup_info = {
                 'SSID': [self.ssid if self.ssid else 'TEST CONFIGURED'][0],
-                'Security': [self.security if self.ssid else 'TEST CONFIGURED'][0],
+                'Security': [self.security if self.security else 'TEST CONFIGURED'][0],
                 'Website / IP': self.target,
                 'No of Devices': '{} (V:{}, A:{}, W:{}, L:{}, M:{})'.format(len(self.sta_list), len(self.sta_list) - len(self.real_sta_list), self.android, self.windows, self.linux, self.mac),
                 'Duration': self.duration,
@@ -2395,6 +2496,14 @@ class Ping(Realm):
         last_interation = False
         for coord in self.coordinates_completed:
             for angle in self.angle_list:
+                # a coordinate stopped before any data was collected has nothing to report - skip it
+                if self.rotation_enabled:
+                    if coord not in self.coordinate_json or angle not in self.coordinate_json[coord]:
+                        logger.warning("No ping data was collected for coordinate %s angle %s; skipping it in the report.", coord, angle)
+                        continue
+                elif coord not in self.coordinate_json:
+                    logger.warning("No ping data was collected for coordinate %s; skipping it in the report.", coord)
+                    continue
                 # Detect the final iteration so we can break the outer loop
                 if coord == len(self.coordinates_completed) - 1 and self.angle_list[angle] == self.currentangle:
                     last_interation = True
@@ -2701,9 +2810,13 @@ class Ping(Realm):
             if last_interation:
                 break
         # closing
+        if self.device_issue_log:
+            issues_df = pd.DataFrame(self.device_issue_log)
+            issues_df.to_csv(os.path.join(report_path_date_time, "clients_issue.csv"), index=False)
         report.build_footer()
         report.write_html()
         report.write_pdf()
+        logger.info("Monitoring Duration: %s", self.format_monitoring_duration())
 
         if self.do_webUI:
             self.copy_reports(report_path_date_time)
@@ -3409,23 +3522,29 @@ connectivity problems.
             'received': [],
             'dropped': []
         }
+    ping.monitor_start_time = datetime.now()
+    monitor_start = datetime.now()
     while (loop_timer <= duration):
         t_init = datetime.now()
         try:
             result_data = ping.get_results()
-            if result_data is None:
-                logger.warning("get_results() returned no data this poll; skipping to the next iteration.")
-                time.sleep(1)
-                loop_timer += abs(t_init - datetime.now()).total_seconds()
-                continue
-            if not ping.has_valid_endpoint_data(result_data):
-                raise ValueError("There are no valid generic endpoints to run the test")
+            # skip the stopped-status check during the startup grace period, since endpoints
+            # can briefly still report their pre-start status right after start_generic()
+            stopped = result_data is not None and ping.monitoring_elapsed_seconds() >= 10 and ping.all_endpoints_stopped(result_data)
+            if not ping.has_valid_endpoint_data(result_data) or stopped:
+                raise ValueError("There are no valid generic endpoints to run the test" if not stopped
+                                 else "All generic endpoints have stopped responding")
         except ValueError as e:
             logger.info(result_data)
             logger.error(e)
             if ping.wait_for_valid_endpoints(timeout=40):
                 loop_timer += abs(t_init - datetime.now()).total_seconds()
                 continue
+            logger.error("No devices responded within 40 seconds during monitoring, ending "
+                         "the monitor loop gracefully; the test will continue with the data "
+                         "collected so far.")
+            ping.record_device_issue(','.join(ping.generic_endps_profile.created_endp), str(e))
+            ping.all_devices_stopped = True
             break
         if args.virtual:
             logger.debug("GET /ports/all/")
@@ -3839,6 +3958,7 @@ connectivity problems.
         # print(t_end, abs(t_init - t_end).total_seconds())
         loop_timer += abs(t_init - t_end).total_seconds()
     # time.sleep(duration * 60)
+    ping.actual_monitor_duration += (datetime.now() - monitor_start).total_seconds()
 
     logging.info('Stopping the test')
     ping.stop_generic()


### PR DESCRIPTION
Verified CLI:
`python3 lf_interop_ping_plotter.py --mgr 192.168.207.75 --real --ping_interval 1 --ping_duration 1m --target www.google.com --use_default_config`

Test logs:
```
1786378863.015382 INFO Real client generic endpoint creation completed. lf_interop_ping_plotter.py 454
1786378863.015488 INFO {'endp_name': 'generic-1.56.wlan0', 'milliseconds': 250} gen_cxprofile.py 54
1786378863.015518 INFO Setting the report timer to 250 milliseconds for endpoint generic-1.56.wlan0 gen_cxprofile.py 55
1786378863.176627 INFO {'endp_name': 'generic-1.30.wlan0', 'milliseconds': 250} gen_cxprofile.py 54
1786378863.176721 INFO Setting the report timer to 250 milliseconds for endpoint generic-1.30.wlan0 gen_cxprofile.py 55
1786378863.336646 INFO CX_generic-1.56.wlan0 lf_interop_ping_plotter.py 3498
1786378863.336758 INFO Running the ping plotter test for 10.0 minutes lf_interop_ping_plotter.py 3504
1786378863.336804 INFO Starting CXs: ['CX_generic-1.56.wlan0', 'CX_generic-1.30.wlan0'] gen_cxprofile.py 129
1786378863.336831 INFO Created-Endp: ['generic-1.56.wlan0', 'generic-1.30.wlan0'] gen_cxprofile.py 130
1786378863.658810 INFO {} lf_interop_ping_plotter.py 3514
1786378884.764722 INFO Endpoint generic-1.30.wlan0 (resource 30) status changed to Stopped lf_interop_ping_plotter.py 512
1786378907.351870 INFO Endpoint generic-1.56.wlan0 (resource 56) status changed to Stopped lf_interop_ping_plotter.py 512
1786378907.352038 INFO [{'generic-1.30.wlan0': {'_links': 'NA', 'bps rx': '16 bps', 'bps tx': '16 bps', 'command': 'ping -i 5 192.168.0.26', 'delay': '22.2 ms', 'dropped': '0', 'eid': '1.30.0.159.13', 'elapsed': 19, 'entity id': '1.30.0.159.13', 'jitter': '0 us', 'last results': 'PING 192.168.0.26 (192.168.0.26) 56(84) bytes of data.\n64 bytes from 192.168.0.26: icmp_seq=1 ttl=64 time=1.55 ms *** drop: 0 (0 0) rx: 1 fail: 0 bytes: 64 min/avg/max: 1.550/1.550/1.550\n64 bytes from 192.168.0.26: icmp_seq=2 ttl=64 time=16.8 ms *** drop: 0 (0 0) rx: 2 fail: 0 bytes: 128 min/avg/max: 1.550/9.175/16.800\n64 bytes from 192.168.0.26: icmp_seq=3 ttl=64 time=2.65 ms *** drop: 0 (0 0) rx: 3 fail: 0 bytes: 192 min/avg/max: 1.550/7.000/16.800\n64 bytes from 192.168.0.26: icmp_seq=4 ttl=64 time=22.2 ms *** drop: 0 (0 0) rx: 4 fail: 0 bytes: 256 min/avg/max: 1.550/10.800/22.200', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.30.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 5, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '256 B', 'rx pkts': '4', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '256 B', 'tx pkts': '4', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'}}, {'generic-1.56.wlan0': {'_links': 'NA', 'bps rx': '115 bps', 'bps tx': '115 bps', 'command': 'lfping -I wlan0 -i 5 192.168.0.26', 'delay': '1.71 ms', 'dropped': '0', 'eid': '1.56.2.158.13', 'elapsed': 44, 'entity id': '1.56.2.158.13', 'jitter': '0 us', 'last results': '64 bytes from 192.168.0.26: icmp_seq=1 ttl=64 time=4.18 ms *** drop: 0 (0, 0.000) rx: 1 fail: 0 bytes: 64 min/avg/max: 4.180/4.180/4.180\n64 bytes from 192.168.0.26: icmp_seq=1 ttl=64 time=4.18 ms *** drop: 0 (0, 0.000) rx: 1 fail: 0 bytes: 64 min/avg/max: 4.180/4.180/4.180\n64 bytes from 192.168.0.26: icmp_seq=2 ttl=64 time=3.34 ms *** drop: 0 (0, 0.000) rx: 2 fail: 0 bytes: 128 min/avg/max: 3.340/3.760/4.180\n64 bytes from 192.168.0.26: icmp_seq=3 ttl=64 time=1.59 ms *** drop: 0 (0, 0.000) rx: 3 fail: 0 bytes: 192 min/avg/max: 1.590/3.037/4.180\n64 bytes from 192.168.0.26: icmp_seq=4 ttl=64 time=1.22 ms *** drop: 0 (0, 0.000) rx: 4 fail: 0 bytes: 256 min/avg/max: 1.220/2.583/4.180\n64 bytes from 192.168.0.26: icmp_seq=5 ttl=64 time=1.88 ms *** drop: 0 (0, 0.000) rx: 5 fail: 0 bytes: 320 min/avg/max: 1.220/2.442/4.180\n64 bytes from 192.168.0.26: icmp_seq=6 ttl=64 time=1.22 ms *** drop: 0 (0, 0.000) rx: 6 fail: 0 bytes: 384 min/avg/max: 1.220/2.238/4.180\n64 bytes from 192.168.0.26: icmp_seq=7 ttl=64 time=1.71 ms *** drop: 0 (0, 0.000) rx: 7 fail: 0 bytes: 448 min/avg/max: 1.220/2.163/4.180\n64 bytes from 192.168.0.26: icmp_seq=8 ttl=64 time=1.60 ms *** drop: 0 (0, 0.000) rx: 8 fail: 0 bytes: 512 min/avg/max: 1.220/2.093/4.180\n64 bytes from 192.168.0.26: icmp_seq=9 ttl=64 time=1.71 ms *** drop: 0 (0, 0.000) rx: 9 fail: 0 bytes: 576 min/avg/max: 1.220/2.050/4.180', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.56.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 10, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '576 B', 'rx pkts': '9', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '576 B', 'tx pkts': '9', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'}}] lf_interop_ping_plotter.py 3538
1786378907.352149 ERROR All generic endpoints have stopped responding lf_interop_ping_plotter.py 3539
1786378907.352202 WARNING No valid generic endpoints in the last poll. Waiting up to 40s for them to recover before stopping the test. lf_interop_ping_plotter.py 612
1786378909.484513 WARNING Still no valid generic endpoints after 2s, retrying... lf_interop_ping_plotter.py 621
1786378911.612620 WARNING Still no valid generic endpoints after 4s, retrying... lf_interop_ping_plotter.py 621
1786378916.673654 WARNING Still no valid generic endpoints after 9s, retrying... lf_interop_ping_plotter.py 621
1786378918.796190 WARNING Still no valid generic endpoints after 11s, retrying... lf_interop_ping_plotter.py 621
1786378920.922995 WARNING Still no valid generic endpoints after 14s, retrying... lf_interop_ping_plotter.py 621
1786378923.045495 WARNING Still no valid generic endpoints after 16s, retrying... lf_interop_ping_plotter.py 621
1786378925.170417 WARNING Still no valid generic endpoints after 18s, retrying... lf_interop_ping_plotter.py 621
1786378927.299931 WARNING Still no valid generic endpoints after 20s, retrying... lf_interop_ping_plotter.py 621
1786378929.435304 WARNING Still no valid generic endpoints after 22s, retrying... lf_interop_ping_plotter.py 621
1786378931.568958 WARNING Still no valid generic endpoints after 24s, retrying... lf_interop_ping_plotter.py 621
1786378933.699631 INFO Endpoint generic-1.30.wlan0 (resource 30) status changed to Run lf_interop_ping_plotter.py 512
1786378933.700006 INFO Endpoint generic-1.56.wlan0 (resource 56) status changed to Run lf_interop_ping_plotter.py 512
1786378933.700302 INFO Valid endpoint data recovered; resuming the test. lf_interop_ping_plotter.py 618
1786379039.316800 INFO Endpoint generic-1.56.wlan0 (resource 56) status changed to FTM_WAIT lf_interop_ping_plotter.py 512
1786379055.829675 INFO Endpoint generic-1.56.wlan0 (resource 56) status changed to WAITING lf_interop_ping_plotter.py 512
1786379061.469475 INFO Endpoint generic-1.56.wlan0 (resource 56) status changed to Stopped lf_interop_ping_plotter.py 512
1786379064.865385 INFO Endpoint generic-1.56.wlan0 (resource 56) status changed to Run lf_interop_ping_plotter.py 512
1786379464.408350 INFO Stopping the test lf_interop_ping_plotter.py 3963
1786379464.408742 INFO Stopping CXs... gen_cxprofile.py 144
1786379464.777710 INFO Generating Report lf_interop_ping_plotter.py 1206
1786379464.777864 INFO Generating Report lf_interop_ping_plotter.py 1259
1786379464.777908 INFO path set: lf_report.py 85
1786379464.777992 INFO path_date_time 2026-08-10-22-01-04_Ping_Plotter_Test_Report lf_report.py 239
1786379464.778219 INFO report path : 2026-08-10-22-01-04_Ping_Plotter_Test_Report lf_report.py 248
1786379464.779802 INFO path: lf_interop_ping_plotter.py 1267
1786379464.779867 INFO path_date_time: 2026-08-10-22-01-04_Ping_Plotter_Test_Report lf_interop_ping_plotter.py 1268
Linux/x86-64
OPPO CPH2219 r13 sdk: 33
1786379465.525754 INFO uptime graph name uptime_graph.png lf_interop_ping_plotter.py 1355
1786379465.525871 INFO graph_src_file: uptime_graph.png lf_report.py 212
1786379465.525898 INFO graph_dst_file: 2026-08-10-22-01-04_Ping_Plotter_Test_Report/uptime_graph.png lf_report.py 213
Wireless Clients Packets Loss Packets Received Packets Sent
0 1.56.wlan0 Linux ubuntu24 0 81 81
1 1.30.wlan0 Android oppo 1 105 106
1786379465.624261 INFO graph name Packets sent vs received vs dropped.png lf_interop_ping_plotter.py 1482
1786379465.624348 INFO graph_src_file: Packets sent vs received vs dropped.png lf_report.py 212
1786379465.624372 INFO graph_dst_file: 2026-08-10-22-01-04_Ping_Plotter_Test_Report/Packets sent vs received vs dropped.png lf_report.py 213
1786379465.624440 INFO csv_src_file: Packets sent vs received vs dropped.csv lf_report.py 219
1786379465.624475 INFO csv_dst_file: 2026-08-10-22-01-04_Ping_Plotter_Test_Report/Packets sent vs received vs dropped.csv lf_report.py 220
Wireless Clients Min RTT (ms) Average RTT (ms) Max RTT (ms)
0 1.56.wlan0 Linux ubuntu24 1.0 1.965679 11.4
1 1.30.wlan0 Android oppo 0.0 14.335660 105.0
1786379465.704437 INFO graph name Ping RTT per client.png lf_interop_ping_plotter.py 1532