### PR TITLE
android_zoom.py: fix Zoom 6.x control detection and harden the join flow

### DIFF
--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -640,6 +640,21 @@ class ZoomAutomator:
             self.logger.warning(
                 f"Could not fully enable audio/video after {max_retries} retries."
             )
+            self.logger.warning(
+                "Audio and video can only be toggled while Zoom's meeting "
+                "toolbar is on screen, and Zoom Auto hides it a few seconds after "
+                "each tap. Turn on 'Always show meeting controls' once on "
+                "this handset so the buttons stay readable — Zoom keeps the "
+                "setting across restarts:\n"
+                "    1. Open the Zoom app (no sign-in needed).\n"
+                "    2. Tap the gear icon at the top left.\n"
+                "    3. Tap 'Meetings'.\n"
+                "    4. Scroll down to 'IN MEETING CONTROLS'.\n"
+                "    5. Turn on 'Always show meeting controls'.\n"
+                "While on that screen, also leave 'Turn off my video' and "
+                "'Mute my microphone' off, so the client joins unmuted and "
+                "with video already on."
+            )
 
     def upload_ping_log(self):
         """POST this participant's ping log to the host as a file upload.

--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 import os
 import re
+import subprocess
 import sys
 import time
 from datetime import datetime, timedelta
@@ -241,6 +242,60 @@ class ZoomAutomator:
             self.logger.error(f"Failed to connect: {e}")
             raise
 
+    def _adb(self, *args):
+        """Run an adb shell command on this device and return the result."""
+        return subprocess.run(
+            ["adb", "-s", self.device_serial, "shell", *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def grant_permissions(self, package_name=ZOOM_PACKAGE):
+        """Pre-grant the app's runtime permissions so no dialog blocks the join.
+
+        Reads the permissions the package actually declares on this device, so
+        one call covers every API level in the fleet. Returns the number still
+        ungranted afterwards.
+        """
+        self._set_phase("PERMISSIONS")
+
+        listing = self._adb("dumpsys", "package", package_name).stdout
+        wanted, in_runtime = [], False
+        for raw in listing.splitlines():
+            line = raw.strip()
+            if line.startswith("runtime permissions:"):
+                in_runtime = True
+            elif in_runtime:
+                if line.startswith("android.permission."):
+                    wanted.append(line.split(":", 1)[0])
+                elif line:
+                    break
+
+        granted = 0
+        for permission in wanted:
+            result = self._adb("pm", "grant", package_name, permission)
+            output = result.stdout + result.stderr
+            if "GRANT_RUNTIME_PERMISSIONS" in output:
+                self.logger.error(
+                    "This ROM blocks adb from granting permissions. "
+                    "Accept the prompts manually once."
+                )
+                break
+            if not output.strip():
+                granted += 1
+
+        # Not a runtime permission — it is an appop, so pm grant cannot set it.
+        self._adb("appops", "set", package_name, "SYSTEM_ALERT_WINDOW", "allow")
+
+        remaining = self._adb("dumpsys", "package", package_name).stdout.count(
+            "granted=false"
+        )
+        self.logger.info(
+            f"Permissions: granted {granted}/{len(wanted)}, "
+            f"{remaining} still ungranted."
+        )
+        return remaining
+
     def start_interop_app(self):
         """Force-stop Zoom and hand the device back to the interop app.
 
@@ -311,32 +366,15 @@ class ZoomAutomator:
         self.logger.info(f"Starting {ZOOM_PACKAGE} and opening the meeting link.")
         d.app_start(ZOOM_PACKAGE, stop=True)
         time.sleep(2)
-
+        
         self.adb_device.shell(
-            f'am start -a android.intent.action.VIEW -d "{meeting_url}"'
+            f'am start -a android.intent.action.VIEW -d "{meeting_url}" {ZOOM_PACKAGE}'
         )
         self.logger.info(f"Meeting link handed to Zoom: {meeting_url}")
         time.sleep(8)
 
-        self._set_phase("PERMISSIONS")
-        self.logger.info("Checking for permission prompts.")
-        allow_while_using = d(text="While using the app")
-        if allow_while_using.wait(timeout=8):
-            allow_while_using.click()
-            self.logger.info("Granted 'While using the app'.")
-            time.sleep(2)
-
-            for permission_text in ["Allow", "ALLOW"]:
-                allow_btn = d(text=permission_text, className="android.widget.Button")
-                if allow_btn.wait(timeout=5):
-                    allow_btn.click()
-                    self.logger.info(f"Clicked '{permission_text}'.")
-                    time.sleep(1)
-        else:
-            self.logger.info("No permission prompt appeared; already granted.")
-
         preview_join = d(text="Editing display name")
-        if preview_join.wait(timeout=5):
+        if preview_join.wait(timeout=30):
             self.logger.info("Preview screen detected.")
 
             name_input = d(className="android.widget.EditText")
@@ -694,6 +732,7 @@ def main():
     )
     try:
         automator.set_device(args.serial)
+        automator.grant_permissions()
         automator.join_zoom_meeting(args.meeting_url, args.participant_name)
     except Exception as e:
         automator.logger.error(f"Error: {e}")

--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -144,6 +144,11 @@ class ZoomAutomator:
         d.click(*tap_coords)
         time.sleep(1)
 
+    @staticmethod
+    def _control_label(node):
+        """Return a node's label from content-desc, or text when that is empty."""
+        return node.attrib.get("content-desc") or node.attrib.get("text") or ""
+
     def get_audio_control_info(self, d):
         """Return audio state and bounds by parsing the current hierarchy dump."""
         try:
@@ -155,11 +160,11 @@ class ZoomAutomator:
             return None, None, None
 
         for node in root.iter("node"):
-            content_desc = node.attrib.get("content-desc", "")
-            if content_desc == "Mute my audio, button":
-                return True, node.attrib.get("bounds"), content_desc
-            if content_desc == "Unmute my audio, button":
-                return False, node.attrib.get("bounds"), content_desc
+            label = self._control_label(node)
+            if label.startswith("Mute my audio"):
+                return True, node.attrib.get("bounds"), label
+            if label.startswith("Unmute my audio"):
+                return False, node.attrib.get("bounds"), label
 
         return None, None, None
 
@@ -174,11 +179,11 @@ class ZoomAutomator:
             return None, None, None
 
         for node in root.iter("node"):
-            content_desc = node.attrib.get("content-desc", "")
-            if content_desc == "Start my video, button":
-                return False, node.attrib.get("bounds"), content_desc
-            if content_desc == "Stop my video, button":
-                return True, node.attrib.get("bounds"), content_desc
+            label = self._control_label(node)
+            if label.startswith("Start my video"):
+                return False, node.attrib.get("bounds"), label
+            if label.startswith("Stop my video"):
+                return True, node.attrib.get("bounds"), label
 
         return None, None, None
 
@@ -193,9 +198,9 @@ class ZoomAutomator:
             return None, None
 
         for node in root.iter("node"):
-            content_desc = node.attrib.get("content-desc", "")
-            if content_desc == "Leave, button":
-                return node.attrib.get("bounds"), content_desc
+            label = self._control_label(node)
+            if label.startswith("Leave"):
+                return node.attrib.get("bounds"), label
 
         return None, None
 
@@ -366,7 +371,6 @@ class ZoomAutomator:
         self.logger.info(f"Starting {ZOOM_PACKAGE} and opening the meeting link.")
         d.app_start(ZOOM_PACKAGE, stop=True)
         time.sleep(2)
-        
         self.adb_device.shell(
             f'am start -a android.intent.action.VIEW -d "{meeting_url}" {ZOOM_PACKAGE}'
         )


### PR DESCRIPTION
## Summary

Android participants running Zoom 6.x joined meetings but never turned their
camera on, so they contributed no uplink video to the results while the run
still exited 0 and produced a clean-looking report. This branch fixes that and
makes the join path more robust.

Three commits, all in `py-scripts/real_application_tests/zoom_automation/android_zoom.py`:

| Commit | Change |
|---|---|
| `cff162b1` | Pre-grant Zoom's runtime permissions over adb before joining |
| `4fe2c89e` | Target the Zoom package on the meeting intent; raise the preview-screen timeout; explain the toolbar setting when A/V cannot be toggled |
| `6bb72fde` | Match in-meeting control labels by prefix instead of exact equality |

## Root cause of the main bug

Zoom labels the same in-meeting controls differently between releases:

| Zoom | `content-desc` for the mic button |
|---|---|
| 7.x | `Mute my audio, button` |
| 6.x | `Mute my audio Button 1 of 13` |

6.x drops the comma, capitalises `Button`, appends `N of 13`, and labels Leave
through `text=` with an empty `content-desc`. The matchers used exact equality
against the 7.x strings only, so on 6.x clients:

- `get_audio_control_info()` / `get_video_control_info()` returned `None`
- `enable_audio_video()` logged "button not visible" for all 15 retries and left
  the camera off
- `get_leave_control_info()` found nothing and fell through to pressing back

This was confirmed by dumping the live UI hierarchy from a 6.6.0 device while it
sat in a meeting with the toolbar visible: the buttons were present and
readable; only the string comparison failed. Enabling Zoom's
"Always show meeting controls" does not help, because visibility was never the
problem.

`_control_label()` now reads `content-desc`, falls back to `text` when that is
empty, and callers compare on the label prefix, so both layouts resolve.

## Other changes

- **Permission pre-granting** reads the runtime permissions the package actually
  declares on that device, so one code path covers every API level, and sets
  `SYSTEM_ALERT_WINDOW` through appops since `pm grant` cannot. This replaces
  clicking the "While using the app" / "Allow" dialogs.
- **Meeting intent** now names the Zoom package, so the deep link cannot be
  captured by a browser or a chooser dialog.
- **Preview-screen timeout raised 5s to 30s.** This is load-bearing: one handset
  reached the preview screen only after 26 seconds and would have failed at 5s.

## Testing

Three consecutive 2-minute runs on the interop testbed, host plus five Android
devices, covering Zoom **6.5.12, 6.6.0, 7.0.4, 7.1.6** and Android **SDK 31, 33, 36**
(OPPO CPH2725, Pixel 4a x2, Samsung SM-F415F, Samsung SM-A217F).

Every participating device joined, reported both audio and video enabled, and
left without falling back to the back key. Before this change, only the two
Zoom 7.x devices managed that; the three 6.x devices failed all 15 A/V retries.
Both label variants were exercised in the logs.

Verified with:

    python3 lf_interop_zoom.py --duration 2 \
        --lanforge_ip 192.168.245.117 \
        --signin_email <zoom_email> --signin_passwd <zoom_passwd> \
        --participants 6 --audio --video \
        --upstream_port <upstream_ip> \
        --zoom_host 1.13 \
        --resources 1.13,1.12,1.15,1.16,1.22,1.25 \
        --api_stats_collection --env_file .env

## Known limitations

- **Fresh OPPO/ColorOS devices have no permission fallback.** That ROM refuses
  `adb pm grant`, and this branch removes the UI dialog handling that used to
  cover it. Devices where the mic/camera prompts were already accepted once are
  unaffected, which is why the OPPO in the testbed still passes.
