### PR TITLE
WC-1931:lf_interop_ping_plotter.py: Fix ping test if generic tab check is not present

### DIFF
--- a/py-scripts/lf_interop_ping_plotter.py
+++ b/py-scripts/lf_interop_ping_plotter.py
@@ -431,9 +431,8 @@ class Ping(Realm):
         response = self.json_get("generic")
         if response is None:
             logger.error("GET /generic returned no response; Generic tab may not be available on the LANforge manager.")
-            return False
-        else:
-            return True
+            raise RuntimeError("Generic tab is not available on the LANforge manager.")
+        return True
 
     def create_generic_endp(self):
         # Virtual stations are tracked in same list as real stations, so need to separate them
@@ -3486,9 +3485,7 @@ connectivity problems.
         ping.buildstation()
 
     # check if generic tab is enabled or not
-    if not ping.check_tab_exists():
-        logging.error('Generic Tab is not available.\nAborting the test.')
-        exit(0)
+    ping.check_tab_exists()
 
     ping.sta_list += ping.real_sta_list
 


### PR DESCRIPTION
- Fixes the test by raising exception when genric tab is not present

VERIFIED CLI: python3 lf_interop_ping_plotter.py --mgr 192.168.207.75 --target www.google.com --real --ping_interval 5 --ping_duration 300s --use_default_config --do_webUI --resources 1.40.wlan0,1.56.wlan0,1.30.wlan0


Test logs:

```
1786688107.800442 INFO Ping target: www.google.com lf_interop_ping_plotter.py 279
1786688107.922078 INFO The available real devices are: lf_base_interop_profile.py 1770
Port Name hw version MAC
1.30 1.30.wlan0 OPPO CPH2219 r13 sdk: 33 ae:66:2a:be:41:09
1.40 1.40.wlan0 Win/x86 6.2 38:fc:98:d0:56:ec
1.56 1.56.wlan0 Linux/x86-64 5c:5f:67:97:2d:86
You have selected the below devices for testing
Eid hw version MAC
1.40.wlan0 1.40 Win/x86 6.2 38:fc:98:d0:56:ec
1.56.wlan0 1.56 Linux/x86-64 5c:5f:67:97:2d:86
1.30.wlan0 1.30 OPPO CPH2219 r13 sdk: 33 ae:66:2a:be:41:09
1786688107.981845 INFO 1.40.wlan0 lf_interop_ping_plotter.py 390
1786688107.981957 INFO Cleaning up generic endpoints if exists lf_interop_ping_plotter.py 361
1786688107.981989 INFO Cleaning up cxs and endpoints gen_cxprofile.py 158
1786688107.991270 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/cli-json/rm_cx
X-Error-00: unable to execute rm_cx rv: 22 (22 Invalid argument)
X-Error-01: URL: /cli-json/rm_cx
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.003453 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/cli-json/rm_cx
X-Error-00: unable to execute rm_cx rv: 22 (22 Invalid argument)
X-Error-01: URL: /cli-json/rm_cx
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.015357 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/cli-json/rm_cx
X-Error-00: unable to execute rm_cx rv: 22 (22 Invalid argument)
X-Error-01: URL: /cli-json/rm_cx
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.028520 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/cli-json/rm_endp
X-Error-00: unable to execute rm_endp rv: 22 (22 Invalid argument)
X-Error-01: URL: /cli-json/rm_endp
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.042134 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/cli-json/rm_endp
X-Error-00: unable to execute rm_endp rv: 22 (22 Invalid argument)
X-Error-01: URL: /cli-json/rm_endp
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.053312 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/cli-json/rm_endp
X-Error-00: unable to execute rm_endp rv: 22 (22 Invalid argument)
X-Error-01: URL: /cli-json/rm_endp
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.053593 INFO Cleanup Successful lf_interop_ping_plotter.py 365
1786688108.220951 ERROR
= = LANforge Error Messages = =
= = URL: http://192.168.207.75:8080/generic
X-Error-00: Using Generic endpoints requires Generics tab to be shown.
= = = = = = = = = = = = = = = = LFRequest.py 396
1786688108.221113 ERROR GET /generic returned no response; Generic tab may not be available on the LANforge manager. lf_interop_ping_plotter.py 433
Traceback (most recent call last):
File "/home/hari/lanforge-scripts/py-scripts/lf_interop_ping_plotter.py", line 3991, in
main()
File "/home/hari/lanforge-scripts/py-scripts/lf_interop_ping_plotter.py", line 3488, in main
ping.check_tab_exists()
File "/home/hari/lanforge-scripts/py-scripts/lf_interop_ping_plotter.py", line 434, in check_tab_exists
raise RuntimeError("Generic tab is not available on the LANforge manager.")
RuntimeError: Generic tab is not available on the LANforge manager.
Test Completed

Creating Reports....