### PR TITLE
lf_wifi_capacity_test.py: Support CLI Argument Overrides with --load_old_cfg

### DIFF
--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -2,7 +2,7 @@
 """
 NAME:       lf_wifi_capacity_test.py
 
-PURPOSE:    This script runs LANforge GUI-based WiFi Capacity test.
+PURPOSE:    This script runs LANforge GUI-based Wi-Fi Capacity test.
 
 NOTES:      Upon successful termination, the test PDF and HTML reports are saved.
             The report is optionally copied to the current directory on the executing system
@@ -176,7 +176,7 @@ class WiFiCapacityTest(cv_test):
             self.station_profile.admin_up()
             self.wait_for_ip(station_list=sta_names)
             logger.info("Stations created and got the ips...")
-        elif self.create_stations and self.stations_list is not None:
+        elif self.create_stations and self.stations_list:
             sta_names = self.stations_list
             self.station_profile.cleanup(sta_names)
             self.station_profile.use_security(self.security, self.ssid, self.paswd)
@@ -393,7 +393,7 @@ INCLUDE_IN_README:
     parser.add_argument('--logger_no_file',
                         default=None,
                         action="store_true",
-                        help='Show loggingout without the trailing file name and line')
+                        help='Show logging out without the trailing file name and line')
 
     args = parser.parse_args()
 
@@ -410,7 +410,7 @@ INCLUDE_IN_README:
     if args.log_level:
         logger_config.set_level(level=args.log_level)
 
-    # lf_logger_config_json will take presidence to changing debug levels
+    # lf_logger_config_json will take presidency to changing debug levels
     if args.lf_logger_config_json:
         logger_config.lf_logger_config_json = args.lf_logger_config_json
         logger_config.load_lf_logger_config()
@@ -439,12 +439,12 @@ INCLUDE_IN_README:
     else:
         station_list = []
 
-    # add addtional configuration to raw_line
-    if (args.per_station_upload_rate):
+    # add additional configuration to raw_line
+    if args.per_station_upload_rate:
         if "ul_rate_sel: Per-Station Upload Rate:" not in args.raw_line:
             args.raw_line.append("ul_rate_sel: Per-Station Upload Rate")
 
-    if (args.per_station_download_rate):
+    if args.per_station_download_rate:
         if "dl_rate_sel: Per-Station Download Rate:" not in args.raw_line:
             args.raw_line.append("dl_rate_sel: Per-Station Download Rate")
 

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -33,11 +33,10 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --batch_size    2
 
             # Run test using values and options as defined in pre-existing config
-            # Can use additional options like '--duration', '--batch_size', etc.
-            # to override those in config
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
-                    --config_name   existing_wct_config
+                    --config_name   existing_wct_config \
+                    --load_old_cfg
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -325,11 +324,10 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --batch_size    2
 
             # Run test using values and options as defined in pre-existing config
-            # Can use additional options like '--duration', '--batch_size', etc.
-            # to override those in config
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
-                    --config_name   existing_wct_config
+                    --config_name   existing_wct_config \
+                    --load_old_cfg
 
 SCRIPT_CLASSIFICATION:
             Test

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -33,10 +33,13 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --batch_size    2
 
             # Run test using values and options as defined in pre-existing config
+            # Additional options like '--duration', '--batch_size', etc. can be used
+            # to override values in the saved config
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
                     --config_name   existing_wct_config \
-                    --load_old_cfg
+                    --load_old_cfg  \
+                    --batch_size    1,4,8
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -93,8 +96,8 @@ class WiFiCapacityTest(cv_test):
                  duration="5000",
                  pull_report=False,
                  load_old_cfg=False,
-                 upload_rate="10Mbps",
-                 download_rate="1Gbps",
+                 upload_rate="",
+                 download_rate="",
                  sort="interleave",
                  stations="",
                  create_stations=False,
@@ -195,53 +198,59 @@ class WiFiCapacityTest(cv_test):
         if not self.load_old_cfg:
             self.rm_text_blob(self.config_name, blob_test)  # To delete old config with same name
             self.show_text_blob(None, None, False)
-            # Test related settings
-            cfg_options = []
-            if self.upstream != "":
-                eid = LFUtils.name_to_eid(self.upstream)
-                port = "%i.%i.%s" % (eid[0], eid[1], eid[2])
-                port_list = [port]
-                if self.stations or self.stations_list:
-                    stas = None
-                    if self.stations:
-                        stas = self.stations.split(",")
-                    elif self.stations_list:
-                        stas = self.stations_list
-                    for s in stas:
-                        port_list.append(s)
-                else:
-                    stas = self.station_map()
-                    for eid in stas.keys():
-                        port_list.append(eid)
-                logger.info(f"Selected Port list: {port_list}")
+            if self.download_rate == "":
+                self.download_rate = "1Gbps"
+            if self.upload_rate == "":
+                self.upload_rate = "10Mbps"
 
-                idx = 0
-                for eid in port_list:
-                    add_port = "sel_port-" + str(idx) + ": " + eid
-                    self.create_test_config(self.config_name, blob_test, add_port)
-                    idx += 1
-            if self.batch_size != "":
-                cfg_options.append("batch_size: " + self.batch_size)
-            if self.loop_iter != "":
-                cfg_options.append("loop_iter: " + self.loop_iter)
-            if self.protocol != "":
-                cfg_options.append("protocol: " + str(self.protocol))
-            if self.duration != "":
-                cfg_options.append("duration: " + self.duration)
-            if self.upload_rate != "":
-                cfg_options.append("ul_rate: " + self.upload_rate)
-            if self.download_rate != "":
-                cfg_options.append("dl_rate: " + self.download_rate)
-            if self.test_rig != "":
-                cfg_options.append("test_rig: " + self.test_rig)
-            if self.test_tag != "":
-                cfg_options.append("test_tag: " + self.test_tag)
+        # Test related settings
+        cfg_options = []
+        if self.upstream != "":
+            eid = LFUtils.name_to_eid(self.upstream)
+            port = "%i.%i.%s" % (eid[0], eid[1], eid[2])
+            port_list = [port]
+            if self.stations or self.stations_list:
+                stas = None
+                if self.stations:
+                    stas = self.stations.split(",")
+                elif self.stations_list:
+                    stas = self.stations_list
+                for s in stas:
+                    port_list.append(s)
+            else:
+                stas = self.station_map()
+                for eid in stas.keys():
+                    port_list.append(eid)
+            logger.info(f"Selected Port list: {port_list}")
 
+            idx = 0
+            for eid in port_list:
+                add_port = "sel_port-" + str(idx) + ": " + eid
+                self.create_test_config(self.config_name, blob_test, add_port)
+                idx += 1
+        if self.batch_size != "":
+            cfg_options.append("batch_size: " + self.batch_size)
+        if self.loop_iter != "":
+            cfg_options.append("loop_iter: " + self.loop_iter)
+        if self.protocol != "":
+            cfg_options.append("protocol: " + str(self.protocol))
+        if self.duration != "":
+            cfg_options.append("duration: " + self.duration)
+        if self.upload_rate != "":
+            cfg_options.append("ul_rate: " + self.upload_rate)
+        if self.download_rate != "":
+            cfg_options.append("dl_rate: " + self.download_rate)
+        if self.test_rig != "":
+            cfg_options.append("test_rig: " + self.test_rig)
+        if self.test_tag != "":
+            cfg_options.append("test_tag: " + self.test_tag)
+
+        if not self.load_old_cfg:
             cfg_options.append("save_csv: 1")
 
-            self.apply_cfg_options(cfg_options, self.enables, self.disables, self.raw_lines, self.raw_lines_file)
+        self.apply_cfg_options(cfg_options, self.enables, self.disables, self.raw_lines, self.raw_lines_file)
 
-            # Deleted the scenario earlier, now re-build new one line at a time.
+        if cfg_options:
             self.build_cfg(self.config_name, blob_test, cfg_options)
 
         cv_cmds = []
@@ -324,10 +333,13 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --batch_size    2
 
             # Run test using values and options as defined in pre-existing config
+            # Additional options like '--duration', '--batch_size', etc. can be used
+            # to override values in the saved config
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
                     --config_name   existing_wct_config \
-                    --load_old_cfg
+                    --load_old_cfg  \
+                    --batch_size    1,4,8
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -357,9 +369,9 @@ INCLUDE_IN_README:
     parser.add_argument("-d", "--duration", type=str, default="",
                         help="duration in ms. ex. 5000")
     parser.add_argument("--verbosity", default="5", help="Specify verbosity of the report values 1 - 11 default 5")
-    parser.add_argument("--download_rate", type=str, default="1Gbps",
+    parser.add_argument("--download_rate", type=str, default="",
                         help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
-    parser.add_argument("--upload_rate", type=str, default="10Mbps",
+    parser.add_argument("--upload_rate", type=str, default="",
                         help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
     parser.add_argument("--sort", type=str, default="interleave",
                         help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.")


### PR DESCRIPTION
### Description:
- This change helps to overrides the arguments for existing wifi test config when using `--load_old_cfg`.

Verified CLIs:
- With override:
```
python3 ./lf_wifi_capacity_test.py --mgr 192.168.244.45 --load_old_cfg --config_name Test --pull_report --duration 60000
```
- Without override:
```
python3 ./lf_wifi_capacity_test.py --mgr 192.168.244.45 --load_old_cfg --config_name Test --pull_report
```
