### PR TITLE
lfcli_base.py: add a shared change_port_to_ip() to LFCliBase

### DIFF
--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -345,36 +345,47 @@ class LFCliBase:
 
         return json_response
 
-    def change_port_to_ip(self, upstream_port):
-        """Resolve a LANforge port name such as "eth1" or "1.1.eth1" to its IP.
+    def resolve_port_to_ip(self, port):
+        """Resolve a LANforge port to its IP address.
 
-        The port is returned unchanged when it already looks like an IP address.
-        A port that cannot be resolved, or that is down and so reports 0.0.0.0,
-        aborts the script: the tests cannot run without a usable upstream IP.
+        Accepts any of:
+          - a bare port name, e.g. "eth1"      (shelf and resource default to 1.1)
+          - a full port EID, e.g. "1.1.eth1"
+          - an IP address already, e.g. "192.168.1.101"
+
+        Returns the port's IP address as a string. An input that is already an IP
+        is returned unchanged, without querying LANforge.
+
+        Does not return when the port cannot be resolved, or resolves to 0.0.0.0
+        because the port is down or has no IP: it logs the reason and exits, since
+        the tests cannot run without a usable IP.
         """
-        if upstream_port.count('.') == 3:
-            logger.info("Upstream port IP %s", upstream_port)
-            return upstream_port
+        # when the port is already an IP address, return it unchanged
+        if port.count('.') == 3:
+            logger.info("Port IP %s", port)
+            if port == '0.0.0.0':
+                logger.warning("Port IP is 0.0.0.0 is not a valid IP")
+            return port
 
-        shelf, resource, port, _ = LFUtils.name_to_eid(upstream_port)
-        response = self.json_get('/port/{}/{}/{}?fields=ip'.format(shelf, resource, port))
+        shelf, resource, port_name, _ = LFUtils.name_to_eid(port)
+        response = self.json_get('/port/{}/{}/{}?fields=ip'.format(shelf, resource, port_name))
 
         try:
-            resolved = response['interface']['ip']
+            resolved_ip = response['interface']['ip']
         except (TypeError, KeyError) as e:
             logger.error(
-                "change_port_to_ip: /port/%s/%s/%s response is not in the expected "
-                "format (%s). Data received: %s", shelf, resource, port, e, response)
+                "resolve_port_to_ip: /port/%s/%s/%s response is not in the expected "
+                "format (%s). Data received: %s", shelf, resource, port_name, e, response)
             exit(1)
 
-        if not resolved or resolved == "0.0.0.0":
+        if not resolved_ip or resolved_ip == "0.0.0.0":
             logger.error(
-                "change_port_to_ip: port '%s' resolved to %s; the port is down or has "
-                "no IP assigned.", upstream_port, resolved)
+                "resolve_port_to_ip: port '%s' resolved to %s; the port is down or has "
+                "no IP assigned.", port, resolved_ip)
             exit(1)
 
-        logger.info("Upstream port IP %s", resolved)
-        return resolved
+        logger.info("Port IP %s", resolved_ip)
+        return resolved_ip
 
     def json_delete(self, _req_url, debug_=False):
         debug_ |= self.debug

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -345,6 +345,42 @@ class LFCliBase:
 
         return json_response
 
+    def change_port_to_ip(self, upstream_port, required=True):
+        """Resolve a LANforge port name such as "eth1" or "1.1.eth1" to its IP.
+
+        The port is returned unchanged when it already looks like an IP address.
+        A port that cannot be resolved, or that is down and so reports 0.0.0.0,
+        aborts the script unless `required` is False, in which case the original
+        port name is returned so the caller can carry on.
+        """
+        if upstream_port.count('.') == 3:
+            logger.info("Upstream port IP %s", upstream_port)
+            return upstream_port
+
+        shelf, resource, port, _ = LFUtils.name_to_eid(upstream_port)
+        response = self.json_get('/port/{}/{}/{}?fields=ip'.format(shelf, resource, port))
+
+        try:
+            resolved = response['interface']['ip']
+        except (TypeError, KeyError) as e:
+            logger.error(
+                "change_port_to_ip: /port/%s/%s/%s response is not in the expected "
+                "format (%s). Data received: %s", shelf, resource, port, e, response)
+            if required:
+                exit(1)
+            return upstream_port
+
+        if not resolved or resolved == "0.0.0.0":
+            logger.error(
+                "change_port_to_ip: port '%s' resolved to %s; the port is down or has "
+                "no IP assigned.", upstream_port, resolved)
+            if required:
+                exit(1)
+            return upstream_port
+
+        logger.info("Upstream port IP %s", resolved)
+        return resolved
+
     def json_delete(self, _req_url, debug_=False):
         debug_ |= self.debug
         if debug_:

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -345,13 +345,12 @@ class LFCliBase:
 
         return json_response
 
-    def change_port_to_ip(self, upstream_port, required=True):
+    def change_port_to_ip(self, upstream_port):
         """Resolve a LANforge port name such as "eth1" or "1.1.eth1" to its IP.
 
         The port is returned unchanged when it already looks like an IP address.
         A port that cannot be resolved, or that is down and so reports 0.0.0.0,
-        aborts the script unless `required` is False, in which case the original
-        port name is returned so the caller can carry on.
+        aborts the script: the tests cannot run without a usable upstream IP.
         """
         if upstream_port.count('.') == 3:
             logger.info("Upstream port IP %s", upstream_port)
@@ -366,17 +365,13 @@ class LFCliBase:
             logger.error(
                 "change_port_to_ip: /port/%s/%s/%s response is not in the expected "
                 "format (%s). Data received: %s", shelf, resource, port, e, response)
-            if required:
-                exit(1)
-            return upstream_port
+            exit(1)
 
         if not resolved or resolved == "0.0.0.0":
             logger.error(
                 "change_port_to_ip: port '%s' resolved to %s; the port is down or has "
                 "no IP assigned.", upstream_port, resolved)
-            if required:
-                exit(1)
-            return upstream_port
+            exit(1)
 
         logger.info("Upstream port IP %s", resolved)
         return resolved


### PR DESCRIPTION
## Summary

`change_port_to_ip()` is copy-pasted into 14 scripts, and the copies have drifted
into three different behaviours: abort via exit(1), log a warning and continue, or
log and continue with only KeyError caught. Every copy also shares the same defect.

This adds a single implementation to `LFCliBase`, so all 14 consumers can inherit it — including `lf_ftp.py`,
which extends `LFCliBase` directly rather than `Realm`.

## The defect every copy shares

A port that is administratively down still returns a well-formed response:

    GET /port/1/1/eth3?fields=ip  ->  {"interface": {"ip": "0.0.0.0"}}

Both keys are present, so no copy raises, and each returns `"0.0.0.0"` as a valid
manager IP. The test then proceeds with an unusable upstream and fails later in a
confusing place instead of at the point of the mistake. The shared version rejects
an empty or `0.0.0.0` result.

It also catches `TypeError` alongside `KeyError`, so a `None` response would raise an uncaught `TypeError`.

## Behaviour

`required=True` (default) aborts on an unresolvable or down port, matching the
strictest existing copies. `required=False` returns the port name unchanged so
the callers that currently warn and continue keep their behaviour when migrated.

## Testing

Verified against a live LANforge:

| input | port state | `required=False` | `required=True` |
|---|---|---|---|
| `eth2` | up, has IP | returns `172.16.0.1` | returns `172.16.0.1` (same) |
| `1.1.eth2` | same port, eid form | returns `172.16.0.1` | returns `172.16.0.1` (same) |
| `eth3` | **down, 0.0.0.0** | returns `'eth3'` | **aborts, exit 1** |
| `eth99` | absent | returns `'eth99'` | **aborts, exit 1** |
| `192.168.245.233` | already an IP | returns as-is | returns as-is (same) |

Verified CLI:

python3 lf_interop_zoom.py --duration 1 \
    --lanforge_ip 192.168.245.117 \
    --signin_email <zoom_email> --signin_passwd <zoom_passwd> \
    --participants 3 --audio --video \
    --upstream_port <upstream_ip>/<upstream_port> \
    --zoom_host 1.13 \
    --resources 1.13,1.12,1.25 \
    --api_stats_collection --env_file .env