### PR TITLE
lfcli_base.py: add shared resolve_port_to_ipv4() to LFCliBase

### DIFF
--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -373,6 +373,47 @@ class LFCliBase:
         # print("----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- ")
         return json_response
 
+    def resolve_port_to_ipv4(self, port):
+        """Resolve a LANforge port name or EID to its IPv4 address.
+
+        Returns the address as a string, or None when it cannot be resolved.
+        """
+        if not port:
+            logger.error("resolve_port_to_ipv4: please provide a valid port name")
+            return None
+
+        if not isinstance(port, str):
+            logger.error("resolve_port_to_ipv4: port must be a string, got %s",
+                         type(port).__name__)
+            return None
+
+        # when the port is already an IP address, return it unchanged
+        if port.count('.') == 3:
+            logger.info("Port IP %s", port)
+            if port == '0.0.0.0':
+                logger.warning("Port IP is 0.0.0.0 is not a valid IP")
+            return port
+
+        shelf, resource, port_name, _ = LFUtils.name_to_eid(port)
+        response = self.json_get('/port/{}/{}/{}?fields=ip'.format(shelf, resource, port_name))
+
+        try:
+            resolved_ip = response['interface']['ip']
+        except (TypeError, KeyError) as e:
+            logger.error(
+                "resolve_port_to_ipv4: /port/%s/%s/%s response is not in the expected "
+                "format (%s). Data received: %s", shelf, resource, port_name, e, response)
+            return None
+
+        if not resolved_ip or resolved_ip == "0.0.0.0":
+            logger.error(
+                "resolve_port_to_ipv4: port '%s' resolved to %s; the port is down or has "
+                "no IP assigned.", port, resolved_ip)
+            return None
+
+        logger.info("Port IP %s", resolved_ip)
+        return resolved_ip
+
     @staticmethod
     def response_list_to_map(json_list, key, debug_=False):
         reverse_map = {}

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -379,7 +379,7 @@ class LFCliBase:
         Returns the address as a string, or None when it cannot be resolved.
         """
         if not port:
-            logger.error("resolve_port_to_ipv4: please provide a valid port name")
+            logger.error("resolve_port_to_ipv4: provided invalid port name, port: %s", port)
             return None
 
         if not isinstance(port, str):


### PR DESCRIPTION
## Summary

Adds `resolve_port_to_ipv4()` to `LFCliBase`, a shared helper that resolves a
LANforge port to its IPv4 address.

The same port-to-IP logic is currently reimplemented in roughly 15 scripts
(`lf_ftp.py`, `lf_webpage.py`, `DeviceConfig.py`, `test_l3.py`, `lf_multi_traffic.py`,
`lf_interop_*.py`, and several under `real_application_tests/`), each with slightly
different behaviour and error handling. This puts a single implementation on the
base class so those copies can be retired incrementally.

## Behaviour

The method accepts:

- a bare port name — `eth1` (shelf and resource default to `1.1`)
- a full port EID — `1.1.eth1.`
- an address that is already an IP — returned unchanged, with no query issued

It returns the resolved IPv4 address as a string, or `None` when the port cannot
be resolved — the port does not exist, is down, has no address assigned, or the
manager response is not in the expected shape. Every failure path logs the reason
before returning.

Error handling stays with the caller: the helper reports what went wrong and hands
control back, so the calling script decides whether to continue, clean up, record a
failure in its report, or stop. That keeps the decision — and the user-facing
messaging — in the script that owns the test.

Input that is empty or not a string is rejected up front and logged, so a bad
argument surfaces as a clear message rather than an attribute error deeper in.


## Verification

Exercised against LANforge manager `192.168.245.117` 

| Input | Result |
| --- | --- |
| `eth1`, `eth0`, `eth2` | resolved to the port's address |
| `1.1.eth1` | resolved to the port's address |
| `192.168.245.233`, `8.8.8.8` | returned unchanged, no query issued |
| `0.0.0.0` | returned unchanged, warning logged |
| `eth3` (admin down) | `None`, reason logged |
| `eth99` (does not exist) | `None`, reason logged |
| `''`, `None`, `0`, `[]`, `{}` | `None`, reason logged |
| `123`, `1.5`, `['eth1']`, `b'eth1'` | `None`, reason logged |



Verified CLI:

python3 lf_interop_zoom.py --duration 1
--lanforge_ip 192.168.245.117
--signin_email <zoom_email> --signin_passwd <zoom_passwd> --participants 3 --audio --video
--upstream_port <upstream_ip>/<upstream_port>
--zoom_host 1.13
--resources 1.13,1.12,1.25
--api_stats_collection --env_file .env