### PR TITLE
Enhance parameter handling and documentation in CLI scripts

### DIFF
--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -708,12 +708,13 @@ class LFCliBase:
             parser = argparse.ArgumentParser()
         optional = parser.add_argument_group('arguments with PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in /lanforge-scripts/py-json/LANforge/lfcli_base.py')
         required = parser.add_argument_group('arguments with NO PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in  /lanforge-scripts/py-json/LANforge/lfcli_base.py')
-        optional.add_argument('--mgr',
+        optional.add_argument('--mgr', "--m", "--lfmgr", "--lanforge_ip", dest="mgr",
                               default='localhost',
-                              help='hostname for where LANforge GUI is running')
-        optional.add_argument('--mgr_port',
+                              help='Hostname or IP address of the LANforge GUI machine (localhost is default, use when running script on lanforge)')
+        optional.add_argument('--mgr_port', '--port', '--o', '--lanforge_port',
+                              dest='port',
                               default=8080,
-                              help='port LANforge GUI HTTP service is running on')
+                              help='IP Port the LANforge GUI is listening on (8080 is default)')
         optional.add_argument('--debug',
                               '-d',
                               default=False,
@@ -757,25 +758,34 @@ class LFCliBase:
         # Optional Args
         optional.add_argument('--mgr',
                               '--lfmgr',
+                              '--lanforge_ip',
+                              dest='mgr',
                               default='localhost',
                               help='Hostname or IP address of the LANforge GUI machine (localhost is default)')
         optional.add_argument('--mgr_port',
                               '--port',
+                              '--lanforge_port',
+                              dest='port',
                               default=8080,
                               help='IP Port the LANforge GUI is listening on (8080 is default)')
         optional.add_argument('-u',
                               '--upstream_port',
+                              '--upstream',
+                              dest='upstream',
                               default='1.eth1',
-                              help='non-station port that generates traffic: <resource>.<port>, e.g: 1.eth1')
+                              help="""Upstream port used in test. Example: '1.1.eth2. This is the port of the A.P.
+                            that is connected to the LANforge system.  Default is eth1. All data being transmitted
+                            is done via this port.  This port is used to send and receive data
+                            to/from the A.P. that is being tested.
+                            Format: <shelf>.<resource>.<port>""")
         optional.add_argument('--num_stations',
                               type=int,
                               default=0,
-                              help='Number of stations to create')
+                              help='Number of stations to create. Default: 0. Dependency: used together with --radio, --ssid, --security and --paswd when creating stations')
         optional.add_argument('--test_id',
                               default="webconsole",
                               help='Test ID (intended to use for ws events)')
-        optional.add_argument('-d',
-                              '--debug',
+        optional.add_argument('--debug',
                               action="store_true",
                               help='Enable debugging')
         optional.add_argument('--log_level',
@@ -808,6 +818,19 @@ class LFCliBase:
                               default=None,
                               action="store_true",
                               help='Show summary of what this script does')
+        optional.add_argument('--radio',
+                              default='wiphy0',
+                              help='create stations in lanforge at this radio (by default: wiphy0)')
+        optional.add_argument('--security',
+                              default="open",
+                              help='WiFi Security protocol: < open | wep | wpa | wpa2 | wpa3 >')
+        optional.add_argument('--paswd',
+                              '--passwd',
+                              '--password',
+                              '--key',
+                              dest='paswd',
+                              default="[BLANK]",
+                              help='WiFi passphrase/password/key for created stations. Default: [BLANK]. Dependency: REQUIRED when --security is not "open"')
         if more_optional is not None:
             for argument in more_optional:
                 if 'default' in argument.keys():
@@ -816,19 +839,9 @@ class LFCliBase:
                     optional.add_argument(argument['name'], help=argument['help'])
 
         # Required Args
-        required.add_argument('--radio',
-                              help='radio EID, e.g: 1.wiphy2')
         # Silently support capitalized security types
-        required.add_argument('--security',
-                              default="open",
-                              help='WiFi Security protocol: < open | wep | wpa | wpa2 | wpa3 >')
         required.add_argument('--ssid',
-                              help='WiFi SSID for script objects to associate to')
-        required.add_argument('--passwd',
-                              '--password',
-                              '--key',
-                              default="[BLANK]",
-                              help='WiFi passphrase/password/key')
+                              help='REQUIRED. WiFi SSID for created stations to associate to')
         # please override this password argument using set_defaults(passwd='NA')
 
         if more_required is not None:

--- a/py-scripts/create_station.py
+++ b/py-scripts/create_station.py
@@ -111,7 +111,7 @@ EXAMPLE:    # Create a single station
                 --passwd    <password> \
                 --security  wpa2 \
                 --num_stations 10 \
-                --initial_band_pref 5G
+                --initial_band_pref 5GHz
 
             # Create multiple stations
             ./create_station.py \
@@ -336,7 +336,7 @@ class CreateStation(Realm):
 
     def __init__(self,
                  mgr,
-                 mgr_port,
+                 port,
                  proxy,
                  debug,
                  up,
@@ -366,9 +366,9 @@ class CreateStation(Realm):
                  initial_band_pref,
                  **kwargs):
         super().__init__(mgr,
-                         mgr_port)
+                         port)
         self.host = mgr
-        self.port = mgr_port
+        self.port = port
         self.debug = debug
         self.up = up
         self.ssid = ssid
@@ -855,7 +855,8 @@ INCLUDE_IN_README:
 """)
     parser.add_argument('--start_id',
                         type=int,
-                        help='Specify the station starting id \n e.g: --start_id <value> default 0',
+                        help='Specify the station starting id \n e.g: --start_id <value> default 0.\n'
+                        'All stations being created from --create_stations are named from this id, eg. sta<start_id>, sta<start_id + 1> ...',
                         default=0)
     parser.add_argument("--prefix",
                         type=str,
@@ -886,7 +887,6 @@ INCLUDE_IN_README:
                         default="xx:xx:xx:*:*:xx")
     parser.add_argument("--radio_antenna",
                         help='Number of spatial streams: \n'
-                        ' default = -1 \n'
                         ' 0 Diversity (All) \n'
                         ' 1 Fixed-A (1x1) \n'
                         ' 4 AB (2x2) \n'
@@ -906,10 +906,11 @@ INCLUDE_IN_README:
                         default='AUTO')
     parser.add_argument("--country_code",
                         help='Radio Country Code:\n'
-                             'e.g: \t--country_code 840')
+                             'e.g: \t--country_code 840\n'
+                             'Could either mention the code, or the country itself')
     parser.add_argument("--eap_method",
                         type=str,
-                        help='Enter EAP method e.g: TLS')
+                        help='Enter EAP method e.g: TLS. If specified, also mention --eap_identitiy, --key_mgmt')
     parser.add_argument("--eap_identity",
                         "--radius_identity",
                         dest="eap_identity",
@@ -917,13 +918,14 @@ INCLUDE_IN_README:
                         help="This is synonymous with the RADIUS username.")
     parser.add_argument("--eap_anonymous_identity",
                         type=str,
-                        help="",
+                        help="Anonymous identity used in outer EAP authentication (EAP-TTLS/PEAP). Default: [BLANK]. "
+                             "Dependency: used only when --eap_method is TTLS or PEAP",
                         default="[BLANK]")  # TODO: Fix root cause of 'null' when not set issue (REST server-side issue)
     parser.add_argument("--eap_password",
                         "--radius_passwd",
                         dest="eap_password",
                         type=str,
-                        help="This is synonymous with the RADIUS user's password.")
+                        help="This is synonymous with the RADIUS user's password. Need to be specified when --eap_method is not TLS.",)
     parser.add_argument("--eap_phase1",
                         type=str,
                         help="EAP Phase 1 (outer authentication, i.e. TLS tunnel) parameters.\n"
@@ -937,13 +939,13 @@ INCLUDE_IN_README:
                         default="[BLANK]")  # TODO: Fix root cause of 'null' when not set issue (REST server-side issue)
     parser.add_argument("--pk_passwd",
                         type=str,
-                        help='Enter the private key password')
+                        help='Enter the private key password. Need to be mentioned when --eap_method is TLS')
     parser.add_argument("--ca_cert",
                         type=str,
-                        help='Enter path for certificate e.g: /home/lanforge/ca.pem')
+                        help='Enter path for certificate e.g: /home/lanforge/ca.pem. Need to be mentioned when --eap_method is TLS')
     parser.add_argument("--private_key",
                         type=str,
-                        help='Enter private key path e.g: /home/lanforge/client.p12')
+                        help='Enter private key path e.g: /home/lanforge/client.p12. Need to be mentioned when --eap_method is TLS')
     parser.add_argument("--key_mgmt",
                         type=str,
                         help="Authentication key management. Combinations are supported.\n")
@@ -957,7 +959,8 @@ INCLUDE_IN_README:
                              'CCMP-256\n'
                              'GCMP\n'
                              'GCMP-256\n'
-                             'CCMP/GCMP-256',
+                             'CCMP/GCMP-256\n'
+                             'Need to be specified when security is WPA3',
                              default='[BLANK]')
     parser.add_argument("--groupwise_cipher",
                         help='Groupwise Ciphers\n'
@@ -970,7 +973,8 @@ INCLUDE_IN_README:
                              'GCMP-256\n'
                              'CCMP-256\n'
                              'GCMP/CCMP-256\n'
-                             'ALL',
+                             'ALL\n'
+                             'Need to be specified when security is WPA3',
                         default='[BLANK]')
     parser.add_argument("--no_pre_cleanup",
                         help='Add this flag to stop cleaning up before station creation',
@@ -1076,7 +1080,7 @@ def main():
     create_station = CreateStation(**vars(args),
                                    sta_list=station_list,
                                    up=(not args.create_admin_down),
-                                   password=args.passwd,
+                                   password=args.paswd,
                                    set_txo_data=None)
 
     if not args.no_pre_cleanup:


### PR DESCRIPTION
lfclibase.py:

- Added aliases for params to be in line with lf_wifi_capacity_test.py and lf_dataplane_test.py
- Update help for params to be more descriptive
- Moved `radio`, `security` and `password` params to optional params from required params as description of these param groups said that optional are those with default values and required are those with no default values

create_station.py:

- Added aliases for params
- Update help to mention dependency between params, (obtaned from `validate_args()`)
- Updated var names for params with dest to have same nomenclature as in other scripts