### PR TITLE
Ping logging

### DIFF
--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -1520,36 +1520,31 @@ effectively over the network and pinpoint potential issues affecting connectivit
 
     # check if generic tab is enabled or not
     if (not ping.check_tab_exists()):
-        logging.error('Generic Tab is not available.\nAborting the test.')
-        exit(0)
+        raise RuntimeError('Generic Tab is not available.\nAborting the test.')
 
     ping.sta_list += ping.real_sta_list
 
     # creating generic endpoints
     ping.create_generic_endp()
 
-    logging.info(ping.generic_endps_profile.created_cx)
-
     # run the test for the given duration
     logging.info('Running the ping test for {} minutes'.format(duration))
 
     # start generate endpoint
     ping.start_generic()
-    # time_counter = 0
-    ports_data_dict = ping.json_get('/ports/all/')['interfaces']
-    ports_data = {}
-    for ports in ports_data_dict:
-        port, port_data = list(ports.keys())[0], list(ports.values())[0]
-        ports_data[port] = port_data
-
-    time.sleep(duration * 60)
-
+    start_time = time.time()
+    end_time = start_time + (duration * 60)
+    while time.time() < end_time:
+        success = ping.monitor_endp_availability(ping.generic_endps_profile.created_endp)
+        if not success:
+            logger.error('All endpoints are not available. So exiting the monitor early.')
+            break
+        time.sleep(3)
     logging.info('Stopping the test')
     ping.stop_generic()
 
     result_data = ping.get_results()
-    # logging.info(result_data)
-    logging.info(ping.result_json)
+    logger.info("Endpoint results after stopping the test: {}".format(result_data))
     if (args.virtual):
         ports_url = '/ports/all/'
         response = ping.json_get(ports_url)
@@ -1564,111 +1559,91 @@ effectively over the network and pinpoint potential issues affecting connectivit
         for ports in ports_data_dict:
             port, port_data = list(ports.keys())[0], list(ports.values())[0]
             ports_data[port] = port_data
-        if (isinstance(result_data, dict)):
-            for station in ping.sta_list:
-                if (station not in ping.real_sta_list):
-                    current_device_data = ports_data[station]
-                    if (station.split('.')[2] in result_data['name']):
-                        # t_rtt = 0
-                        # min_rtt = 10000
-                        # max_rtt = 0
-                        # for result in result_data['last results'].split('\n'):
-                        #     # logging.info(result)
-                        #     if (result == ''):
-                        #         continue
-                        #     rt_time = result.split()[6]
-                        #     logging.info(rt_time.split('time='))
-                        #     time_value = float(rt_time.split('time=')[1])
-                        #     t_rtt += time_value
-                        #     if (time_value < min_rtt):
-                        #         min_rtt = time_value
-                        #     if (max_rtt < time_value):
-                        #         max_rtt = time_value
-                        # avg_rtt = t_rtt / float(result_data['rx pkts'])
-                        # logging.info(t_rtt, min_rtt, max_rtt, avg_rtt)
+        for station in ping.sta_list:
+            if (station not in ping.real_sta_list):
+                current_device_data = ports_data[station]
+                for ping_device in result_data:
+                    ping_endp, ping_data = list(ping_device.keys())[
+                        0], list(ping_device.values())[0]
+                    if (station.split('.')[2] in ping_endp):
+                        last_result_lines = []
                         try:
+                            last_result_lines = ping_data['last results'].split('\n') if ping_data['last results'] else []
+                            if len(last_result_lines) > 1:
+                                last_result = last_result_lines[-2]
+                            elif last_result_lines:
+                                last_result = last_result_lines[-1]
+                            else:
+                                last_result = ""
+
+                            if 'min/avg/max' in last_result:
+                                rtt_values = last_result.split('min/avg/max:', 1)[1].strip().split()[0].split('/')
+                                min_rtt = rtt_values[0]
+                                avg_rtt = rtt_values[1]
+                                max_rtt = rtt_values[2]
+                            else:
+                                min_rtt = '0'
+                                avg_rtt = '0'
+                                max_rtt = '0'
+
                             ping.result_json[station] = {
-                                'command': result_data['command'],
-                                'sent': result_data['tx pkts'],
-                                'recv': result_data['rx pkts'],
-                                'dropped': result_data['dropped'],
-                                'min_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split('/')[0] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                'avg_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split('/')[1] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                'max_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split('/')[2] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
+                                'command': ping_data['command'],
+                                'sent': ping_data['tx pkts'],
+                                'recv': ping_data['rx pkts'],
+                                'dropped': ping_data['dropped'],
+                                'min_rtt': min_rtt,
+                                'avg_rtt': avg_rtt,
+                                'max_rtt': max_rtt,
                                 'mac': current_device_data['mac'],
-                                'channel': current_device_data['channel'],
                                 'ssid': current_device_data['ssid'],
+                                'channel': current_device_data['channel'],
                                 'mode': current_device_data['mode'],
                                 'name': station,
                                 'os': 'Virtual',
                                 'remarks': [],
-                                'last_result': [result_data['last results'].split('\n')[-2] if len(result_data['last results']) != 0 else ""][0]
+                                'last_result': last_result
                             }
                             ping.result_json[station]['remarks'] = ping.generate_remarks(ping.result_json[station])
-                        except Exception:
-                            logging.error('Failed parsing the result for the station {}'.format(station))
-
-        else:
-            for station in ping.sta_list:
-                if (station not in ping.real_sta_list):
-                    current_device_data = ports_data[station]
-                    for ping_device in result_data:
-                        ping_endp, ping_data = list(ping_device.keys())[
-                            0], list(ping_device.values())[0]
-                        if (station.split('.')[2] in ping_endp):
-                            # t_rtt = 0
-                            # min_rtt = 10000
-                            # max_rtt = 0
-                            # for result in ping_data['last results'].split('\n'):
-                            #     if (result == ''):
-                            #         continue
-                            #     rt_time = result.split()[6]
-                            #     time_value = float(rt_time.split('time=')[1])
-                            #     t_rtt += time_value
-                            #     if (time_value < min_rtt):
-                            #         min_rtt = time_value
-                            #     if (max_rtt < time_value):
-                            #         max_rtt = time_value
-                            # avg_rtt = t_rtt / float(ping_data['rx pkts'])
-                            # logging.info(t_rtt, min_rtt, max_rtt, avg_rtt)
-                            try:
-                                ping.result_json[station] = {
-                                    'command': ping_data['command'],
-                                    'sent': ping_data['tx pkts'],
-                                    'recv': ping_data['rx pkts'],
-                                    'dropped': ping_data['dropped'],
-                                    'min_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split('/')[0] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                    'avg_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split('/')[1] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                    'max_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split('/')[2] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                    'mac': current_device_data['mac'],
-                                    'ssid': current_device_data['ssid'],
-                                    'channel': current_device_data['channel'],
-                                    'mode': current_device_data['mode'],
-                                    'name': station,
-                                    'os': 'Virtual',
-                                    'remarks': [],
-                                    'last_result': [ping_data['last results'].split('\n')[-2] if len(ping_data['last results']) != 0 else ""][0]
-                                }
-                                ping.result_json[station]['remarks'] = ping.generate_remarks(ping.result_json[station])
-                            except Exception:
-                                logging.error('Failed parsing the result for the station {}'.format(station))
+                        except Exception as error:
+                            logger.error(
+                                "Failed parsing the result for station %s. Error: %s\nLast result lines: %s",
+                                station, error, last_result_lines)
 
     if (args.real):
-        if (isinstance(result_data, dict)):
-            for station in ping.real_sta_list:
-                current_device_data = Devices.devices_data[station]
-                # logging.info(current_device_data)
-                if (station in result_data['name']):
+        for station in ping.real_sta_list:
+            current_device_data = Devices.devices_data[station]
+            for ping_device in result_data:
+                ping_endp, ping_data = list(ping_device.keys())[
+                    0], list(ping_device.values())[0]
+                if (station in ping_endp):
+                    last_result_lines = []
                     try:
-                        # logging.info(result_data['last results'].split('\n'))
+                        last_result_lines = ping_data['last results'].split('\n') if ping_data['last results'] else []
+                        if len(last_result_lines) > 1:
+                            last_result = last_result_lines[-2]
+                        elif last_result_lines:
+                            last_result = last_result_lines[-1]
+                        else:
+                            last_result = ""
+
+                        if 'min/avg/max' in last_result:
+                            rtt_values = last_result.split('min/avg/max:', 1)[1].strip().split()[0].split('/')
+                            min_rtt = rtt_values[0]
+                            avg_rtt = rtt_values[1]
+                            max_rtt = rtt_values[2]
+                        else:
+                            min_rtt = '0'
+                            avg_rtt = '0'
+                            max_rtt = '0'
+
                         ping.result_json[station] = {
-                            'command': result_data['command'],
-                            'sent': result_data['tx pkts'],
-                            'recv': result_data['rx pkts'],
-                            'dropped': result_data['dropped'],
-                            'min_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[0] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                            'avg_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[1] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                            'max_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[2] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
+                            'command': ping_data['command'],
+                            'sent': ping_data['tx pkts'],
+                            'recv': ping_data['rx pkts'],
+                            'dropped': ping_data['dropped'],
+                            'min_rtt': min_rtt,
+                            'avg_rtt': avg_rtt,
+                            'max_rtt': max_rtt,
                             'mac': current_device_data['mac'],
                             'ssid': current_device_data['ssid'],
                             'channel': current_device_data['channel'],
@@ -1676,41 +1651,15 @@ effectively over the network and pinpoint potential issues affecting connectivit
                             'name': [current_device_data['user'] if current_device_data['user'] != '' else current_device_data['hostname']][0],
                             'os': ['Windows' if 'Win' in current_device_data['hw version'] else 'Linux' if 'Linux' in current_device_data['hw version'] else 'Mac' if 'Apple' in current_device_data['hw version'] else 'Android'][0],  # noqa E501
                             'remarks': [],
-                            'last_result': [result_data['last results'].split('\n')[-2] if len(result_data['last results']) != 0 else ""][0]
+                            'last_result': last_result
                         }
                         ping.result_json[station]['remarks'] = ping.generate_remarks(ping.result_json[station])
-                    except Exception:
-                        logging.error('Failed parsing the result for the station {}'.format(station))
-        else:
-            for station in ping.real_sta_list:
-                current_device_data = Devices.devices_data[station]
-                for ping_device in result_data:
-                    ping_endp, ping_data = list(ping_device.keys())[
-                        0], list(ping_device.values())[0]
-                    if (station in ping_endp):
-                        try:
-                            ping.result_json[station] = {
-                                'command': ping_data['command'],
-                                'sent': ping_data['tx pkts'],
-                                'recv': ping_data['rx pkts'],
-                                'dropped': ping_data['dropped'],
-                                'min_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[0] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                'avg_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[1] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                'max_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[2] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa E501
-                                'mac': current_device_data['mac'],
-                                'ssid': current_device_data['ssid'],
-                                'channel': current_device_data['channel'],
-                                'mode': current_device_data['mode'],
-                                'name': [current_device_data['user'] if current_device_data['user'] != '' else current_device_data['hostname']][0],
-                                'os': ['Windows' if 'Win' in current_device_data['hw version'] else 'Linux' if 'Linux' in current_device_data['hw version'] else 'Mac' if 'Apple' in current_device_data['hw version'] else 'Android'][0],  # noqa E501
-                                'remarks': [],
-                                'last_result': [ping_data['last results'].split('\n')[-2] if len(ping_data['last results']) != 0 else ""][0]
-                            }
-                            ping.result_json[station]['remarks'] = ping.generate_remarks(ping.result_json[station])
-                        except Exception:
-                            logging.error('Failed parsing the result for the station {}'.format(station))
+                    except Exception as error:
+                        logger.error(
+                            "Failed parsing the result for station %s. Error: %s\nLast result lines: %s",
+                            station, error, last_result_lines)
 
-    logging.info(ping.result_json)
+    logger.info("Final parsed per-station results: {}".format(ping.result_json))
 
     # station post cleanup
     ping.cleanup()

--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -199,6 +199,7 @@ class Ping(Realm):
         self.test_name = test_name
         self.missing_endp_logged = set()
         self.not_running_endp_logged = set()
+        self.client_issue_csv_name = "client_issue.csv"
         self.client_issue_data = []
         self.latest_results = {}
         self.eap_method = eap_method
@@ -416,6 +417,17 @@ class Ping(Realm):
             state,
             response
         ])
+
+    def write_client_issue_csv(self, report_path):
+        """Create the endpoint issue CSV in the report folder."""
+        if not self.client_issue_data:
+            return
+
+        csv_path = os.path.join(report_path, self.client_issue_csv_name)
+        with open(csv_path, "w", newline="") as file:
+            writer = csv.writer(file)
+            writer.writerow(["TIMESTAMP", "ENDP_NAME", "STATE", "API RESPONSE"])
+            writer.writerows(self.client_issue_data)
 
     def check_endpoint_availability(self, expected_endps, present_endps):
         """Log endpoint missing/not-running/recovered transitions and update the tracking sets."""
@@ -692,6 +704,9 @@ class Ping(Realm):
                            _path=report_path)
         report_path = report.get_path()
         report_path_date_time = report.get_path_date_time()
+
+        self.write_client_issue_csv(report_path_date_time)
+
         logging.info('path: {}'.format(report_path))
         logging.info('path_date_time: {}'.format(report_path_date_time))
 

--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -288,19 +288,19 @@ class Ping(Realm):
         if (self.enable_virtual):
             # removing virtual stations if existing
             for station in self.sta_list:
-                logging.info('Removing the station {} if exists'.format(station))
+                logger.info('Removing the station {} if exists'.format(station))
                 self.rm_port(station, check_exists=True)
 
             if (not LFUtils.wait_until_ports_disappear(base_url=self.host, port_list=self.sta_list, debug=self.debug)):
-                logging.info('All stations are not removed or a timeout occured.')
-                logging.error('Aborting the test.')
+                logger.info('All stations are not removed or a timeout occured.')
+                logger.error('Aborting the test.')
                 exit(0)
 
-        logging.info("Cleaning up generic endpoints if exists: cx={}, endp={}".format(self.generic_endps_profile.created_cx, self.generic_endps_profile.created_endp))
+        logger.info("Cleaning up generic endpoints if exists: cx={}, endp={}".format(self.generic_endps_profile.created_cx, self.generic_endps_profile.created_endp))
         self.generic_endps_profile.cleanup()
         self.generic_endps_profile.created_cx = []
         self.generic_endps_profile.created_endp = []
-        logging.info('Cleanup Successful')
+        logger.info('Cleanup Successful')
 
     # Args:
     #   devices: Connected RealDevice object which has already populated tracked real device
@@ -317,7 +317,7 @@ class Ping(Realm):
         if (len(self.real_sta_list) == 0):
             raise RuntimeError('There are no real devices in this testbed. Aborting test')
 
-        logging.info(self.real_sta_list)
+        logger.info(self.real_sta_list)
 
         for sta_name in self.real_sta_list:
             if sta_name not in real_devices.devices_data:
@@ -339,10 +339,10 @@ class Ping(Realm):
         return d_list
 
     def buildstation(self):
-        logging.info('Creating Stations {}'.format(self.sta_list))
+        logger.info('Creating Stations {}'.format(self.sta_list))
         for station_index in range(len(self.sta_list)):
             shelf, resource, port = self.sta_list[station_index].split('.')
-            logging.info('{} {} {}'.format(shelf, resource, port))
+            logger.info('{} {} {}'.format(shelf, resource, port))
             station_object = StationProfile(lfclient_url='http://{}:{}'.format(self.host, self.port), local_realm=self, ssid=self.ssid,
                                             ssid_pass=self.password, security=self.security, number_template_='00', up=True, resource=resource, shelf=shelf)
             station_object.use_security(
@@ -372,7 +372,7 @@ class Ping(Realm):
 
         if (self.enable_virtual):
             if (self.generic_endps_profile.create(ports=virtual_stations, sleep_time=.5)):
-                logging.info('Virtual client generic endpoint creation completed.')
+                logger.info('Virtual client generic endpoint creation completed.')
             else:
                 raise RuntimeError('Virtual client generic endpoint creation failed.')
 
@@ -380,7 +380,7 @@ class Ping(Realm):
             real_sta_os_types = [self.real_sta_data_dict[real_sta_name]['ostype'] for real_sta_name in self.real_sta_data_dict]
 
             if (self.generic_endps_profile.create(ports=self.real_sta_list, sleep_time=.5, real_client_os_types=real_sta_os_types)):
-                logging.info('Real client generic endpoint creation completed.')
+                logger.info('Real client generic endpoint creation completed.')
             else:
                 raise RuntimeError('Real client generic endpoint creation failed.')
 
@@ -608,10 +608,10 @@ class Ping(Realm):
                 target_port_ip = self.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
                 upstream_port = target_port_ip
             except Exception:
-                logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
-            logging.info(f"Upstream port IP {upstream_port}")
+                logger.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
+            logger.info(f"Upstream port IP {upstream_port}")
         else:
-            logging.info(f"Upstream port IP {upstream_port}")
+            logger.info(f"Upstream port IP {upstream_port}")
         return upstream_port
 
     # Calculates pass/fail status for each client based on their result compared to the expected value.
@@ -658,7 +658,7 @@ class Ping(Realm):
                         found = True
                         break
                 if not found:
-                    logging.info(f"Ping result for device {device} not found in CSV. Using default packet loss = 10%")
+                    logger.info(f"Ping result for device {device} not found in CSV. Using default packet loss = 10%")
                     test_input_list.append(10)
             self.percent_pac_loss = []
             for i in range(len(self.packets_sent)):
@@ -730,7 +730,7 @@ class Ping(Realm):
     def generate_report(self, result_json=None, result_dir='Ping_Test_Report', report_path='', config_devices='', group_device_map=None):
         if result_json is not None:
             self.result_json = result_json
-        logging.info('Generating Report')
+        logger.info('Generating Report')
 
         report = lf_report(_output_pdf='interop_ping.pdf',
                            _output_html='interop_ping.html',
@@ -741,8 +741,8 @@ class Ping(Realm):
 
         self.write_client_issue_csv(report_path_date_time)
 
-        logging.info('path: {}'.format(report_path))
-        logging.info('path_date_time: {}'.format(report_path_date_time))
+        logger.info('path: {}'.format(report_path))
+        logger.info('path_date_time: {}'.format(report_path_date_time))
 
         # setting report title
         report.set_title('Ping Test Report')
@@ -803,7 +803,7 @@ class Ping(Realm):
         # packet_count_data = {}
         os_type = []
         for device, device_data in self.result_json.items():
-            logging.info('Device data: {} {}'.format(device, device_data))
+            logger.info('Device data: {} {}'.format(device, device_data))
             os_type.append(device_data['os'])
             self.packets_sent.append(int(device_data['sent']))
             self.packets_received.append(int(device_data['recv']))
@@ -866,7 +866,7 @@ class Ping(Realm):
                                         _color_name=['lightgrey', 'orange', 'steelblue'])
 
         graph_png = graph.build_bar_graph_horizontal()
-        logging.info('graph name {}'.format(graph_png))
+        logger.info('graph name {}'.format(graph_png))
         report.set_graph_image(graph_png)
         # need to move the graph image to the results directory
         report.move_graph_image()
@@ -968,7 +968,7 @@ class Ping(Realm):
                                         _color_name=['lightgrey', 'orange', 'steelblue'])
 
         graph_png = graph.build_bar_graph_horizontal()
-        logging.info('graph name {}'.format(graph_png))
+        logger.info('graph name {}'.format(graph_png))
         report.set_graph_image(graph_png)
         # need to move the graph image to the results directory
         report.move_graph_image()
@@ -1436,12 +1436,12 @@ effectively over the network and pinpoint potential issues affecting connectivit
     # creating virtual stations if --virtual flag is specified
     if (args.virtual):
 
-        logging.info('Proceeding to create {} virtual stations on {}'.format(num_sta, radio))
+        logger.info('Proceeding to create {} virtual stations on {}'.format(num_sta, radio))
         station_list = LFUtils.portNameSeries(
             prefix_='sta', start_id_=0, end_id_=num_sta - 1, padding_number_=100000, radio=radio)
         ping.sta_list = station_list
         if (debug):
-            logging.info('Virtual Stations: {}'.format(station_list).replace(
+            logger.info('Virtual Stations: {}'.format(station_list).replace(
                 '[', '').replace(']', '').replace('\'', ''))
 
     # selecting real clients if --real flag is specified
@@ -1528,7 +1528,7 @@ effectively over the network and pinpoint potential issues affecting connectivit
     ping.create_generic_endp()
 
     # run the test for the given duration
-    logging.info('Running the ping test for {} minutes'.format(duration))
+    logger.info('Running the ping test for {} minutes'.format(duration))
 
     # start generate endpoint
     ping.start_generic()
@@ -1540,7 +1540,7 @@ effectively over the network and pinpoint potential issues affecting connectivit
             logger.error('All endpoints are not available. So exiting the monitor early.')
             break
         time.sleep(3)
-    logging.info('Stopping the test')
+    logger.info('Stopping the test')
     ping.stop_generic()
 
     result_data = ping.get_results()

--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -81,6 +81,8 @@ import argparse
 import time
 import sys
 import os
+import datetime
+import json
 import pandas as pd
 import importlib
 import logging
@@ -155,7 +157,9 @@ class Ping(Realm):
                  wait_time=60,
                  total_floors: int = None,
                  get_live_view: bool = None,
-                 result_dir: str = None):
+                 result_dir: str = None,
+                 dowebgui: bool = False,
+                 test_name: str = None):
         super().__init__(lfclient_host=host,
                          lfclient_port=port)
         self.ssid_list = []
@@ -191,6 +195,12 @@ class Ping(Realm):
         self.total_floors = total_floors
         self.get_live_view = get_live_view
         self.result_dir = result_dir
+        self.dowebgui = dowebgui
+        self.test_name = test_name
+        self.missing_endp_logged = set()
+        self.not_running_endp_logged = set()
+        self.client_issue_data = []
+        self.latest_results = {}
         self.eap_method = eap_method
         self.eap_identity = eap_identity
         self.ieee80211 = ieee80211
@@ -358,20 +368,162 @@ class Ping(Realm):
         self.generic_endps_profile.start_cx()
 
     def stop_generic(self):
+        if self.missing_endp_logged:
+            missing_cx_names = {'CX_{}'.format(endp) for endp in self.missing_endp_logged}
+            self.generic_endps_profile.created_endp = [
+                endp for endp in self.generic_endps_profile.created_endp
+                if endp not in self.missing_endp_logged
+            ]
+            self.generic_endps_profile.created_cx = [
+                cx for cx in self.generic_endps_profile.created_cx
+                if cx not in missing_cx_names
+            ]
         self.generic_endps_profile.stop_cx()
 
     def get_results(self):
-        logging.debug(self.generic_endps_profile.created_endp)
-        results = self.json_get(
-            "/generic/{}".format(','.join(self.generic_endps_profile.created_endp)))
-        if (len(self.generic_endps_profile.created_endp) > 1) and 'endpoints' in results.keys():
-            results = results['endpoints']
+        logger.debug(self.generic_endps_profile.created_endp)
+        endp_url = "/generic/{}".format(','.join(self.generic_endps_profile.created_endp))
+        response = self.json_get(endp_url)
+        if not response:
+            logger.error("Failed to fetch endpoint results.\nRequested URL: '{}'\nResponse: {}".format(endp_url, response))
         else:
-            try:
-                results = results['endpoint']
-            except Exception as e:
-                logger.error(f"Endpoint not found {e}")
-        return (results)
+            endpoint = response.get('endpoints', response.get('endpoint', []))
+            if isinstance(endpoint, dict):
+                endpoint = [{endpoint['name']: endpoint}]
+            present_endps = {}
+            for endp_entry in endpoint:
+                for endp_name, endp_response in endp_entry.items():
+                    # Use the second-last result when more than one is available.
+                    last_results = endp_response.get('last results')
+                    if last_results:
+                        result_lines = last_results.split('\n')
+                        if len(result_lines) > 1:
+                            endp_response['last results'] = result_lines[-2]
+                    present_endps[endp_name] = endp_response
+            self.latest_results.update(present_endps)
+
+        if not self.latest_results:
+            logger.error('No ping results were collected for any endpoint during the entire test.')
+            return []
+
+        return [{name: data} for name, data in self.latest_results.items()]
+
+    def append_endp_data(self, name, state, response):
+        """Save an endpoint state change for the report."""
+        self.client_issue_data.append([
+            datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            name,
+            state,
+            response
+        ])
+
+    def check_endpoint_availability(self, expected_endps, present_endps):
+        """Log endpoint missing/not-running/recovered transitions and update the tracking sets."""
+        endp_url = "/generic/{}".format(','.join(expected_endps))
+        for endp_name in expected_endps:
+            if endp_name not in present_endps.keys():
+                if endp_name not in self.missing_endp_logged:
+                    present_endp_names = list(present_endps)
+                    logger.warning(
+                        "Endpoint '{}' is missing from the monitoring data.\n"
+                        "Requested URL: '{}'\n"
+                        "Response: {}".format(endp_name, endp_url, present_endp_names))
+                    self.append_endp_data(name=endp_name, state="MISSING", response=present_endp_names)
+                    self.missing_endp_logged.add(endp_name)
+                self.not_running_endp_logged.discard(endp_name)
+            elif present_endps[endp_name].get('status').lower() != "run":
+                if endp_name not in self.not_running_endp_logged:
+                    logger.warning(
+                        "Endpoint '{}' is not running in the monitoring data.\n"
+                        "Requested URL: '{}'\n"
+                        "Response: {}".format(endp_name, endp_url, present_endps[endp_name]))
+                    self.append_endp_data(name=endp_name, state=present_endps[endp_name].get('status'), response=present_endps[endp_name])
+                    self.not_running_endp_logged.add(endp_name)
+                self.missing_endp_logged.discard(endp_name)
+            else:
+                if endp_name in self.missing_endp_logged or endp_name in self.not_running_endp_logged:
+                    logger.info(
+                        "Endpoint '{}' is running in the monitoring data\n"
+                        "Requested URL: '{}'\n"
+                        "Response: {}".format(endp_name, endp_url, present_endps[endp_name]))
+                    self.append_endp_data(name=endp_name, state=present_endps[endp_name].get('status'), response=present_endps[endp_name])
+                self.missing_endp_logged.discard(endp_name)
+                self.not_running_endp_logged.discard(endp_name)
+
+    def is_test_stopped_by_webgui(self):
+        """Check the webgui running-instance file to see if the user stopped the test."""
+        if not self.dowebgui:
+            return False
+        running_file = f"{self.result_dir}/../../Running_instances/{self.host}_{self.test_name}_running.json"
+        try:
+            with open(running_file, "r") as file:
+                data = json.load(file)
+            if data.get("status") != "Running":
+                logger.warning("Test is stopped by the user")
+                return True
+        except FileNotFoundError:
+            logger.warning(f"Running instance file not found: {running_file}")
+            return True
+        except json.JSONDecodeError:
+            logger.warning(f"Running instance file corrupted or empty: {running_file}")
+            return True
+        except Exception as e:
+            logger.error(f"Unexpected error reading running.json: {e}")
+            return True
+        return False
+
+    def monitor_endp_availability(self, expected_endps, duration=40, interval=5):
+        """Retry for up to duration seconds until at least one expected endpoint is present and running."""
+        start_time = time.time()
+        end_time = start_time + duration
+        no_of_attempts = duration // interval
+        count = 0
+        while (start_time <= end_time):
+            count += 1
+            if self.is_test_stopped_by_webgui():
+                logger.info("Test stopped by user via WebGUI. Exiting monitoring.")
+                return False
+            if count > 1:
+                logger.info("Attempt {} of {} to check endpoints availability".format(count, no_of_attempts))
+            endp_url = "/generic/{}".format(','.join(expected_endps))
+            response = self.json_get(endp_url)
+            if not response:
+                logger.error(
+                    "Failed to fetch endpoints. Received empty response.\n"
+                    f"Requested URL: '{endp_url}'\n"
+                    f"Response: {response}")
+                response = {}
+            endpoint = response.get('endpoints', response.get('endpoint', []))
+            if isinstance(endpoint, dict):
+                endpoint = [{endpoint['name']: endpoint}]
+            present_endps = {}
+            for endp_entry in endpoint:
+                for endp_name, endp_response in endp_entry.items():
+                    # Use the second-last result when more than one is available.
+                    last_results = endp_response.get('last results')
+                    if last_results:
+                        result_lines = last_results.split('\n')
+                        if len(result_lines) > 1:
+                            endp_response['last results'] = result_lines[-2]
+                    present_endps[endp_name] = endp_response
+            self.latest_results.update(present_endps)
+            self.check_endpoint_availability(expected_endps, present_endps)
+            missed = len(self.missing_endp_logged)
+            not_run = len(self.not_running_endp_logged)
+            if missed == len(expected_endps):
+                logger.error("All expected endpoints ({}) are missing from the monitoring data. Retrying... Before giving up and stopping test".format(
+                    ", ".join(self.missing_endp_logged)))
+            elif not_run == len(expected_endps):
+                logger.error("All expected endpoints ({}) are present but not running. Retrying... Before giving up and stopping test".format(
+                    ", ".join(self.not_running_endp_logged)))
+            elif missed + not_run == len(expected_endps):
+                logger.error("Some expected endpoints ({}) are missing and some endpoints ({}) are not running. Retrying... Before giving up and stopping test".format(
+                    ", ".join(self.missing_endp_logged), ", ".join(self.not_running_endp_logged)))
+            else:
+                return True
+            time.sleep(interval)
+            start_time = time.time()
+        return False
 
     def generate_remarks(self, station_ping_data):
         remarks = []

--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -86,7 +86,6 @@ import json
 import pandas as pd
 import importlib
 import logging
-import traceback
 import asyncio
 import csv
 
@@ -238,17 +237,21 @@ class Ping(Realm):
             # checking if target is eth1 or 1.1.eth1
             target_port_list = self.name_to_eid(self.target)
             shelf, resource, port, _ = target_port_list
-            try:
-                target_port_ip = self.json_get('/port/{}/{}/{}?fields=ip'.format(shelf, resource, port))['interface']['ip']
-            except Exception:
-                tb_str = traceback.format_exc()  # capture traceback as string
-                logger.error("An exception occurred:\n%s", tb_str)
-                logging.error('The target port {} not found on the LANforge. Please change the target.'.format(self.target))
-                exit(0)
-            self.target = target_port_ip
-            print(self.target)
+            port_url = '/port/{}/{}/{}?fields=ip'.format(shelf, resource, port)
+            response = self.json_get(port_url)
+            if not response:
+                logger.error("Failed to fetch port info. Received empty response.\nRequested URL: '{}'\nResponse: {}".format(port_url, response))
+                raise RuntimeError('The target port {} not found on the LANforge. Please change the target.'.format(self.target))
+            if 'interface' not in response:
+                logger.error("'interface' key not found in response.\nRequested URL: '{}'\nResponse: {}".format(port_url, response))
+                raise RuntimeError('The target port {} not found on the LANforge. Please change the target.'.format(self.target))
+            if 'ip' not in response['interface']:
+                logger.error("'ip' key not found in response.\nRequested URL: '{}'\nResponse: {}".format(port_url, response))
+                raise RuntimeError('The target port {} not found on the LANforge. Please change the target.'.format(self.target))
+            self.target = response['interface']['ip']
+            logger.info(self.target)
         else:
-            print(self.target)
+            logger.info(self.target)
 
     def cleanup(self):
         expected_endp_names = []
@@ -312,14 +315,13 @@ class Ping(Realm):
 
         # Need real stations to run interop test
         if (len(self.real_sta_list) == 0):
-            logger.error('There are no real devices in this testbed. Aborting test')
-            exit(0)
+            raise RuntimeError('There are no real devices in this testbed. Aborting test')
 
         logging.info(self.real_sta_list)
 
         for sta_name in self.real_sta_list:
             if sta_name not in real_devices.devices_data:
-                logger.error('Real station not in devices data, ignoring it from testing')
+                logger.error('Real station {} not in devices data, ignoring it from testing'.format(sta_name))
                 continue
                 # raise ValueError('Real station not in devices data')
 
@@ -356,11 +358,12 @@ class Ping(Realm):
                 "Stations failed to get IPs", print_=True)
 
     def check_tab_exists(self):
-        response = self.json_get("generic")
-        if response is None:
+        generic_url = "generic"
+        response = self.json_get(generic_url)
+        if not response:
+            logger.error("Failed to fetch generic tab data.\nRequested URL: '{}'\nResponse: {}".format(generic_url, response))
             return False
-        else:
-            return True
+        return True
 
     def create_generic_endp(self):
         # Virtual stations are tracked in same list as real stations, so need to separate them
@@ -371,8 +374,7 @@ class Ping(Realm):
             if (self.generic_endps_profile.create(ports=virtual_stations, sleep_time=.5)):
                 logging.info('Virtual client generic endpoint creation completed.')
             else:
-                logging.error('Virtual client generic endpoint creation failed.')
-                exit(0)
+                raise RuntimeError('Virtual client generic endpoint creation failed.')
 
         if (self.enable_real):
             real_sta_os_types = [self.real_sta_data_dict[real_sta_name]['ostype'] for real_sta_name in self.real_sta_data_dict]
@@ -380,8 +382,7 @@ class Ping(Realm):
             if (self.generic_endps_profile.create(ports=self.real_sta_list, sleep_time=.5, real_client_os_types=real_sta_os_types)):
                 logging.info('Real client generic endpoint creation completed.')
             else:
-                logging.error('Real client generic endpoint creation failed.')
-                exit(0)
+                raise RuntimeError('Real client generic endpoint creation failed.')
 
     def start_generic(self):
         self.generic_endps_profile.start_cx()
@@ -620,16 +621,25 @@ class Ping(Realm):
             res_list = []
             test_input_list = []
             pass_fail_list = []
-            interop_tab_data = self.json_get('/adb/')["devices"]
+            adb_url = '/adb/'
+            response = self.json_get(adb_url)
+            if not response:
+                logger.error("Failed to fetch adb data.\nRequested URL: '{}'\nResponse: {}".format(adb_url, response))
+                interop_tab_data = None
+            else:
+                interop_tab_data = response['devices']
+                if isinstance(interop_tab_data, dict):
+                    interop_tab_data = [{interop_tab_data['name']: interop_tab_data}]
             for client in range(len(os_type)):
                 if os_type[client] != 'Android':
                     # Example: From "DESKTOP-DDPI3HE Windows", extract "DESKTOP-DDPI3HE"
                     res_list.append(self.device_names[client].split(' ')[0:-1][0])
                 else:
-                    for dev in interop_tab_data:
-                        for item in dev.values():
-                            if item['user-name'] == self.device_names[client].split(' ')[0:-1][0]:
-                                res_list.append(item['name'].split('.')[2])
+                    if interop_tab_data is not None:
+                        for dev in interop_tab_data:
+                            for item in dev.values():
+                                if item['user-name'] == self.device_names[client].split(' ')[0:-1][0]:
+                                    res_list.append(item['name'].split('.')[2])
             with open(self.csv_name, mode='r') as file:
                 reader = csv.DictReader(file)
                 rows = list(reader)
@@ -1012,7 +1022,15 @@ class Ping(Realm):
         pac_loss = []
         input_list = []
         pass_fail = []
-        interop_tab_data = self.json_get('/adb/')["devices"]
+        adb_url = '/adb/'
+        response = self.json_get(adb_url)
+        if not response:
+            logger.error("Failed to fetch adb data.\nRequested URL: '{}'\nResponse: {}".format(adb_url, response))
+            interop_tab_data = None
+        else:
+            interop_tab_data = response['devices']
+            if isinstance(interop_tab_data, dict):
+                interop_tab_data = [{interop_tab_data['name']: interop_tab_data}]
         for i in range(len(device_names)):
             for j in groupdevlist:
                 # For a string like "1.360 Lin test3":
@@ -1032,7 +1050,7 @@ class Ping(Realm):
                         pac_loss.append(percent_pac_loss[i])
                         input_list.append(test_input_list[i])
                         pass_fail.append(pass_fail_list[i])
-                else:
+                elif interop_tab_data is not None:
                     for dev in interop_tab_data:
                         for item in dev.values():
                             # For a string like 1.15 android samsungmob:
@@ -1527,7 +1545,15 @@ effectively over the network and pinpoint potential issues affecting connectivit
     # logging.info(result_data)
     logging.info(ping.result_json)
     if (args.virtual):
-        ports_data_dict = ping.json_get('/ports/all/')['interfaces']
+        ports_url = '/ports/all/'
+        response = ping.json_get(ports_url)
+        if not response:
+            logger.error("Failed to fetch ports. Received empty response.\nRequested URL: '{}'\nResponse: {}".format(ports_url, response))
+            raise RuntimeError('Failed to fetch port data from the LANforge.')
+        if 'interfaces' not in response:
+            logger.error("'interfaces' key not found in response.\nRequested URL: '{}'\nResponse: {}".format(ports_url, response))
+            raise RuntimeError('Failed to fetch port data from the LANforge.')
+        ports_data_dict = response['interfaces']
         ports_data = {}
         for ports in ports_data_dict:
             port, port_data = list(ports.keys())[0], list(ports.values())[0]

--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -631,15 +631,21 @@ class Ping(Realm):
                 if isinstance(interop_tab_data, dict):
                     interop_tab_data = [{interop_tab_data['name']: interop_tab_data}]
             for client in range(len(os_type)):
+                device_name = self.device_names[client].split(' ')[0:-1][0]
                 if os_type[client] != 'Android':
-                    # Example: From "DESKTOP-DDPI3HE Windows", extract "DESKTOP-DDPI3HE"
-                    res_list.append(self.device_names[client].split(' ')[0:-1][0])
+                    res_list.append(device_name)
                 else:
+                    matched_name = None
                     if interop_tab_data is not None:
                         for dev in interop_tab_data:
                             for item in dev.values():
-                                if item['user-name'] == self.device_names[client].split(' ')[0:-1][0]:
-                                    res_list.append(item['name'].split('.')[2])
+                                if item['user-name'] == device_name:
+                                    matched_name = item['name'].split('.')[2]
+                                    break
+                            if matched_name is not None:
+                                break
+                    # Always append one entry so res_list stays aligned with os_type/packets_sent.
+                    res_list.append(matched_name if matched_name is not None else device_name)
             with open(self.csv_name, mode='r') as file:
                 reader = csv.DictReader(file)
                 rows = list(reader)

--- a/py-scripts/lf_interop_ping.py
+++ b/py-scripts/lf_interop_ping.py
@@ -251,15 +251,41 @@ class Ping(Realm):
             print(self.target)
 
     def cleanup(self):
+        expected_endp_names = []
+        # setting the created_cx and created_endp to empty list and adding the existing endpoints to the list for cleanup
+        self.generic_endps_profile.created_cx = []
+        self.generic_endps_profile.created_endp = []
+        if (self.enable_virtual):
+            for station in self.sta_list:
+                expected_endp_names.append('generic-{}'.format(station.split('.')[2]))
+        if (self.enable_real):
+            for station in self.real_sta_list:
+                expected_endp_names.append('generic-{}'.format(station))
+
+        if expected_endp_names:
+            endp_url = "/generic/{}".format(','.join(expected_endp_names))
+            response = self.json_get(endp_url)
+            if not response:
+                logger.error("Failed to fetch endpoints for cleanup.\nRequested URL: '{}'\nResponse: {}".format(endp_url, response))
+                endpoint = []
+            else:
+                endpoint = response.get('endpoints', response.get('endpoint', []))
+                if isinstance(endpoint, dict):
+                    endpoint = [{endpoint['name']: endpoint}]
+
+            present_endp_names = set()
+            for endp_entry in endpoint:
+                present_endp_names.update(endp_entry.keys())
+
+            for endp_name in expected_endp_names:
+                if endp_name in present_endp_names:
+                    self.generic_endps_profile.created_endp.append(endp_name)
+                    self.generic_endps_profile.created_cx.append('CX_{}'.format(endp_name))
 
         if (self.enable_virtual):
             # removing virtual stations if existing
             for station in self.sta_list:
                 logging.info('Removing the station {} if exists'.format(station))
-                self.generic_endps_profile.created_cx.append(
-                    'CX_generic-{}'.format(station.split('.')[2]))
-                self.generic_endps_profile.created_endp.append(
-                    'generic-{}'.format(station.split('.')[2]))
                 self.rm_port(station, check_exists=True)
 
             if (not LFUtils.wait_until_ports_disappear(base_url=self.host, port_list=self.sta_list, debug=self.debug)):
@@ -267,15 +293,7 @@ class Ping(Realm):
                 logging.error('Aborting the test.')
                 exit(0)
 
-        if (self.enable_real):
-            # removing generic endpoints for real devices if existing
-            for station in self.real_sta_list:
-                self.generic_endps_profile.created_cx.append(
-                    'CX_generic-{}'.format(station))
-                self.generic_endps_profile.created_endp.append(
-                    'generic-{}'.format(station))
-
-        logging.info('Cleaning up generic endpoints if exists')
+        logging.info("Cleaning up generic endpoints if exists: cx={}, endp={}".format(self.generic_endps_profile.created_cx, self.generic_endps_profile.created_endp))
         self.generic_endps_profile.cleanup()
         self.generic_endps_profile.created_cx = []
         self.generic_endps_profile.created_endp = []


### PR DESCRIPTION
**lf_interop_ping.py** now tracks endpoint health throughout the ping test instead of relying on a fixed wait, and fixes several correctness issues found along the way.

- Ping test now waits for endpoints to come up and detects when they go missing or stop running mid-run, instead of sleeping for a fixed duration
- Test now stops promptly when the user hits Stop on the webgui
- Endpoint problems are recorded in the report as client_issue.csv
- Cleanup no longer tries to remove endpoints that were never created
- Test now fails with a clear error instead of crashing when the LANforge API returns an unexpected or empty response
- Fixed a bug where pass/fail results could get attributed to the wrong device when an Android device couldn't be matched
- Simplified duplicate result-parsing logic for real and virtual devices

Test logs:
```1787290133.941973 INFO     The available real devices are: lf_base_interop_profile.py 1770
       Port Name    hw version                MAC
1.50    1.50.en0  Apple/x86-64  30:35:ad:c5:e1:be
1.56  1.56.wlan0  Linux/x86-64  5c:5f:67:9d:47:86
You have selected the below devices for testing
           Eid    hw version                MAC
1.50.en0  1.50  Apple/x86-64  30:35:ad:c5:e1:be
1787290133.963673 INFO     ['1.50.en0'] lf_interop_ping.py 320
1787290134.111290 INFO     Cleaning up generic endpoints if exists: cx=['CX_generic-1.50.en0'], endp=['generic-1.50.en0'] lf_interop_ping.py 299
1787290134.111452 INFO     Cleaning up cxs and endpoints gen_cxprofile.py 158
1787290134.701307 INFO     Cleanup Successful lf_interop_ping.py 303
1787290138.596329 INFO     {'alias': 'CX_generic-1.50.en0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.50.en0'} gen_cxprofile.py 454
1787290139.609753 INFO     Real client generic endpoint creation completed. lf_interop_ping.py 383
1787290139.611873 INFO     Running the ping test for 3.0 minutes lf_interop_ping.py 1531
1787290139.612687 INFO     Starting CXs: ['CX_generic-1.50.en0'] gen_cxprofile.py 129
1787290139.613394 INFO     Created-Endp: ['generic-1.50.en0'] gen_cxprofile.py 130
1787290140.014524 WARNING  Endpoint 'generic-1.50.en0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.50.en0'
Response: {'_links': 'NA', 'bps rx': '8.258 Kbps', 'bps tx': '8.258 Kbps', 'command': 'lfping -b en0 -i 5 192.168.0.30', 'delay': '2.71 ms', 'dropped': '0', 'eid': '1.50.1.212.13', 'elapsed': 0, 'entity id': '1.50.1.212.13', 'jitter': '0 us', 'last results': '64 bytes from 192.168.0.30: icmp_seq=0 ttl=64 time=2.710 ms *** drop: 0 (0, 0.000)  rx: 1  fail: 0  bytes: 64 min/avg/max: 2.710/2.710/2.710', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.50.en0', 'pdu/s rx': '16', 'pdu/s tx': '16', 'rpt timer': 5000, 'rpt#': 1, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '64 B', 'rx pkts': '1', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '64 B', 'tx pkts': '1', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787290140.017631 ERROR    All expected endpoints (generic-1.50.en0) are present but not running. Retrying... Before giving up and stopping test lf_interop_ping.py 548
1787290145.018388 INFO     Attempt 2 of 8 to check endpoints availability lf_interop_ping.py 518
1787290146.312408 INFO     Endpoint 'generic-1.50.en0' is running in the monitoring data
Requested URL: '/generic/generic-1.50.en0'
Response: {'_links': 'NA', 'bps rx': '201 bps', 'bps tx': '201 bps', 'command': 'lfping -b en0 -i 5 192.168.0.30', 'delay': '3.099 ms', 'dropped': '0', 'eid': '1.50.1.212.13', 'elapsed': 5, 'entity id': '1.50.1.212.13', 'jitter': '0 us', 'last results': '64 bytes from 192.168.0.30: icmp_seq=0 ttl=64 time=2.710 ms *** drop: 0 (0, 0.000)  rx: 1  fail: 0  bytes: 64 min/avg/max: 2.710/2.710/2.710', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.50.en0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 2, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '128 B', 'rx pkts': '2', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '128 B', 'tx pkts': '2', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787290168.325884 WARNING  Endpoint 'generic-1.50.en0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.50.en0'
Response: [] lf_interop_ping.py 458
1787290168.326292 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290173.326544 INFO     Attempt 2 of 8 to check endpoints availability lf_interop_ping.py 518
1787290173.463298 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290178.464153 INFO     Attempt 3 of 8 to check endpoints availability lf_interop_ping.py 518
1787290178.606293 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290183.607687 INFO     Attempt 4 of 8 to check endpoints availability lf_interop_ping.py 518
1787290183.747971 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290188.750499 INFO     Attempt 5 of 8 to check endpoints availability lf_interop_ping.py 518
1787290188.908020 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290193.909434 INFO     Attempt 6 of 8 to check endpoints availability lf_interop_ping.py 518
1787290194.054644 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290199.055520 INFO     Attempt 7 of 8 to check endpoints availability lf_interop_ping.py 518
1787290199.219926 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290204.220531 INFO     Attempt 8 of 8 to check endpoints availability lf_interop_ping.py 518
1787290204.364460 ERROR    All expected endpoints (generic-1.50.en0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787290209.365176 ERROR    All endpoints are not available. So exiting the monitor early. lf_interop_ping.py 1540
1787290209.365384 INFO     Stopping the test lf_interop_ping.py 1543
1787290209.365482 INFO     Stopping CXs... gen_cxprofile.py 144```