### PR TITLE
Mixed traffic ping fixes

### DIFF
--- a/py-scripts/lf_mixed_traffic.py
+++ b/py-scripts/lf_mixed_traffic.py
@@ -715,9 +715,10 @@ class Mixed_Traffic(Realm):
             self.ping_test_obj = ping_test.Ping(host=self.host, port=self.port, ssid=ssid, security=security,
                                                 password=password, lanforge_password="lanforge", target=self.target,
                                                 interval=self.interval, sta_list=[], virtual=self.virtual, real=self.real,
-                                                duration=ping_test_duration, result_dir=self.result_dir)
+                                                duration=ping_test_duration, result_dir=self.result_dir,
+                                                dowebgui=self.dowebgui, test_name=self.test_name)
             if not self.ping_test_obj.check_tab_exists():
-                print('Generic Tab is not available for Ping Test.\nAborting the test.')
+                logger.info('Generic Tab is not available for Ping Test.\nAborting the test.')
                 exit(0)
             if self.real:
                 self.ping_test_obj.select_real_devices(real_devices=self.base_interop_profile,
@@ -730,20 +731,11 @@ class Mixed_Traffic(Realm):
                     logger.info("No Device is available to run the test hence aborting the test")
                     exit(0)
                 self.ping_test_obj.cleanup()
-                self.ping_test_obj.sta_list = self.user_query[0]
+                self.ping_test_obj.sta_list = self.ping_test_obj.real_sta_list
             elif self.virtual:
                 self.ping_test_obj.sta_list = self.station_list
                 print('Virtual Stations: {}'.format(self.station_list).replace('[', '').replace(']', '').replace('\'', ''))
-                # #cleanup
-                for station in self.station_list:
-                    print('Removing the station {} if exists'.format(station))
-                    self.ping_test_obj.generic_endps_profile.created_cx.append(
-                        'CX_generic-{}'.format(station.split('.')[2]))
-                    self.ping_test_obj.generic_endps_profile.created_endp.append(
-                        'generic-{}'.format(station.split('.')[2]))
-                self.ping_test_obj.generic_endps_profile.cleanup()
-                self.ping_test_obj.generic_endps_profile.created_cx = []
-                self.ping_test_obj.generic_endps_profile.created_endp = []
+                self.ping_test_obj.cleanup()
             # creating generic endpoints
             self.ping_test_obj.create_generic_endp()
             logger.info("Generic Cross-Connection List: {}".format(self.ping_test_obj.generic_endps_profile.created_cx))

--- a/py-scripts/lf_mixed_traffic.py
+++ b/py-scripts/lf_mixed_traffic.py
@@ -753,6 +753,10 @@ class Mixed_Traffic(Realm):
                 end_time = start_time + datetime.timedelta(seconds=ping_test_duration * 60)
                 temp_json = []
                 while (datetime.datetime.now() < end_time):
+                    success = self.ping_test_obj.monitor_endp_availability(self.ping_test_obj.generic_endps_profile.created_endp)
+                    if not success:
+                        logger.error('All endpoints are not available. So exiting the monitor early.')
+                        break
                     temp_json = []
                     temp_checked_sta = []
                     temp_result_data = self.ping_test_obj.get_results()
@@ -799,7 +803,14 @@ class Mixed_Traffic(Realm):
                         logging.info("Exception while reading running json in ping")
                     time.sleep(3)
             else:
-                time.sleep(ping_test_duration * 60)
+                start_time = time.time()
+                end_time = start_time + (ping_test_duration * 60)
+                while time.time() < end_time:
+                    success = self.ping_test_obj.monitor_endp_availability(self.ping_test_obj.generic_endps_profile.created_endp)
+                    if not success:
+                        logger.error('All endpoints are not available. So exiting the monitor early.')
+                        break
+                    time.sleep(3)
             logger.info("Stopping the Ping Test")
             self.ping_test_obj.stop_generic()
             # getting result dict

--- a/py-scripts/lf_mixed_traffic.py
+++ b/py-scripts/lf_mixed_traffic.py
@@ -790,103 +790,115 @@ class Mixed_Traffic(Realm):
             # getting result dict
             result_data = self.ping_test_obj.get_results()
             result_json = {}
-            if self.real:
-                if isinstance(result_data, dict):
-                    for station in self.ping_test_obj.sta_list:
-                        current_device_data = self.base_interop_profile.devices_data[station]
-                        if station in result_data['name']:
-                            result_json[station] = {
-                                'command': result_data['command'],
-                                'sent': result_data['tx pkts'],
-                                'recv': result_data['rx pkts'],
-                                'dropped': result_data['dropped'],
-                                'min_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[0] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                'avg_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[1] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                'max_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[2] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                'mac': current_device_data['mac'],
-                                'channel': current_device_data['channel'],
-                                'ssid': current_device_data['ssid'],
-                                'mode': current_device_data['mode'],
-                                'name': [current_device_data['user'] if current_device_data['user'] != '' else current_device_data['hostname']][0],
-                                'os': ['Windows' if 'Win' in current_device_data['hw version'] else 'Linux' if 'Linux' in current_device_data['hw version'] else 'Mac' if 'Apple' in current_device_data['hw version'] else 'Android'][0],  # noqa: E501
-                                'remarks': [],
-                                'last_result': [result_data['last results'].split('\n')[-2] if len(result_data['last results']) != 0 else ""][0]}
-                            result_json[station]['remarks'] = self.ping_test_obj.generate_remarks(result_json[station])
-                else:
-                    for station in self.ping_test_obj.sta_list:
-                        current_device_data = self.base_interop_profile.devices_data[station]
-                        for ping_device in result_data:
-                            ping_endp, ping_data = list(ping_device.keys())[0], list(ping_device.values())[0]
-                            if station in ping_endp:
-                                result_json[station] = {
-                                    'command': ping_data['command'],
-                                    'sent': ping_data['tx pkts'],
-                                    'recv': ping_data['rx pkts'],
-                                    'dropped': ping_data['dropped'],
-                                    'min_rtt': [(ping_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[0]).replace(',', '') if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                    'avg_rtt': [(ping_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[1]).replace(',', '') if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                    'max_rtt': [(ping_data['last results'].split('\n')[-2].split()[-1].split(':')[-1].split('/')[2]).replace(',', '') if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                    'mac': current_device_data['mac'],
-                                    'channel': current_device_data['channel'],
-                                    'ssid': current_device_data['ssid'],
-                                    'mode': current_device_data['mode'],
-                                    'name': [current_device_data['user'] if current_device_data['user'] != '' else current_device_data['hostname']][0],
-                                    'os': ['Windows' if 'Win' in current_device_data['hw version'] else 'Linux' if 'Linux' in current_device_data['hw version'] else 'Mac' if 'Apple' in current_device_data['hw version'] else 'Android'][0],  # noqa: E501
-                                    'remarks': [],
-                                    'last_result': [ping_data['last results'].split('\n')[-2] if len(ping_data['last results']) != 0 else ""][0]}
-                                result_json[station]['remarks'] = self.ping_test_obj.generate_remarks(result_json[station])
             if self.virtual:
-                ports_data_dict = self.ping_test_obj.json_get('/ports/all/')['interfaces']
+                ports_url = '/ports/all/'
+                response = self.ping_test_obj.json_get(ports_url)
+                if not response:
+                    logger.error("Failed to fetch ports. Received empty response.\nRequested URL: '{}'\nResponse: {}".format(ports_url, response))
+                    raise RuntimeError('Failed to fetch port data from the LANforge.')
+                if 'interfaces' not in response:
+                    logger.error("'interfaces' key not found in response.\nRequested URL: '{}'\nResponse: {}".format(ports_url, response))
+                    raise RuntimeError('Failed to fetch port data from the LANforge.')
+                ports_data_dict = response['interfaces']
                 ports_data = {}
                 for ports in ports_data_dict:
                     port, port_data = list(ports.keys())[0], list(ports.values())[0]
                     ports_data[port] = port_data
-                if isinstance(result_data, dict):
-                    for station in self.ping_test_obj.sta_list:
-                        if station not in self.ping_test_obj.real_sta_list:
-                            current_device_data = ports_data[station]
-                            if station.split('.')[2] in result_data['name']:
-                                result_json[station] = {
-                                    'command': result_data['command'],
-                                    'sent': result_data['tx pkts'],
-                                    'recv': result_data['rx pkts'],
-                                    'dropped': result_data['dropped'],
-                                    'min_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split('/')[0] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                    'avg_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split('/')[1] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                    'max_rtt': [result_data['last results'].split('\n')[-2].split()[-1].split('/')[2] if len(result_data['last results']) != 0 and 'min/avg/max' in result_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                    'mac': current_device_data['mac'],
-                                    'channel': current_device_data['channel'],
-                                    'ssid': current_device_data['ssid'],
-                                    'mode': current_device_data['mode'],
-                                    'name': station,
-                                    'os': 'Virtual',
-                                    'remarks': [],
-                                    'last_result': [result_data['last results'].split('\n')[-2] if len(result_data['last results']) != 0 else ""][0]}
-                                result_json[station]['remarks'] = self.ping_test_obj.generate_remarks(result_json[station])
-                else:
-                    for station in self.ping_test_obj.sta_list:
-                        if station not in self.ping_test_obj.real_sta_list:
-                            current_device_data = ports_data[station]
-                            for ping_device in result_data:
-                                ping_endp, ping_data = list(ping_device.keys())[0], list(ping_device.values())[0]
-                                if station.split('.')[2] in ping_endp:
+                for station in self.ping_test_obj.sta_list:
+                    if station not in self.ping_test_obj.real_sta_list:
+                        current_device_data = ports_data[station]
+                        for ping_device in result_data:
+                            ping_endp, ping_data = list(ping_device.keys())[0], list(ping_device.values())[0]
+                            if station.split('.')[2] in ping_endp:
+                                last_result_lines = []
+                                try:
+                                    last_result_lines = ping_data['last results'].split('\n') if ping_data['last results'] else []
+                                    if len(last_result_lines) > 1:
+                                        last_result = last_result_lines[-2]
+                                    elif last_result_lines:
+                                        last_result = last_result_lines[-1]
+                                    else:
+                                        last_result = ""
+
+                                    if 'min/avg/max' in last_result:
+                                        rtt_values = last_result.split('min/avg/max:', 1)[1].strip().split()[0].split('/')
+                                        min_rtt = rtt_values[0]
+                                        avg_rtt = rtt_values[1]
+                                        max_rtt = rtt_values[2]
+                                    else:
+                                        min_rtt = '0'
+                                        avg_rtt = '0'
+                                        max_rtt = '0'
+
                                     result_json[station] = {
                                         'command': ping_data['command'],
                                         'sent': ping_data['tx pkts'],
                                         'recv': ping_data['rx pkts'],
                                         'dropped': ping_data['dropped'],
-                                        'min_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split('/')[0] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                        'avg_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split('/')[1] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
-                                        'max_rtt': [ping_data['last results'].split('\n')[-2].split()[-1].split('/')[2] if len(ping_data['last results']) != 0 and 'min/avg/max' in ping_data['last results'].split('\n')[-2] else '0'][0],  # noqa: E501
+                                        'min_rtt': min_rtt,
+                                        'avg_rtt': avg_rtt,
+                                        'max_rtt': max_rtt,
                                         'mac': current_device_data['mac'],
-                                        'channel': current_device_data['channel'],
                                         'ssid': current_device_data['ssid'],
+                                        'channel': current_device_data['channel'],
                                         'mode': current_device_data['mode'],
                                         'name': station,
                                         'os': 'Virtual',
                                         'remarks': [],
-                                        'last_result': [ping_data['last results'].split('\n')[-2] if len(ping_data['last results']) != 0 else ""][0]}
+                                        'last_result': last_result}
                                     result_json[station]['remarks'] = self.ping_test_obj.generate_remarks(result_json[station])
+                                except Exception as error:
+                                    logger.error(
+                                        "Failed parsing the result for station %s. Error: %s\nLast result lines: %s",
+                                        station, error, last_result_lines)
+
+            if self.real:
+                for station in self.ping_test_obj.real_sta_list:
+                    current_device_data = self.base_interop_profile.devices_data[station]
+                    for ping_device in result_data:
+                        ping_endp, ping_data = list(ping_device.keys())[0], list(ping_device.values())[0]
+                        if station in ping_endp:
+                            last_result_lines = []
+                            try:
+                                last_result_lines = ping_data['last results'].split('\n') if ping_data['last results'] else []
+                                if len(last_result_lines) > 1:
+                                    last_result = last_result_lines[-2]
+                                elif last_result_lines:
+                                    last_result = last_result_lines[-1]
+                                else:
+                                    last_result = ""
+
+                                if 'min/avg/max' in last_result:
+                                    rtt_values = last_result.split('min/avg/max:', 1)[1].strip().split()[0].split('/')
+                                    min_rtt = rtt_values[0]
+                                    avg_rtt = rtt_values[1]
+                                    max_rtt = rtt_values[2]
+                                else:
+                                    min_rtt = '0'
+                                    avg_rtt = '0'
+                                    max_rtt = '0'
+
+                                result_json[station] = {
+                                    'command': ping_data['command'],
+                                    'sent': ping_data['tx pkts'],
+                                    'recv': ping_data['rx pkts'],
+                                    'dropped': ping_data['dropped'],
+                                    'min_rtt': min_rtt,
+                                    'avg_rtt': avg_rtt,
+                                    'max_rtt': max_rtt,
+                                    'mac': current_device_data['mac'],
+                                    'ssid': current_device_data['ssid'],
+                                    'channel': current_device_data['channel'],
+                                    'mode': current_device_data['mode'],
+                                    'name': [current_device_data['user'] if current_device_data['user'] != '' else current_device_data['hostname']][0],
+                                    'os': ['Windows' if 'Win' in current_device_data['hw version'] else 'Linux' if 'Linux' in current_device_data['hw version'] else 'Mac' if 'Apple' in current_device_data['hw version'] else 'Android'][0],  # noqa: E501
+                                    'remarks': [],
+                                    'last_result': last_result}
+                                result_json[station]['remarks'] = self.ping_test_obj.generate_remarks(result_json[station])
+                            except Exception as error:
+                                logger.error(
+                                    "Failed parsing the result for station %s. Error: %s\nLast result lines: %s",
+                                    station, error, last_result_lines)
             if self.dowebgui:
                 temp_json = []
                 for station in result_json:

--- a/py-scripts/lf_mixed_traffic.py
+++ b/py-scripts/lf_mixed_traffic.py
@@ -741,66 +741,40 @@ class Mixed_Traffic(Realm):
             logger.info("Generic Cross-Connection List: {}".format(self.ping_test_obj.generic_endps_profile.created_cx))
             logger.info("Starting running the Ping Test for {} minutes".format(ping_test_duration))
             # start generate endpoint
-            time.sleep(20)
             self.ping_test_obj.start_generic()
-            ports_data_dict = self.ping_test_obj.json_get('/ports/all/')['interfaces']
-            ports_data = {}
-            for ports in ports_data_dict:
-                port, port_data = list(ports.keys())[0], list(ports.values())[0]
-                ports_data[port] = port_data
+            time.sleep(10)
             if self.dowebgui:
                 start_time = datetime.datetime.now()
                 end_time = start_time + datetime.timedelta(seconds=ping_test_duration * 60)
-                temp_json = []
                 while (datetime.datetime.now() < end_time):
                     success = self.ping_test_obj.monitor_endp_availability(self.ping_test_obj.generic_endps_profile.created_endp)
                     if not success:
                         logger.error('All endpoints are not available. So exiting the monitor early.')
                         break
                     temp_json = []
-                    temp_checked_sta = []
-                    temp_result_data = self.ping_test_obj.get_results()
-                    if isinstance(temp_result_data, dict):
-                        for station in self.ping_test_obj.real_sta_list:
-                            current_device_data = ports_data[station]
-                            if (station in temp_result_data['name']):
+                    for station in self.ping_test_obj.real_sta_list:
+                        for ping_endp, ping_data in self.ping_test_obj.latest_results.items():
+                            if ping_endp == 'generic-{}'.format(station):
                                 temp_json.append({
                                     'device': station,
-                                    'sent': temp_result_data['tx pkts'],
-                                    'recv': temp_result_data['rx pkts'],
-                                    'dropped': temp_result_data['dropped'],
+                                    'sent': ping_data['tx pkts'],
+                                    'recv': ping_data['rx pkts'],
+                                    'dropped': ping_data['dropped'],
                                     'status': "Running",
                                     'start_time': start_time.strftime("%d/%m %I:%M:%S %p"),
                                     'end_time': end_time.strftime("%d/%m %I:%M:%S %p"),
                                     "remaining_time": ""
                                 })
-                    else:
-                        for station in self.ping_test_obj.real_sta_list:
-                            current_device_data = ports_data[station]
-                            for ping_device in temp_result_data:
-                                ping_endp, ping_data = list(ping_device.keys())[0], list(ping_device.values())[0]
-                                if station.split('-')[-1] in ping_endp and station not in temp_checked_sta:
-                                    temp_checked_sta.append(station)
-                                    temp_json.append({
-                                        'device': station,
-                                        'sent': ping_data['tx pkts'],
-                                        'recv': ping_data['rx pkts'],
-                                        'dropped': ping_data['dropped'],
-                                        'status': "Running",
-                                        'start_time': start_time.strftime("%d/%m %I:%M:%S %p"),
-                                        'end_time': end_time.strftime("%d/%m %I:%M:%S %p"),
-                                        "remaining_time": ""
-                                    })
                     df1 = pd.DataFrame(temp_json)
                     df1.to_csv('{}/ping_datavalues.csv'.format(self.result_dir), index=False)
                     try:
                         with open(self.result_dir + "/../../Running_instances/{}_{}_running.json".format(self.host, self.test_name), 'r') as file:
                             data = json.load(file)
                             if data["status"] != "Running":
-                                logging.info('Test is stopped by the user')
+                                logger.info('Test is stopped by the user')
                                 break
-                    except Exception:
-                        logging.info("Exception while reading running json in ping")
+                    except Exception as e:
+                        logger.info("Error while checking running status during ping execution: {}".format(e))
                     time.sleep(3)
             else:
                 start_time = time.time()


### PR DESCRIPTION
### Summary

Fixes and hardens the ping_test() method in Mixed_Traffic: corrects a station-list bug, replaces blind sleeps with active endpoint-availability monitoring, switches webui live polling to a more reliable results source, and makes the final result parsing crash-resistant.

### Changes

- Pass dowebgui/test_name into the Ping object so it can report status correctly
- Fix sta_list to use the filtered real_sta_list (post iOS-filtering) instead of the raw, unfiltered user_query
- Simplify virtual station cleanup to reuse cleanup() instead of manually rebuilding endpoint names
- Replace the blind time.sleep(duration) (and a stray 20s pre-start sleep) with active monitor_endp_availability() polling that exits early — with a logged error — if endpoints go down, in both the webui and non-webui paths
- Reads live ping stats directly from latest_results, matching each ping endpoint to its station by the generic-{station} name
- Validates the /ports/all/ response before indexing into it, instead of crashing on a bad response
- Parses RTT values (min/avg/max) by splitting on the label instead of assuming a fixed word position
- Isolates each station's parsing in its own try/except so one bad result doesn't abort parsing for every other station

### Test logs:
```1787291406.249350 INFO     The available real devices are: lf_base_interop_profile.py 1770
       Port Name                    hw version                MAC
1.10  1.10.wlan0   samsung SM-X115 r16 sdk: 36  36:5c:7d:f5:30:4c
1.11  1.11.wlan0                  Linux/x86-64  48:45:20:dc:7d:50
1.15  1.15.wlan0   Google Pixel 4a r13 sdk: 33  02:66:b7:06:10:a3
1.16  1.16.wlan0  samsung SM-F415F r12 sdk: 31  fa:3e:e4:96:4a:85
1.22  1.22.wlan0   Google Pixel 4a r13 sdk: 33  4e:3f:0b:63:a4:2a
1.25  1.25.wlan0  samsung SM-A217F r12 sdk: 31  3e:96:2d:16:b2:a3
1.29    1.29.en0                  Apple/x86-64  50:ed:3c:1c:52:9e
You have selected the below devices for testing
             Eid                    hw version                MAC
1.11.wlan0  1.11                  Linux/x86-64  48:45:20:dc:7d:50
1.29.en0    1.29                  Apple/x86-64  50:ed:3c:1c:52:9e
1.22.wlan0  1.22   Google Pixel 4a r13 sdk: 33  4e:3f:0b:63:a4:2a
1.15.wlan0  1.15   Google Pixel 4a r13 sdk: 33  02:66:b7:06:10:a3
1.10.wlan0  1.10   samsung SM-X115 r16 sdk: 36  36:5c:7d:f5:30:4c
1.25.wlan0  1.25  samsung SM-A217F r12 sdk: 31  3e:96:2d:16:b2:a3
1.16.wlan0  1.16  samsung SM-F415F r12 sdk: 31  fa:3e:e4:96:4a:85
1787291406.274882 INFO     Real Station List: 1.11.wlan0 lf_mixed_traffic.py 648
1787291406.275397 INFO     List of selected tests: ['1'] lf_mixed_traffic.py 3376
1787291406.829126 INFO     ['1.11.wlan0', '1.29.en0', '1.22.wlan0', '1.15.wlan0', '1.10.wlan0', '1.25.wlan0', '1.16.wlan0'] lf_interop_ping.py 320
1787291409.293427 INFO     Cleaning up generic endpoints if exists: cx=[], endp=[] lf_interop_ping.py 299
1787291409.293769 INFO     Cleaning up cxs and endpoints gen_cxprofile.py 158
1787291409.294649 INFO     Cleanup Successful lf_interop_ping.py 303
1787291418.700982 INFO     {'alias': 'CX_generic-1.11.wlan0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.11.wlan0'} gen_cxprofile.py 454
1787291418.944358 INFO     {'alias': 'CX_generic-1.29.en0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.29.en0'} gen_cxprofile.py 454
1787291419.201195 INFO     {'alias': 'CX_generic-1.22.wlan0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.22.wlan0'} gen_cxprofile.py 454
1787291419.427963 INFO     {'alias': 'CX_generic-1.15.wlan0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.15.wlan0'} gen_cxprofile.py 454
1787291419.829939 INFO     {'alias': 'CX_generic-1.10.wlan0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.10.wlan0'} gen_cxprofile.py 454
1787291420.049359 INFO     {'alias': 'CX_generic-1.25.wlan0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.25.wlan0'} gen_cxprofile.py 454
1787291420.299004 INFO     {'alias': 'CX_generic-1.16.wlan0',
 'test_mgr': 'default_tm',
 'tx_endp': 'generic-1.16.wlan0'} gen_cxprofile.py 454
1787291423.168836 INFO     Real client generic endpoint creation completed. lf_interop_ping.py 383
1787291423.169156 INFO     Generic Cross-Connection List: ['CX_generic-1.11.wlan0', 'CX_generic-1.29.en0', 'CX_generic-1.22.wlan0', 'CX_generic-1.15.wlan0', 'CX_generic-1.10.wlan0', 'CX_generic-1.25.wlan0', 'CX_generic-1.16.wlan0'] lf_mixed_traffic.py 741
1787291423.169228 INFO     Starting running the Ping Test for 3.0 minutes lf_mixed_traffic.py 742
1787291423.169280 INFO     Starting CXs: ['CX_generic-1.11.wlan0', 'CX_generic-1.29.en0', 'CX_generic-1.22.wlan0', 'CX_generic-1.15.wlan0', 'CX_generic-1.10.wlan0', 'CX_generic-1.25.wlan0', 'CX_generic-1.16.wlan0'] gen_cxprofile.py 129
1787291423.169312 INFO     Created-Endp: ['generic-1.11.wlan0', 'generic-1.29.en0', 'generic-1.22.wlan0', 'generic-1.15.wlan0', 'generic-1.10.wlan0', 'generic-1.25.wlan0', 'generic-1.16.wlan0'] gen_cxprofile.py 130
1787291454.279059 WARNING  Endpoint 'generic-1.25.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '15 bps', 'bps tx': '15 bps', 'command': 'ping -i 5 www.google.com', 'delay': '22.4 ms', 'dropped': '0', 'eid': '1.25.0.681.13', 'elapsed': 26, 'entity id': '1.25.0.681.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.150.119: icmp_seq=5 ttl=112 time=22.9 ms *** drop: 0 (0 0) rx: 5 fail: 0 bytes: 320 min/avg/max: 9.830/19.406/22.900', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.25.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 7, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '384 B', 'rx pkts': '6', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '384 B', 'tx pkts': '6', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291467.088207 INFO     Endpoint 'generic-1.25.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '0 bps', 'bps tx': '0 bps', 'command': 'ping -i 5 www.google.com', 'delay': '0 us', 'dropped': '0', 'eid': '1.25.0.681.13', 'elapsed': 0, 'entity id': '1.25.0.681.13', 'jitter': '0 us', 'last results': '', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.25.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 0, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '0 B', 'rx pkts': '0', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '0 B', 'tx pkts': '0', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291482.989927 WARNING  Endpoint 'generic-1.11.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '111 bps', 'bps tx': '111 bps', 'command': 'lfping -I wlan0 -i 5 www.google.com', 'delay': '10.3 ms', 'dropped': '0', 'eid': '1.11.2.676.13', 'elapsed': 57, 'entity id': '1.11.2.676.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.156.119: icmp_seq=11 ttl=113 time=10.2 ms *** drop: 0 (0, 0.000)  rx: 11  fail: 0  bytes: 704 min/avg/max: 9.530/10.265/10.800', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.11.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 13, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '768 B', 'rx pkts': '12', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '768 B', 'tx pkts': '12', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990151 WARNING  Endpoint 'generic-1.29.en0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '111 bps', 'bps tx': '111 bps', 'command': 'lfping -b en0 -i 5 www.google.com', 'delay': '19.467 ms', 'dropped': '0', 'eid': '1.29.1.677.13', 'elapsed': 57, 'entity id': '1.29.1.677.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.154.119: icmp_seq=10 ttl=112 time=17.470 ms *** drop: 0 (0, 0.000)  rx: 11  fail: 0  bytes: 704 min/avg/max: 12.980/22.105/41.483', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.29.en0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 12, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '768 B', 'rx pkts': '12', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '768 B', 'tx pkts': '12', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990229 WARNING  Endpoint 'generic-1.22.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '13 bps', 'bps tx': '13 bps', 'command': 'ping -i 5 www.google.com', 'delay': '24.6 ms', 'dropped': '0', 'eid': '1.22.0.678.13', 'elapsed': 56, 'entity id': '1.22.0.678.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.152.119: icmp_seq=11 ttl=111 time=25.6 ms *** drop: 0 (0 0) rx: 11 fail: 0 bytes: 704 min/avg/max: 12.500/24.145/28.700', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.22.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 13, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '768 B', 'rx pkts': '12', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '768 B', 'tx pkts': '12', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990290 WARNING  Endpoint 'generic-1.15.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '13 bps', 'bps tx': '13 bps', 'command': 'ping -i 5 www.google.com', 'delay': '25.1 ms', 'dropped': '0', 'eid': '1.15.0.679.13', 'elapsed': 56, 'entity id': '1.15.0.679.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.150.119: icmp_seq=11 ttl=112 time=24.3 ms *** drop: 0 (0 0) rx: 11 fail: 0 bytes: 704 min/avg/max: 11.000/21.936/25.900', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.15.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 13, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '768 B', 'rx pkts': '12', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '768 B', 'tx pkts': '12', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990353 WARNING  Endpoint 'generic-1.10.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '13 bps', 'bps tx': '13 bps', 'command': 'ping -i 5 www.google.com', 'delay': '13.3 ms', 'dropped': '0', 'eid': '1.10.0.680.13', 'elapsed': 56, 'entity id': '1.10.0.680.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.152.119: icmp_seq=11 ttl=111 time=18.0 ms *** drop: 0 (0 0) rx: 11 fail: 0 bytes: 704 min/avg/max: 12.300/17.018/19.900', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.10.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 13, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '768 B', 'rx pkts': '12', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '768 B', 'tx pkts': '12', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990407 WARNING  Endpoint 'generic-1.25.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '16 bps', 'bps tx': '16 bps', 'command': 'ping -i 5 www.google.com', 'delay': '19.5 ms', 'dropped': '0', 'eid': '1.25.0.681.13', 'elapsed': 15, 'entity id': '1.25.0.681.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.150.119: icmp_seq=3 ttl=112 time=20.2 ms *** drop: 0 (0 0) rx: 3 fail: 0 bytes: 192 min/avg/max: 10.000/16.100/20.200', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.25.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 5, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '256 B', 'rx pkts': '4', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '256 B', 'tx pkts': '4', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990485 WARNING  Endpoint 'generic-1.16.wlan0' is not running in the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '13 bps', 'bps tx': '13 bps', 'command': 'ping -i 5 www.google.com', 'delay': '17.9 ms', 'dropped': '0', 'eid': '1.16.0.682.13', 'elapsed': 55, 'entity id': '1.16.0.682.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.152.119: icmp_seq=11 ttl=111 time=17.6 ms *** drop: 0 (0 0) rx: 11 fail: 0 bytes: 704 min/avg/max: 10.700/17.145/20.800', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.16.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 13, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '768 B', 'rx pkts': '12', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Stopped', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '768 B', 'tx pkts': '12', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 467
1787291482.990593 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are present but not running. Retrying... Before giving up and stopping test lf_interop_ping.py 548
1787291487.992059 INFO     Attempt 2 of 8 to check endpoints availability lf_interop_ping.py 518
1787291488.168149 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are present but not running. Retrying... Before giving up and stopping test lf_interop_ping.py 548
1787291493.168740 INFO     Attempt 3 of 8 to check endpoints availability lf_interop_ping.py 518
1787291493.341438 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are present but not running. Retrying... Before giving up and stopping test lf_interop_ping.py 548
1787291498.342360 INFO     Attempt 4 of 8 to check endpoints availability lf_interop_ping.py 518
1787291498.460091 INFO     Endpoint 'generic-1.11.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '4.74 Kbps', 'bps tx': '4.74 Kbps', 'command': 'lfping -I wlan0 -i 5 www.google.com', 'delay': '11.6 ms', 'dropped': '0', 'eid': '1.11.2.676.13', 'elapsed': 0, 'entity id': '1.11.2.676.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.155.119: icmp_seq=1 ttl=113 time=11.6 ms *** drop: 0 (0, 0.000)  rx: 1  fail: 0  bytes: 64 min/avg/max: 11.600/11.600/11.600', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.11.wlan0', 'pdu/s rx': '9', 'pdu/s tx': '9', 'rpt timer': 5000, 'rpt#': 1, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '64 B', 'rx pkts': '1', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '64 B', 'tx pkts': '1', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291498.460253 INFO     Endpoint 'generic-1.29.en0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '10.24 Kbps', 'bps tx': '10.24 Kbps', 'command': 'lfping -b en0 -i 5 www.google.com', 'delay': '14.595 ms', 'dropped': '0', 'eid': '1.29.1.677.13', 'elapsed': 0, 'entity id': '1.29.1.677.13', 'jitter': '0 us', 'last results': '64 bytes from 142.251.154.119: icmp_seq=0 ttl=112 time=14.595 ms *** drop: 0 (0, 0.000)  rx: 1  fail: 0  bytes: 64 min/avg/max: 14.595/14.595/14.595', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.29.en0', 'pdu/s rx': '20', 'pdu/s tx': '20', 'rpt timer': 5000, 'rpt#': 1, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '64 B', 'rx pkts': '1', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '64 B', 'tx pkts': '1', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291498.460339 INFO     Endpoint 'generic-1.22.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '0 bps', 'bps tx': '0 bps', 'command': 'ping -i 5 www.google.com', 'delay': '0 us', 'dropped': '0', 'eid': '1.22.0.678.13', 'elapsed': 0, 'entity id': '1.22.0.678.13', 'jitter': '0 us', 'last results': '', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.22.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 0, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '0 B', 'rx pkts': '0', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '0 B', 'tx pkts': '0', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291498.460400 INFO     Endpoint 'generic-1.15.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '0 bps', 'bps tx': '0 bps', 'command': 'ping -i 5 www.google.com', 'delay': '0 us', 'dropped': '0', 'eid': '1.15.0.679.13', 'elapsed': 0, 'entity id': '1.15.0.679.13', 'jitter': '0 us', 'last results': '', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.15.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 0, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '0 B', 'rx pkts': '0', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '0 B', 'tx pkts': '0', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291498.460454 INFO     Endpoint 'generic-1.10.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '0 bps', 'bps tx': '0 bps', 'command': 'ping -i 5 www.google.com', 'delay': '0 us', 'dropped': '0', 'eid': '1.10.0.680.13', 'elapsed': 0, 'entity id': '1.10.0.680.13', 'jitter': '0 us', 'last results': '', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.10.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 0, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '0 B', 'rx pkts': '0', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '0 B', 'tx pkts': '0', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291498.460512 INFO     Endpoint 'generic-1.25.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '0 bps', 'bps tx': '0 bps', 'command': 'ping -i 5 www.google.com', 'delay': '0 us', 'dropped': '0', 'eid': '1.25.0.681.13', 'elapsed': 0, 'entity id': '1.25.0.681.13', 'jitter': '0 us', 'last results': '', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.25.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 0, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '0 B', 'rx pkts': '0', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '0 B', 'tx pkts': '0', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291498.460634 INFO     Endpoint 'generic-1.16.wlan0' is running in the monitoring data
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: {'_links': 'NA', 'bps rx': '0 bps', 'bps tx': '0 bps', 'command': 'ping -i 5 www.google.com', 'delay': '0 us', 'dropped': '0', 'eid': '1.16.0.682.13', 'elapsed': 0, 'entity id': '1.16.0.682.13', 'jitter': '0 us', 'last results': '', 'lr bps rx': '0 bps', 'lr bps tx': '0 bps', 'lr delay': '0 us', 'lr dropped': '0', 'lr jitter': '0 us', 'lr pdu/s rx': '0', 'lr pdu/s tx': '0', 'lr rx bytes': '0 B', 'lr rx pkts': '0', 'lr tx bytes': '0 B', 'lr tx pkts': '0', 'name': 'generic-1.16.wlan0', 'pdu/s rx': '0', 'pdu/s tx': '0', 'rpt timer': 5000, 'rpt#': 0, 'rx audio delay': '0 ms', 'rx audio jitter': '0 ms', 'rx audio pkt drop %': '0.0', 'rx bytes': '0 B', 'rx pkts': '0', 'rx video delay': '0 ms', 'rx video fps': '0', 'rx video jitter': '0 ms', 'rx video pkt drop %': '0.0', 'status': 'Run', 'tx audio delay': '0 ms', 'tx audio jitter': '0 ms', 'tx audio pkt drop %': '0.0', 'tx bytes': '0 B', 'tx pkts': '0', 'tx video delay': '0 ms', 'tx video fps': '0', 'tx video jitter': '0 ms', 'tx video pkt drop %': '0.0', 'type': 'Generic'} lf_interop_ping.py 476
1787291532.883749 WARNING  Endpoint 'generic-1.11.wlan0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.884505 WARNING  Endpoint 'generic-1.29.en0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.884695 WARNING  Endpoint 'generic-1.22.wlan0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.884798 WARNING  Endpoint 'generic-1.15.wlan0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.884889 WARNING  Endpoint 'generic-1.10.wlan0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.884976 WARNING  Endpoint 'generic-1.25.wlan0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.885061 WARNING  Endpoint 'generic-1.16.wlan0' is missing from the monitoring data.
Requested URL: '/generic/generic-1.11.wlan0,generic-1.29.en0,generic-1.22.wlan0,generic-1.15.wlan0,generic-1.10.wlan0,generic-1.25.wlan0,generic-1.16.wlan0'
Response: [] lf_interop_ping.py 458
1787291532.885193 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787291537.886228 INFO     Attempt 2 of 8 to check endpoints availability lf_interop_ping.py 518
1787291537.998286 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787291542.999474 INFO     Attempt 3 of 8 to check endpoints availability lf_interop_ping.py 518
1787291543.114420 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787291548.115085 INFO     Attempt 4 of 8 to check endpoints availability lf_interop_ping.py 518
1787291548.230742 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787291553.232820 INFO     Attempt 5 of 8 to check endpoints availability lf_interop_ping.py 518
1787291553.351380 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787291558.354101 INFO     Attempt 6 of 8 to check endpoints availability lf_interop_ping.py 518
1787291558.605592 ERROR    All expected endpoints (generic-1.11.wlan0, generic-1.25.wlan0, generic-1.16.wlan0, generic-1.22.wlan0, generic-1.15.wlan0, generic-1.29.en0, generic-1.10.wlan0) are missing from the monitoring data. Retrying... Before giving up and stopping test lf_interop_ping.py 545
1787291563.606233 WARNING  Test is stopped by the user lf_interop_ping.py 493
1787291563.606655 INFO     Test stopped by user via WebGUI. Exiting monitoring. lf_interop_ping.py 515
1787291563.606782 ERROR    All endpoints are not available. So exiting the monitor early. lf_mixed_traffic.py 752
1787291563.606879 INFO     Stopping the Ping Test lf_mixed_traffic.py 788
1787291563.607126 INFO     Stopping CXs... gen_cxprofile.py 144
1787291564.110881 INFO     Generating Report lf_interop_ping.py 733
1787291564.111171 INFO     path set: /home/durga/webui/local/interop-webGUI/results/mixping_2/Aug 21 11:20:04 mixed_traffic_test/Aug 21 11:20:05Mixed_Traffic_Test_Iteration_1/2026-08-21-11-20-05_Mixed_Traffic_Test_Report_all lf_report.py 85
1787291564.111467 INFO     path_date_time /home/durga/webui/local/interop-webGUI/results/mixping_2/Aug 21 11:20:04 mixed_traffic_test/Aug 21 11:20:05Mixed_Traffic_Test_Iteration_1/2026-08-21-11-20-05_Mixed_Traffic_Test_Report_all/2026-08-21-11-22-44_Ping_Test_Report lf_report.py 239
1787291564.111925 INFO     report path : /home/durga/webui/local/interop-webGUI/results/mixping_2/Aug 21 11:20:04 mixed_traffic_test/Aug 21 11:20:05Mixed_Traffic_Test_Iteration_1/2026-08-21-11-20-05_Mixed_Traffic_Test_Report_all/2026-08-21-11-22-44_Ping_Test_Report lf_report.py 248
1787291564.114575 INFO     path: /home/durga/webui/local/interop-webGUI/results/mixping_2/Aug 21 11:20:04 mixed_traffic_test/Aug 21 11:20:05Mixed_Traffic_Test_Iteration_1/2026-08-21-11-20-05_Mixed_Traffic_Test_Report_all lf_interop_ping.py 744
1787291564.114628 INFO     path_date_time: /home/durga/webui/local/interop-webGUI/results/mixping_2/Aug 21 11:20:04 mixed_traffic_test/Aug 21 11:20:05Mixed_Traffic_Test_Iteration_1/2026-08-21-11-20-05_Mixed_Traffic_Test_Report_all/2026-08-21-11-22-44_Ping_Test_Report lf_interop_ping.py 745```