### PR TITLE
py-scripts/README.md: Add toolbox documentation

### DIFF
--- a/py-scripts/README.md
+++ b/py-scripts/README.md
@@ -5,7 +5,9 @@ This directory contains Python scripts to configure and test devices with LANfor
 To learn more about automating Chamber View tests like TR-398, WiFi Capacity Test, and others, see [Chamber View Examples](./cv_examples/README.md)
 for more information.
 
-We also support Toolbox functionality (`--toolbox`), enabling modular standalone operations (e.g., creating stations, managing cross-connections, toggling port admin states, etc.) on supported scripts—currently available in [`test_l3.py`](./test_l3.py). For detailed CLI scenarios and usage examples, refer to the [Toolbox Documentation](https://candelatech.atlassian.net/wiki/spaces/LANFORGE/folder/2854748163).
+We also support Toolbox mode (--toolbox), enabling modular, standalone operations such as creating stations, managing cross-connections, and toggling port administrative states on supported scripts:
+- [`test_l3.py`](./test_l3.py) — Layer-3 traffic generation (see [Toolbox Documentation](https://candelatech.atlassian.net/wiki/spaces/LANFORGE/pages/2854715395/test_l3.py+Toolbox+Mode+CLI+Reference+Usage+Guide))
+- [`lf_test_generic.py`](./lf_test_generic.py) — Generic endpoints and cross-connections (see [Toolbox Documentation](https://candelatech.atlassian.net/wiki/spaces/LANFORGE/pages/2859859969/lf_test_generic.py+Toolbox+Mode+CLI+Reference+Usage+Guide))
 
 For more information, see [these documentation links](../README.md#documentation-links) or email [`support@candelatech.com`](mailto:support@candelatech.com)
 with questions.

--- a/py-scripts/README.md
+++ b/py-scripts/README.md
@@ -5,6 +5,8 @@ This directory contains Python scripts to configure and test devices with LANfor
 To learn more about automating Chamber View tests like TR-398, WiFi Capacity Test, and others, see [Chamber View Examples](./cv_examples/README.md)
 for more information.
 
+We also support Toolbox functionality (`--toolbox`), enabling modular standalone operations (e.g., creating stations, managing cross-connections, toggling port admin states, etc.) on supported scripts—currently available in [`test_l3.py`](./test_l3.py). For detailed CLI scenarios and usage examples, refer to the [Toolbox Documentation](https://candelatech.atlassian.net/wiki/spaces/LANFORGE/folder/2854748163).
+
 For more information, see [these documentation links](../README.md#documentation-links) or email [`support@candelatech.com`](mailto:support@candelatech.com)
 with questions.
 


### PR DESCRIPTION
## Description: 
-  Added a sentence specifying the availability of Toolbox functionality in `py-scripts`.

## Updated README.md Output:


LANforge Python Scripts

This directory contains Python scripts to configure and test devices with LANforge traffic generation and network impairment systems.

To learn more about automating Chamber View tests like TR-398, WiFi Capacity Test, and others, see [Chamber View Examples](./cv_examples/README.md)
for more information.

We also support Toolbox mode (--toolbox), enabling modular, standalone operations such as creating stations, managing cross-connections, and toggling port administrative states on supported scripts:
- [`test_l3.py`](./test_l3.py) — Layer-3 traffic generation (see [Toolbox Documentation](https://candelatech.atlassian.net/wiki/spaces/LANFORGE/pages/2854715395/test_l3.py+Toolbox+Mode+CLI+Reference+Usage+Guide))
- [`lf_test_generic.py`](./lf_test_generic.py) — Generic endpoints and cross-connections (see [Toolbox Documentation](https://candelatech.atlassian.net/wiki/spaces/LANFORGE/pages/2859859969/lf_test_generic.py+Toolbox+Mode+CLI+Reference+Usage+Guide))

For more information, see [these documentation links](../README.md#documentation-links) or email [`support@candelatech.com`](mailto:support@candelatech.com)
with questions.

Setup

Setup instructions have been moved to [this document](../README.md#installing-from-source).
