### PR TITLE
lf_interop_qos.py: Added duraion in mins for QoS test

### DIFF
--- a/py-scripts/throughput_qos.py
+++ b/py-scripts/throughput_qos.py
@@ -875,7 +875,7 @@ class ThroughputQOS(Realm):
             "SSID_2.4GHz": self.ssid_2g,
             "SSID_5GHz": self.ssid_5g,
             "SSID_6GHz": self.ssid_6g,
-            "Traffic Duration in hours": round(int(self.test_duration) / 3600, 2),
+            "Traffic Duration in minutes": round(int(self.test_duration) / 60, 2),
             "Security_2.4GHz": self.security_2g,
             "Security_5GHz": self.security_5g,
             "Security_6GHz": self.security_6g,


### PR DESCRIPTION
- Adds the time duration of QoS in mins

VERIFIED CLI: python3 -u lf_interop_qos.py --mgr 192.168.244.97 --upstream_port 1.eth1 --security None --ssid "Authtesting" --passwd "" --traffic_type lf_tcp --download 100000000 --upload 0 --test_duration 2m --tos VO,VI,BE,BK --device_list 1.13,1.10 --test_name qos_checkkkkk --result_dir /home/hari/scripts/interop-webGUI/results/qos_checkkkkk --dowebgui True


<img width="1078" height="696" alt="Screenshot 2026-09-01 161624" src="https://github.com/user-attachments/assets/dd035f7d-491b-45d3-a9b6-e555a1e629d8" />
