### PR TITLE
android_zoom.py: Retry the meeting link when the Zoom join flow stalls

### DIFF
--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -19,6 +19,7 @@ from ppadb.client import Client as AdbClient
 # from ping_monitor import PingMonitor
 
 ZOOM_PACKAGE = "us.zoom.videomeetings"
+NAME_SCREEN_ATTEMPTS = 3
 
 
 class ZoomAutomator:
@@ -335,6 +336,92 @@ class ZoomAutomator:
             self.logger.error(f"Error checking stop signal: {e}")
             return self.stop_signal
 
+    def open_meeting_link(self, d, meeting_url, attempt):
+        """Cold-start Zoom and hand it the meeting link.
+
+        Called once per join attempt, so a retry gets a genuinely fresh app
+        rather than whatever screen the last one stalled on.
+        """
+        self.logger.info(
+            f"Starting {ZOOM_PACKAGE} and opening the meeting link "
+            f"(attempt {attempt}/{NAME_SCREEN_ATTEMPTS})."
+        )
+        d.app_start(ZOOM_PACKAGE, stop=True)
+        pid = d.app_wait(ZOOM_PACKAGE, front=True, timeout=30)
+        if not pid:
+            raise RuntimeError(
+                f"{ZOOM_PACKAGE} did not come to foreground within 30s of cold start — "
+                "device may be slow/overloaded. Aborting this participant."
+            )
+        self.adb_device.shell(
+            f'am start -a android.intent.action.VIEW -d "{meeting_url}" {ZOOM_PACKAGE}'
+        )
+        self.logger.info(f"Meeting link handed to Zoom: {meeting_url}")
+        time.sleep(8)
+
+    def enter_participant_name(self, d, participant_name):
+        """Type the display name into whichever join screen this Zoom build shows.
+
+        Returns True once the name is in and the join is under way, False if
+        neither the preview screen nor the older name dialog ever appeared —
+        that one is worth another launch, so the caller retries it. A screen
+        that does appear but cannot be driven still raises, since relaunching
+        would not help.
+        """
+        preview_join = d(text="Editing display name")
+        if preview_join.wait(timeout=30):
+            self.logger.info("Preview screen detected.")
+
+            name_input = d(className="android.widget.EditText")
+            if not name_input.wait(timeout=10):
+                self.logger.warning(
+                    "Preview screen had no name field "
+                    "(className='android.widget.EditText')."
+                )
+                return False
+
+            self.logger.info(f"Entering participant name: {participant_name}")
+            name_input.set_text(participant_name)
+            time.sleep(1)
+            ok_btn = d(text="OK")
+            if ok_btn.wait(timeout=10):
+                ok_btn.click()
+                self.logger.info("Clicked 'OK' on preview screen.")
+            else:
+                raise RuntimeError(
+                    "'OK' button not found within 10 seconds on preview screen."
+                )
+
+            join_btn = d(text="Join")
+            if join_btn.wait(timeout=10):
+                join_btn.click()
+                self.logger.info("Clicked 'Join' on preview screen.")
+            else:
+                raise RuntimeError(
+                    "'Join' button not found within 10 seconds on preview screen."
+                )
+            return True
+
+        # Old flow: check for name input screen
+        name_input = d(resourceId="us.zoom.videomeetings:id/edtScreenName")
+        if not name_input.wait(timeout=15):
+            self.logger.warning(
+                "Neither the preview screen nor the name dialog "
+                "(resourceId='us.zoom.videomeetings:id/edtScreenName') appeared."
+            )
+            return False
+
+        self.logger.info(f"Entering participant name: {participant_name}")
+        name_input.set_text(participant_name)
+        time.sleep(1)
+        ok_btn = d(text="OK", className="android.widget.Button")
+        if ok_btn.wait(timeout=10):
+            ok_btn.click()
+        else:
+            d(resourceId="us.zoom.videomeetings:id/button1").click()
+        self.logger.info("Clicked 'Ok Button'")
+        return True
+
     def join_zoom_meeting(self, meeting_url, participant_name):
         """Drive one device through a full Zoom call, start to finish.
 
@@ -362,80 +449,23 @@ class ZoomAutomator:
         self.logger.info(f"Starting Zoom automation for {participant_name}.")
         self.logger.info(f"Screen {width}x{height}, centre tap at {tap_coords}.")
 
-        self.logger.info(f"Starting {ZOOM_PACKAGE} and opening the meeting link.")
-        d.app_start(ZOOM_PACKAGE, stop=True)
-        pid = d.app_wait(ZOOM_PACKAGE, front=True, timeout=30)
-        if not pid:
-            raise RuntimeError(
-                f"{ZOOM_PACKAGE} did not come to foreground within 30s of cold start — "
-                "device may be slow/overloaded. Aborting this participant."
+        for attempt in range(1, NAME_SCREEN_ATTEMPTS + 1):
+            self.open_meeting_link(d, meeting_url, attempt)
+            if self.enter_participant_name(d, participant_name):
+                break
+            self.logger.warning(
+                f"No join screen on attempt {attempt}/{NAME_SCREEN_ATTEMPTS}."
             )
-        self.adb_device.shell(
-            f'am start -a android.intent.action.VIEW -d "{meeting_url}" {ZOOM_PACKAGE}'
-        )
-        self.logger.info(f"Meeting link handed to Zoom: {meeting_url}")
-        time.sleep(8)
-
-        preview_join = d(text="Editing display name")
-        if preview_join.wait(timeout=30):
-            self.logger.info("Preview screen detected.")
-
-            name_input = d(className="android.widget.EditText")
-            if name_input.wait(timeout=10):
-                self.logger.info(f"Entering participant name: {participant_name}")
-                name_input.set_text(participant_name)
-                time.sleep(1)
-                ok_btn = d(text="OK")
-                if ok_btn.wait(timeout=10):
-                    ok_btn.click()
-                    self.logger.info("Clicked 'OK' on preview screen.")
-                else:
-                    raise RuntimeError(
-                        "'OK' button not found within 10 seconds on preview screen."
-                    )
-            else:
-                self.logger.error(
-                    "Name input screen not found "
-                    "(className='android.widget.EditText'). "
-                    "Aborting automation."
-                )
-                raise RuntimeError(
-                    "Could not find name input screen. "
-                    "Zoom may not have launched correctly or the UI flow changed."
-                )
-
-            join_btn = d(text="Join")
-            if join_btn.wait(timeout=10):
-                join_btn.click()
-                self.logger.info("Clicked 'Join' on preview screen.")
-            else:
-                raise RuntimeError(
-                    "'Join' button not found within 10 seconds on preview screen."
-                )
-
         else:
-            # Old flow: check for name input screen
-            name_input = d(resourceId="us.zoom.videomeetings:id/edtScreenName")
-            if name_input.wait(timeout=15):
-                self.logger.info(f"Entering participant name: {participant_name}")
-                name_input.set_text(participant_name)
-                time.sleep(1)
-                ok_btn = d(text="OK", className="android.widget.Button")
-                if ok_btn.wait(timeout=10):
-                    ok_btn.click()
-                else:
-                    d(resourceId="us.zoom.videomeetings:id/button1").click()
-                self.logger.info("Clicked 'Ok Button'")
-            else:
-                self.logger.error(
-                    "Name input screen not found "
-                    "(resourceId='us.zoom.videomeetings:id/edtScreenName'). "
-                    "Aborting automation."
-                )
-                raise RuntimeError(
-                    "Could not find name input screen. "
-                    "Zoom may not have launched correctly or the UI flow changed."
-                )
+            self.logger.error(
+                f"Name input screen not found in {NAME_SCREEN_ATTEMPTS} attempts. "
+                "Aborting automation."
+            )
+            raise RuntimeError(
+                f"Could not find name input screen in {NAME_SCREEN_ATTEMPTS} "
+                "attempts. Zoom may not have launched correctly or the UI flow "
+                "changed."
+            )
 
         self.logger.info("Waiting to join meeting...")
         time.sleep(10)

--- a/py-scripts/real_application_tests/zoom_automation/android_zoom.py
+++ b/py-scripts/real_application_tests/zoom_automation/android_zoom.py
@@ -20,6 +20,7 @@ from ppadb.client import Client as AdbClient
 
 ZOOM_PACKAGE = "us.zoom.videomeetings"
 NAME_SCREEN_ATTEMPTS = 3
+FOREGROUND_TIMEOUT = 30  # seconds to wait for Zoom to reach the foreground after a cold start
 
 
 class ZoomAutomator:
@@ -338,26 +339,22 @@ class ZoomAutomator:
 
     def open_meeting_link(self, d, meeting_url, attempt):
         """Cold-start Zoom and hand it the meeting link.
-
-        Called once per join attempt, so a retry gets a genuinely fresh app
-        rather than whatever screen the last one stalled on.
+        Input: d (uiautomator2 device), meeting_url (Zoom join link), attempt (attempt number, used in the log).
+        Output: True once the link is handed to Zoom; False if Zoom did not reach the foreground within FOREGROUND_TIMEOUT seconds.
         """
         self.logger.info(
             f"Starting {ZOOM_PACKAGE} and opening the meeting link "
             f"(attempt {attempt}/{NAME_SCREEN_ATTEMPTS})."
         )
         d.app_start(ZOOM_PACKAGE, stop=True)
-        pid = d.app_wait(ZOOM_PACKAGE, front=True, timeout=30)
-        if not pid:
-            raise RuntimeError(
-                f"{ZOOM_PACKAGE} did not come to foreground within 30s of cold start — "
-                "device may be slow/overloaded. Aborting this participant."
-            )
+        if not d.app_wait(ZOOM_PACKAGE, front=True, timeout=FOREGROUND_TIMEOUT):
+            return False
         self.adb_device.shell(
             f'am start -a android.intent.action.VIEW -d "{meeting_url}" {ZOOM_PACKAGE}'
         )
         self.logger.info(f"Meeting link handed to Zoom: {meeting_url}")
         time.sleep(8)
+        return True
 
     def enter_participant_name(self, d, participant_name):
         """Type the display name into whichever join screen this Zoom build shows.
@@ -449,16 +446,38 @@ class ZoomAutomator:
         self.logger.info(f"Starting Zoom automation for {participant_name}.")
         self.logger.info(f"Screen {width}x{height}, centre tap at {tap_coords}.")
 
+        foreground_failures = 0
         for attempt in range(1, NAME_SCREEN_ATTEMPTS + 1):
-            self.open_meeting_link(d, meeting_url, attempt)
+            if not self.open_meeting_link(d, meeting_url, attempt):
+                foreground_failures += 1
+                self.logger.warning(
+                    f"{ZOOM_PACKAGE} did not come to foreground within "
+                    f"{FOREGROUND_TIMEOUT}s on attempt {attempt}/{NAME_SCREEN_ATTEMPTS}."
+                )
+                continue
             if self.enter_participant_name(d, participant_name):
                 break
             self.logger.warning(
                 f"No join screen on attempt {attempt}/{NAME_SCREEN_ATTEMPTS}."
             )
         else:
+            if foreground_failures == NAME_SCREEN_ATTEMPTS:
+                self.logger.error(
+                    f"{ZOOM_PACKAGE} did not come to foreground in "
+                    f"{NAME_SCREEN_ATTEMPTS} attempts. Aborting automation."
+                )
+                raise RuntimeError(
+                    f"{ZOOM_PACKAGE} did not come to foreground within "
+                    f"{FOREGROUND_TIMEOUT}s of cold start in {NAME_SCREEN_ATTEMPTS} "
+                    "attempts — device may be slow/overloaded. Aborting this participant."
+                )
+            detail = (
+                f" ({foreground_failures} of them never brought {ZOOM_PACKAGE} to the foreground)"
+                if foreground_failures
+                else ""
+            )
             self.logger.error(
-                f"Name input screen not found in {NAME_SCREEN_ATTEMPTS} attempts. "
+                f"Name input screen not found in {NAME_SCREEN_ATTEMPTS} attempts{detail}. "
                 "Aborting automation."
             )
             raise RuntimeError(


### PR DESCRIPTION
## Summary

`join_zoom_meeting()` gave each Android participant a single attempt to join. If Zoom did not reach the foreground within 30s of the cold start, or neither the preview screen nor the older name dialog appeared, it raised a `RuntimeError`, and that participant dropped out of the test. Both failures are often transient on slow or loaded devices, so this PR relaunches Zoom and resends the meeting link up to 3 times before giving up.

## Changes

- Split the launch and name-entry steps out of `join_zoom_meeting()` into `open_meeting_link()` and `enter_participant_name()`.
- Wrap them in a retry loop bounded by `NAME_SCREEN_ATTEMPTS = 3`. Each attempt cold-starts Zoom (`app_start(..., stop=True)`), so a retry starts from a fresh app instead of the screen the previous attempt stalled on.
- `open_meeting_link()` returns `False` when Zoom does not reach the foreground within `FOREGROUND_TIMEOUT` (30s, previously hardcoded) instead of raising.
- `enter_participant_name()` returns `False` when no join screen appears. A join screen that appears but cannot be driven (missing `OK` or `Join` button) still raises immediately, since relaunching would not help.
- When all attempts fail, the error distinguishes "Zoom never reached the foreground" from "no join screen appeared", and reports how many attempts hit the foreground timeout.



## Testing

Verified with an 11-participant meeting, audio and video enabled:

```
python3 lf_interop_zoom.py \
    --duration 1 \
    --lanforge_ip 192.168.10.6 \
    --signin_email demo@gmail.com \
    --signin_passwd 'demo123' \
    --participants 11 \
    --audio --video \
    --upstream_port 1.1.eth2 \
    --zoom_host 1.110 \
    --resources 1.110,1.10,1.11,1.12,1.14,1.15,1.16,1.17,1.18,1.19,1.28 \
    --api_stats_collection \
    --env_file .env
```
